### PR TITLE
AEIM-1248: support multiple floating IPs

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,7 +22,9 @@ nebula::profile::elastic::logstash_hosts:
 - logstash.default.invalid:1234
 nebula::profile::elastic::filebeat::prospectors::mgetit::log_path: /var/log/mgetit.default.invalid
 nebula::profile::elastic::period: 90
-nebula::profile::haproxy::keepalived::floating_ip: '12.23.32.22'
+nebula::profile::haproxy::keepalived::floating_ips: 
+  svc1: '12.23.32.22'
+  svc2: '12.23.32.23'
 nebula::profile::haproxy::cert_source: ''
 nebula::profile::haproxy::monitoring_user:
   name: haproxyctl

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -6,7 +6,7 @@
 #
 # @example
 #   include nebula::profile::haproxy
-class nebula::profile::haproxy(String $floating_ip, String $cert_source, Hash $monitoring_user) {
+class nebula::profile::haproxy(Hash $floating_ips, String $cert_source, Hash $monitoring_user) {
   service { 'haproxy':
     ensure     => 'running',
     enable     => true,
@@ -58,16 +58,18 @@ class nebula::profile::haproxy(String $floating_ip, String $cert_source, Hash $m
       group  => 'root'
     }
 
-    file { '/etc/ssl/private/www-lib':
-      ensure  => 'directory',
-      mode    => '0700',
-      owner   => 'haproxy',
-      group   => 'haproxy',
-      recurse => true,
-      purge   => true,
-      links   => 'follow',
-      notify  => Service['haproxy'],
-      source  => "puppet://${cert_source}/www-lib"
+    $frontends.each |$frontend, $nodes| {
+      file { "/etc/ssl/private/${frontend}":
+        ensure  => 'directory',
+        mode    => '0700',
+        owner   => 'haproxy',
+        group   => 'haproxy',
+        recurse => true,
+        purge   => true,
+        links   => 'follow',
+        notify  => Service['haproxy'],
+        source  => "puppet://${cert_source}/${frontend}"
+      }
     }
   }
 

--- a/manifests/profile/haproxy/keepalived.pp
+++ b/manifests/profile/haproxy/keepalived.pp
@@ -6,10 +6,10 @@
 #
 # @example
 #   include nebula::profile::haproxy::keepalived
-class nebula::profile::haproxy::keepalived(String $floating_ip,
+class nebula::profile::haproxy::keepalived(Hash $floating_ips,
     Boolean $master = false) {
   class { 'nebula::profile::haproxy':
-    floating_ip => $floating_ip,
+    floating_ips => $floating_ips,
   }
 
   package { 'keepalived': }

--- a/spec/classes/profile/haproxy/keepalived_spec.rb
+++ b/spec/classes/profile/haproxy/keepalived_spec.rb
@@ -74,14 +74,19 @@ describe 'nebula::profile::haproxy::keepalived' do
           is_expected.to contain_file(file).with_content(%r{^vrrp_script check_haproxy})
         end
 
-        it 'has the haproxy floating ip address' do
-          is_expected.to contain_file(file).with_content(%r{virtual_ipaddress {\n\s*12\.23\.32\.22\n\s*}}m)
+        it 'has the haproxy floating ip addresses' do
+          is_expected.to contain_file(file).with_content(%r{virtual_ipaddress {\n\s*12\.23\.32\.22\n\s*12\.23\.32\.23\n\s*}}m)
         end
 
         context 'with a floating ip address parameter' do
-          let(:params) { { floating_ip: Faker::Internet.ip_v4_address } }
+          let(:params) do
+            {
+              floating_ips: { svc1: Faker::Internet.ip_v4_address,
+                              svc2: Faker::Internet.ip_v4_address },
+            }
+          end
 
-          it { is_expected.to contain_file(file).with_content(%r{virtual_ipaddress {\n\s*#{params[:floating_ip]}\n\s*}}m) }
+          it { is_expected.to contain_file(file).with_content(%r{virtual_ipaddress {\n\s*#{params[:floating_ips][:svc1]}\n\s*#{params[:floating_ips][:svc2]}\n\s*}}m) }
         end
 
         it { is_expected.to contain_file(file).with_content(%r{unicast_src_ip #{my_ip}}) }

--- a/templates/profile/haproxy/frontends.cfg.erb
+++ b/templates/profile/haproxy/frontends.cfg.erb
@@ -1,15 +1,15 @@
 # Managed by puppet (nebula/profile/haproxy/frontends.cfg.erb)
 
-<% @frontends.keys.sort.each do |frontend| -%>
+<% @frontends.keys.map { |k| k.to_s }.sort.each do |frontend| -%>
 frontend <%= frontend %>-<%= @datacenter -%>-http-front
-  bind <%= @floating_ip -%>:80,<%= @networking['ip'] -%>:80
+  bind <%= @floating_ips[frontend] -%>:80,<%= @networking['ip'] -%>:80
   stats uri /haproxy?stats
   default_backend <%= frontend %>-<%= @datacenter -%>-http-back
   http-request set-header X-Client-IP %ci
   http-request set-header X-Forwarded-Proto http
 
 frontend <%= frontend %>-<%= @datacenter -%>-https-front
-  bind <%= @floating_ip -%>:443,<%= @networking['ip'] -%>:443 ssl crt /etc/ssl/private/www-lib
+  bind <%= @floating_ips[frontend] -%>:443,<%= @networking['ip'] -%>:443 ssl crt /etc/ssl/private/<%= frontend %>
   stats uri /haproxy?stats
   default_backend <%= frontend %>-<%= @datacenter -%>-https-back
   http-response set-header "Strict-Transport-Security" "max-age=31536000"

--- a/templates/profile/haproxy/keepalived/keepalived.conf.erb
+++ b/templates/profile/haproxy/keepalived/keepalived.conf.erb
@@ -27,7 +27,9 @@ vrrp_instance haproxy {
   interface <%= @networking['primary'] %>
   virtual_router_id 51
   virtual_ipaddress {
-    <%= @floating_ip %>
+    <%- @floating_ips.each do |_,floating_ip| -%>
+      <%= floating_ip %>
+    <%- end -%>
   }
 
   unicast_src_ip <%= @networking["ip"] %>
@@ -47,4 +49,3 @@ vrrp_instance haproxy {
     check_haproxy
   }
 }
-


### PR DESCRIPTION
* Changes floating_ip from a single string to a hash based on service name
* Remove all vestiges of fixed service name 'www-lib'
* Use correct SSL cert dir based on service name

N.B. I manually tested the syntax for keepalived (multiple floating IPs in a single virtual_ipaddress block) and it seems to work AFAICT