### PR TITLE
only use other keepalive nodes as keepalived "unicast peers"

### DIFF
--- a/manifests/profile/haproxy/keepalived.pp
+++ b/manifests/profile/haproxy/keepalived.pp
@@ -22,7 +22,8 @@ class nebula::profile::haproxy::keepalived(Hash $floating_ips,
     require    => Package['keepalived'],
   }
 
-  $frontends = balanced_frontends()
+  $nodes_for_class = nodes_for_class($title)
+  $nodes_for_datacenter = nodes_for_datacenter($::datacenter)
   $email = lookup('nebula::root_email')
 
   file { '/etc/keepalived/keepalived.conf':

--- a/spec/classes/profile/haproxy/keepalived_spec.rb
+++ b/spec/classes/profile/haproxy/keepalived_spec.rb
@@ -22,19 +22,14 @@ describe 'nebula::profile::haproxy::keepalived' do
       end
 
       let(:thisnode) { { 'ip' => facts[:networking][:ip], 'hostname' => facts[:hostname] } }
-      let(:scotch) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'scotch' } }
-      let(:soda)   { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'soda' } }
-      let(:coffee) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'coffee' } }
+      let(:haproxy2) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'haproxy2' } }
       let(:base_file) { '/etc/keepalived/keepalived.conf' }
       let(:service) { 'keepalived' }
 
-      include_context 'with mocked puppetdb functions', 'somedc', %w[thisnode scotch soda coffee]
+      include_context 'with mocked puppetdb functions', 'somedc', %w[thisnode haproxy2]
 
-      before(:each) do
-        stub('balanced_frontends') do |d|
-          allow_call(d).and_return('www-lib': %w[scotch soda], 'svc2': %w[scotch coffee])
-        end
-      end
+      # required for included haproxy role, but isn't tested here
+      before(:each) { stub('balanced_frontends') { |d| allow_call(d).and_return({}) } }
 
       describe 'roles' do
         it { is_expected.to contain_class('nebula::profile::haproxy') }
@@ -92,7 +87,7 @@ describe 'nebula::profile::haproxy::keepalived' do
         it { is_expected.to contain_file(file).with_content(%r{unicast_src_ip #{my_ip}}) }
 
         it 'has a unicast_peer block with the IP addresses of all nodes with the same profile at the same datancenter except for me' do
-          is_expected.to contain_file(file).with_content(%r{unicast_peer {\n\s*#{coffee['ip']}\n\s*#{scotch['ip']}\n\s*#{soda['ip']}\n\s*}})
+          is_expected.to contain_file(file).with_content(%r{unicast_peer {\n\s*#{haproxy2['ip']}\n\s*}\n\s*})
         end
 
         it { is_expected.to contain_file(file).with_content(%r{interface #{facts[:networking][:primary]}}) }

--- a/templates/profile/haproxy/keepalived/keepalived.conf.erb
+++ b/templates/profile/haproxy/keepalived/keepalived.conf.erb
@@ -35,7 +35,7 @@ vrrp_instance haproxy {
   unicast_src_ip <%= @networking["ip"] %>
   unicast_peer {
   <%-
-  nodes = @frontends.values.flatten.sort.uniq
+  nodes = (@nodes_for_class & @nodes_for_datacenter)
     .map{|node_id| scope.call_function('fact_for', [node_id, 'networking'])}
     .map{|networking| networking['ip']}
     .select{ |ip| ip != @networking['ip'] }


### PR DESCRIPTION
partially reverts https://github.com/mlibrary/nebula/commit/53e3bd8b#diff-6587d3550c955340798dee887ef692b5R36