### PR TITLE
Revert "Make 'rspec' do what 'rake spec_standlone' does"

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --format documentation
---pattern spec/\{aliases,classes,defines,unit,functions,hosts,integration,plans,type_aliases,types\}/\*\*/\*_spec.rb


### PR DESCRIPTION
This reverts commit e17a35fddd6b4ad7d6d14662dabab4b84ae00ad0.

It turns out that when a pattern is supplied in this way, the rspec
executable ignores when you specify a single file, and will thus
always run the full suite. This is undesireable.