### PR TITLE
AEIM-1244: Add functions for getting facts for other nodes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,3 +103,5 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/SymbolProc:
   Enabled: false
+RSpec/LetSetup:
+  Enabled: false # let!() is required for mocking puppet functions

--- a/lib/puppet/functions/fact_for.rb
+++ b/lib/puppet/functions/fact_for.rb
@@ -10,19 +10,24 @@ Puppet::Functions.create_function(:fact_for) do
 
   def fact_for(node_id, fact_name)
     fact_keys = fact_name.split('.')
-    fact_base = fact_keys.shift
 
-    value = call_function('puppetdb_query',
-                          ['from', 'facts',
-                           ['extract', ['value'],
-                            ['and',
-                             ['=', 'certname', node_id],
-                             ['=', 'name', fact_base]]]])[0]['value']
+    value = run_query(node_id, fact_keys.shift)
 
-    fact_keys.each do |key|
-      value = value[key]
+    if fact_keys.empty?
+      value
+    else
+      value.dig(*fact_keys)
     end
+  end
 
-    value
+  private
+
+  def run_query(node_id, fact_name)
+    call_function('puppetdb_query',
+                  ['from', 'facts',
+                   ['extract', ['value'],
+                    ['and',
+                     ['=', 'certname', node_id],
+                     ['=', 'name', fact_name]]]])[0]['value']
   end
 end

--- a/lib/puppet/functions/fact_for.rb
+++ b/lib/puppet/functions/fact_for.rb
@@ -1,0 +1,28 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+Puppet::Functions.create_function(:fact_for) do
+  dispatch :fact_for do
+    required_param 'String', :node_id
+    required_param 'String', :fact_name
+  end
+
+  def fact_for(node_id, fact_name)
+    fact_keys = fact_name.split('.')
+    fact_base = fact_keys.shift
+
+    value = call_function('puppetdb_query',
+                          ['from', 'facts',
+                           ['extract', ['value'],
+                            ['and',
+                             ['=', 'certname', node_id],
+                             ['=', 'name', fact_base]]]])[0]['value']
+
+    fact_keys.each do |key|
+      value = value[key]
+    end
+
+    value
+  end
+end

--- a/lib/puppet/functions/nodes_for_datacenter.rb
+++ b/lib/puppet/functions/nodes_for_datacenter.rb
@@ -14,6 +14,7 @@ Puppet::Functions.create_function(:nodes_for_datacenter) do
                    ['extract', ['certname'],
                     ['and',
                      ['=', 'name', 'datacenter'],
-                     ['=', 'value', datacenter]]]]).map { |x| x['certname'] }
+                     ['=', 'value', datacenter]]]])
+      .map { |fact| fact['certname'] }
   end
 end

--- a/lib/puppet/functions/nodes_for_datacenter.rb
+++ b/lib/puppet/functions/nodes_for_datacenter.rb
@@ -1,0 +1,19 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+Puppet::Functions.create_function(:nodes_for_datacenter) do
+  dispatch :nodes_for_datacenter do
+    required_param 'String', :datacenter
+    return_type 'Array[String]'
+  end
+
+  def nodes_for_datacenter(datacenter)
+    call_function('puppetdb_query',
+                  ['from', 'facts',
+                   ['extract', ['certname'],
+                    ['and',
+                     ['=', 'name', 'datacenter'],
+                     ['=', 'value', datacenter]]]]).map { |x| x['certname'] }
+  end
+end

--- a/lib/puppet/functions/nodes_for_role.rb
+++ b/lib/puppet/functions/nodes_for_role.rb
@@ -1,0 +1,19 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+Puppet::Functions.create_function(:nodes_for_role) do
+  dispatch :nodes_for_role do
+    required_param 'String', :role
+    return_type 'Array[String]'
+  end
+
+  def nodes_for_role(role)
+    db_role = role.split('::').map { |x| x.capitalize }.join('::')
+
+    call_function('puppetdb_query',
+                  ['from', 'resources',
+                   ['extract', ['certname'],
+                    ['=', 'title', db_role]]]).map { |x| x['certname'] }
+  end
+end

--- a/lib/puppet/functions/nodes_for_role.rb
+++ b/lib/puppet/functions/nodes_for_role.rb
@@ -9,11 +9,16 @@ Puppet::Functions.create_function(:nodes_for_role) do
   end
 
   def nodes_for_role(role)
