### PR TITLE
optionally provisions local storage for a vmhost

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,6 +18,9 @@ fixtures:
     inifile:
       repo: "puppetlabs/inifile"
       ref: "1.1.3"
+    lvm:
+      repo: "puppetlabs/lvm"
+      ref: "1.0.1"
     postgresql:
       repo: "puppetlabs/postgresql"
       ref: "5.2.1"

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,7 @@
     {"name": "puppetlabs/concat", "version_requirement": ">= 4.2.0 < 5.0.0"},
     {"name": "puppetlabs/firewall", "version_requirement": ">= 1.1.3 < 2.0.0"},
     {"name": "puppetlabs/inifile", "version_requirement": ">= 1.1.3 < 3.0.0"},
+    {"name": "puppetlabs/lvm", "version_requirement": ">= 1.0.1"},
     {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},


### PR DESCRIPTION
I figure we can factor the LV / filesystem / mount creation out to a new define the next time we want to do it the same way.