### PR TITLE
provision user for monitoring haproxy

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,6 +24,13 @@ nebula::profile::elastic::filebeat::prospectors::mgetit::log_path: /var/log/mget
 nebula::profile::elastic::period: 90
 nebula::profile::haproxy::keepalived::floating_ip: '12.23.32.22'
 nebula::profile::haproxy::cert_source: ''
+nebula::profile::haproxy::monitoring_user:
+  name: haproxyctl
+  home: /var/haproxyctl
+  key:
+    type: ecdsa-sha2-nistp256
+    data: CCCCCCCCCCCC
+    comment: 'haproxyctl@default.invalid'
 nebula::profile::ruby::install_dir: '/opt/rbenv'
 nebula::profile::ruby::plugins:
 - rbenv/rbenv-vars

--- a/manifests/authzd_user.pp
+++ b/manifests/authzd_user.pp
@@ -11,20 +11,13 @@ define nebula::authzd_user(
   Hash $key,
   String $gid) {
 
-  $key_file = "${home}/.ssh/authorized_keys"
-
-  file { $home:
-    ensure => 'directory',
-    mode   => '0755'
-  }
-
   user { $title:
-    gid     => $gid,
-    home    => $home,
-    require => File[$home]
+    gid        => $gid,
+    home       => $home,
+    managehome => true
   }
 
-  nebula::file::ssh_keys { $key_file:
+  nebula::file::ssh_keys { "${home}/.ssh/authorized_keys":
     keys   => [ $key],
     secret => true,
   }

--- a/manifests/authzd_user.pp
+++ b/manifests/authzd_user.pp
@@ -1,0 +1,31 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# keepalived
+#
+# @example
+#   include nebula::profile::authzd_user()
+define nebula::authzd_user(
+  String $home,
+  Hash $key,
+  String $gid) {
+
+  $key_file = "${home}/.ssh/authorized_keys"
+
+  file { $home:
+    ensure => 'directory',
+    mode   => '0755'
+  }
+
+  user { $title:
+    gid     => $gid,
+    home    => $home,
+    require => File[$home]
+  }
+
+  nebula::file::ssh_keys { $key_file:
+    keys   => [ $key],
+    secret => true,
+  }
+}

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -6,7 +6,7 @@
 #
 # @example
 #   include nebula::profile::haproxy
-class nebula::profile::haproxy(String $floating_ip, String $cert_source) {
+class nebula::profile::haproxy(String $floating_ip, String $cert_source, Hash $monitoring_user) {
   service { 'haproxy':
     ensure     => 'running',
     enable     => true,
@@ -73,8 +73,11 @@ class nebula::profile::haproxy(String $floating_ip, String $cert_source) {
     }
   }
 
-  user { 'haproxyctl':
-    gid     => 'haproxy'
+  nebula::authzd_user { $monitoring_user['name']:
+    gid  => 'haproxy',
+    home => $monitoring_user['home'],
+    key  => merge($monitoring_user['key'],
+        { command => '/usr/sbin/haproxyctl' } )
   }
 
 }

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -73,5 +73,8 @@ class nebula::profile::haproxy(String $floating_ip, String $cert_source) {
     }
   }
 
+  user { 'haproxyctl':
+    gid     => 'haproxy'
+  }
 
 }

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -76,8 +76,7 @@ class nebula::profile::haproxy(String $floating_ip, String $cert_source, Hash $m
   nebula::authzd_user { $monitoring_user['name']:
     gid  => 'haproxy',
     home => $monitoring_user['home'],
-    key  => merge($monitoring_user['key'],
-        { command => '/usr/sbin/haproxyctl' } )
+    key  => $monitoring_user['key'] + { command => '/usr/sbin/haproxyctl' }
   }
 
 }

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -197,10 +197,12 @@ describe 'nebula::profile::haproxy' do
       end
 
       describe 'users' do
-        it { is_expected.to contain_user('haproxyctl').with(name: 'haproxyctl') }
-        it { is_expected.to contain_user('haproxyctl').with(gid: 'haproxy') }
-        it 'grants ssh access to the monitoring user'
-        it 'restricts ssh access for the monitoring user to running haproxyctl'
+        it { is_expected.to contain_user('haproxyctl').with(name: 'haproxyctl', gid: 'haproxy', home: '/var/haproxyctl').that_requires('File[/var/haproxyctl]') }
+
+        it 'grants ssh access to the monitoring user with force command haproxyctl' do
+          is_expected.to contain_file('/var/haproxyctl/.ssh/authorized_keys')
+            .with_content(%r{^command="/usr/sbin/haproxyctl" ecdsa-sha2-nistp256 CCCCCCCCCCCC haproxyctl@default\.invalid$})
+        end
       end
     end
   end

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -72,6 +72,12 @@ describe 'nebula::profile::haproxy' do
         it 'does not have a frontend section' do
           is_expected.not_to contain_file(file).with_content(%r{^frontend\W+.*\n})
         end
+        it 'configures the admin socket in the correct place with group privileges' do
+          is_expected.to contain_file(file).with_content(%r{stats socket /run/haproxy/admin.sock mode 660 level admin})
+        end
+        it 'runs with the haproxy group' do
+          is_expected.to contain_file(file).with_content(%r{group haproxy})
+        end
       end
 
       describe 'default file' do
@@ -188,6 +194,13 @@ describe 'nebula::profile::haproxy' do
           it { is_expected.to contain_file(dest).with(links: 'follow') }
           it { is_expected.to contain_file(dest).with(purge: true) }
         end
+      end
+
+      describe 'users' do
+        it { is_expected.to contain_user('haproxyctl').with(name: 'haproxyctl') }
+        it { is_expected.to contain_user('haproxyctl').with(gid: 'haproxy') }
+        it 'grants ssh access to the monitoring user'
+        it 'restricts ssh access for the monitoring user to running haproxyctl'
       end
     end
   end

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -197,7 +197,7 @@ describe 'nebula::profile::haproxy' do
       end
 
       describe 'users' do
-        it { is_expected.to contain_user('haproxyctl').with(name: 'haproxyctl', gid: 'haproxy', home: '/var/haproxyctl').that_requires('File[/var/haproxyctl]') }
+        it { is_expected.to contain_user('haproxyctl').with(name: 'haproxyctl', gid: 'haproxy', managehome: true, home: '/var/haproxyctl') }
 
         it 'grants ssh access to the monitoring user with force command haproxyctl' do
           is_expected.to contain_file('/var/haproxyctl/.ssh/authorized_keys')

--- a/spec/defines/authzd_user_spec.rb
+++ b/spec/defines/authzd_user_spec.rb
@@ -26,8 +26,7 @@ describe 'nebula::authzd_user' do
       let(:facts) { os_facts }
 
       describe 'users' do
-        it { is_expected.to contain_user(title).with(name: title, gid: params[:gid], home: home).that_requires("File[#{home}]") }
-        it { is_expected.to contain_file(home).with(ensure: 'directory', mode: '0755') }
+        it { is_expected.to contain_user(title).with(name: title, gid: params[:gid], home: home, managehome: true) }
         it { is_expected.to contain_file("#{home}/.ssh").with(ensure: 'directory', mode: '0700') }
 
         it 'creates authorized_keys with the given key' do

--- a/spec/defines/authzd_user_spec.rb
+++ b/spec/defines/authzd_user_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::authzd_user' do
+  let(:title) { Faker::Internet.user_name }
+  let(:home) { '/some/where' }
+  let(:params) do
+    {
+      gid: Faker::Internet.user_name,
+      home: home,
+      key: {
+        type: 'ssh-rsa',
+        data: 'CCCCCCCCCCCC',
+        comment: Faker::Internet.email,
+      },
+    }
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      describe 'users' do
+        it { is_expected.to contain_user(title).with(name: title, gid: params[:gid], home: home).that_requires("File[#{home}]") }
+        it { is_expected.to contain_file(home).with(ensure: 'directory', mode: '0755') }
+        it { is_expected.to contain_file("#{home}/.ssh").with(ensure: 'directory', mode: '0700') }
+
+        it 'creates authorized_keys with the given key' do
+          is_expected.to contain_file("#{home}/.ssh/authorized_keys")
+            .with_content(%r{^#{params[:key][:type]} #{params[:key][:data]} #{params[:key][:comment]}$})
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/file/ssh_keys_spec.rb
+++ b/spec/defines/file/ssh_keys_spec.rb
@@ -49,6 +49,26 @@ describe 'nebula::file::ssh_keys' do
         end
       end
 
+      context 'when given a key with a command' do
+        let(:params) do
+          {
+            keys: [
+              {
+                type: 'ssh-rsa',
+                data: 'AAAAAAAAAAAA',
+                comment: 'name',
+                command: '/usr/bin/whatever',
+              },
+            ],
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/opt/keys')
+            .with_content(%r{^command="/usr/bin/whatever" ssh-rsa AAAAAAAAAAAA name$})
+        end
+      end
+
       context 'when called /etc/secret/keys and secret is true' do
         let(:title) { '/etc/secret/keys' }
         let(:params) { { secret: true } }

--- a/templates/file/ssh_keys.erb
+++ b/templates/file/ssh_keys.erb
@@ -1,4 +1,8 @@
 # Managed by puppet (nebula/file/ssh_keys)
-<% @keys.each do |key| -%>
-<%= key.has_key?('command') ? "command=\"#{key['command']}\" " : '' %><%= key['type'] %> <%= key['data'] %> <%= key['comment'] %>
+<% @keys.each do |ssh_key| -%>
+<% if ssh_key.has_key?('command') -%>
+command="<%= ssh_key['command'] %>" <%= ssh_key['type'] %> <%= ssh_key['data'] %> <%= ssh_key['comment'] %>
+<% else -%>
+<%= ssh_key['type'] %> <%= ssh_key['data'] %> <%= ssh_key['comment'] %>
+<% end -%>
 <% end -%>

--- a/templates/file/ssh_keys.erb
+++ b/templates/file/ssh_keys.erb
@@ -1,4 +1,4 @@
 # Managed by puppet (nebula/file/ssh_keys)
 <% @keys.each do |key| -%>
-<%= key['type'] %> <%= key['data'] %> <%= key['comment'] %>
+<%= key.has_key?('command') ? "command=\"#{key['command']}\" " : '' %><%= key['type'] %> <%= key['data'] %> <%= key['comment'] %>
 <% end -%>


### PR DESCRIPTION
Things I'd like feedback on:

- Whether the method of passing the user to the haproxy profile looks reasonable
- The nebula::authzd_user define in general - the general existence of it, but also in particular if there's a way of passing excess parameters to the user resource, that'd be nice (i.e. basically have nebula::authzd_user act as a decorator that ensures the home directory exists and can provision an ssh key in addition to actually creating the user)

- If there's a cleaner way of passing the parameters from `nebula::profile::haproxy` to `nebula::authzd_user` (a la https://github.com/mlibrary/nebula/blob/master/manifests/profile/vmhost/host.pp#L30 ) (I might experiment a little bit here if I have time)

- An easier-to-read way than https://github.com/mlibrary/nebula/compare/aeim-1296?expand=1#diff-889480bf39ad9af01eb92e9ac1a43da0L3 for conditionally putting the command in