-    db_role = role.split('::').map { |x| x.capitalize }.join('::')
-
     call_function('puppetdb_query',
                   ['from', 'resources',
                    ['extract', ['certname'],
-                    ['=', 'title', db_role]]]).map { |x| x['certname'] }
+                    ['=', 'title', capitalize_each_namespace(role)]]])
+      .map { |resource| resource['certname'] }
+  end
+
+  private
+
+  def capitalize_each_namespace(resource_name)
+    resource_name.split('::').map { |ns| ns.capitalize }.join('::')
   end
 end

--- a/spec/functions/fact_for_spec.rb
+++ b/spec/functions/fact_for_spec.rb
@@ -1,0 +1,40 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'fact_for' do
+  let(:node_id) { '' }
+  let(:fact_name) { '' }
+  let(:fact_value) { '' }
+
+  let!(:puppetdb_query) do
+    MockFunction.new('puppetdb_query') do |f|
+      f.stubbed
+       .with(['from', 'facts', ['extract', ['value'], ['and', ['=', 'certname', node_id], ['=', 'name', fact_name]]]])
+       .returns([{ 'value' => fact_value }])
+    end
+  end
+
+  context 'when my_node has datacenter my_datacenter' do
+    let(:node_id) { 'my_node' }
+    let(:fact_name) { 'datacenter' }
+    let(:fact_value) { 'my_datacenter' }
+
+    it do
+      is_expected.to run.with_params('my_node', 'datacenter')
+                        .and_return('my_datacenter')
+    end
+  end
+
+  context 'when node_a has networking.ip 10.1.2.3' do
+    let(:node_id) { 'node_a' }
+    let(:fact_name) { 'networking' }
+    let(:fact_value) { { 'ip' => '10.1.2.3' } }
+
+    it do
+      is_expected.to run.with_params('node_a', 'networking.ip')
+                        .and_return('10.1.2.3')
+    end
+  end
+end

--- a/spec/functions/nodes_for_datacenter_spec.rb
+++ b/spec/functions/nodes_for_datacenter_spec.rb
@@ -1,0 +1,36 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nodes_for_datacenter' do
+  let(:datacenter) { '' }
+  let(:nodes) { [] }
+  let!(:puppetdb_query) do
+    MockFunction.new('puppetdb_query') do |f|
+      f.stubbed
+       .with(['from', 'facts', ['extract', ['certname'], ['and', ['=', 'name', 'datacenter'], ['=', 'value', datacenter]]]])
+       .returns(nodes.map { |n| { 'certname' => n } })
+    end
+  end
+
+  context 'when nodes node_a and node_b are in my_datacenter' do
+    let(:datacenter) { 'my_datacenter' }
+    let(:nodes) { %w[node_a node_b] }
+
+    it do
+      is_expected.to run.with_params('my_datacenter')
+                        .and_return(%w[node_a node_b])
+    end
+  end
+
+  context 'when nodes node_c and node_d are in another_datacenter' do
+    let(:datacenter) { 'another_datacenter' }
+    let(:nodes) { %w[node_c node_d] }
+
+    it do
+      is_expected.to run.with_params('another_datacenter')
+                        .and_return(%w[node_c node_d])
+    end
+  end
+end

--- a/spec/functions/nodes_for_role_spec.rb
+++ b/spec/functions/nodes_for_role_spec.rb
@@ -1,0 +1,36 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nodes_for_role' do
+  let(:role) { '' }
+  let(:nodes) { [] }
+  let!(:puppetdb_query) do
+    MockFunction.new('puppetdb_query') do |f|
+      f.stubbed
+       .with(['from', 'resources', ['extract', ['certname'], ['=', 'title', role]]])
+       .returns(nodes.map { |n| { 'certname' => n } })
+    end
+  end
+
+  context 'when nodes node_a and node_b have the role my_role' do
+    let(:role) { 'My_role' }
+    let(:nodes) { %w[node_a node_b] }
+
+    it do
+      is_expected.to run.with_params('my_role')
+                        .and_return(%w[node_a node_b])
+    end
+  end
+
+  context 'when nodes node_1, node_2, and node_3 have the role nebula::default' do
+    let(:role) { 'Nebula::Default' }
+    let(:nodes) { %w[node_1 node_2 node_3] }
+
+    it do
+      is_expected.to run.with_params('nebula::default')
+                        .and_return(%w[node_1 node_2 node_3])
+    end
+  end
+end


### PR DESCRIPTION
They mock puppetdb so that you don't have to. You can just mock these
functions instead. I tested that puppetdb_query works the way I'm
assuming it does by checking by hand in production, adding lines like
this one to site.pp:

notify { to_json(puppetdb_query([etc])): }

Then I ran puppet agent on one of the other nodes to see if it returned
the output I expected. I am confident that these functions can be
trusted to work right when in production.