### PR TITLE
remove default services/floating ips for haproxy

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,13 +22,7 @@ nebula::profile::elastic::logstash_hosts:
 - logstash.default.invalid:1234
 nebula::profile::elastic::filebeat::prospectors::mgetit::log_path: /var/log/mgetit.default.invalid
 nebula::profile::elastic::period: 90
-nebula::profile::haproxy::services:
-  svc1:
-    floating_ip: '12.23.32.22'
-    max_requests_per_sec: 10
-    max_requests_burst: 200
-  svc2:
-    floating_ip: '12.23.32.23'
+nebula::profile::haproxy::services: {}
 nebula::profile::haproxy::cert_source: ''
 nebula::profile::haproxy::monitoring_user:
   name: haproxyctl

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -40,7 +40,9 @@ class nebula::profile::haproxy(
     group  => 'root'
   }
 
-  $balanced_frontends.each |$service, $node_names| {
+  $balanced_frontends.filter |$service, $node_names| {
+    $services.has_key($service)
+  }.each |$service, $node_names| {
     nebula::haproxy_service { $service :
       cert_source => $cert_source,
       node_names  => $node_names,

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -32,7 +32,16 @@ describe 'nebula::profile::haproxy' do
       let(:scotch) { { 'ip' => '111.111.111.123', 'hostname' => 'scotch' } }
       let(:soda)   { { 'ip' => '222.222.222.234', 'hostname' => 'soda' } }
       let(:third_server) { { 'ip' => '333.333.333.345', 'hostname' => 'third_server' } }
-      let(:params) { { cert_source: '/some/where' } }
+      let(:base_params) do
+        { cert_source: '/some/where',
+          services: {"svc1"=>
+           {"floating_ip"=>"12.23.32.22",
+            "max_requests_per_sec"=>10,
+            "max_requests_burst"=>200},
+            "svc2"=>{"floating_ip"=>"12.23.32.23"}}}
+      end
+      let(:params) { base_params }
+
 
       include_context 'with mocked puppetdb functions', 'somedc', %w[thisnode haproxy2 scotch soda third_server], 'nebula::profile::haproxy' => %w[thisnode haproxy2]
 
@@ -189,14 +198,14 @@ describe 'nebula::profile::haproxy' do
         it { is_expected.to contain_file(file).with_content(%r{notification_email_from root@default.invalid}) }
 
         context 'on a master node' do
-          let(:params) { { master: true } }
+          let(:params) { base_params.merge({ master: true }) }
 
           it { is_expected.to contain_file(file).with_content(%r{priority 101}) }
           it { is_expected.to contain_file(file).with_content(%r{state MASTER}) }
         end
 
         context 'on a backup node' do
-          let(:params) { { master: false } }
+          let(:params) { base_params.merge({ master: false }) }
 
           it { is_expected.to contain_file(file).with_content(%r{priority 100}) }
           it { is_expected.to contain_file(file).with_content(%r{state BACKUP}) }

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -34,14 +34,13 @@ describe 'nebula::profile::haproxy' do
       let(:third_server) { { 'ip' => '333.333.333.345', 'hostname' => 'third_server' } }
       let(:base_params) do
         { cert_source: '/some/where',
-          services: {"svc1"=>
-           {"floating_ip"=>"12.23.32.22",
-            "max_requests_per_sec"=>10,
-            "max_requests_burst"=>200},
-            "svc2"=>{"floating_ip"=>"12.23.32.23"}}}
+          services: { 'svc1' =>
+           { 'floating_ip' => '12.23.32.22',
+             'max_requests_per_sec' => 10,
+             'max_requests_burst' => 200 },
+                      'svc2' => { 'floating_ip' => '12.23.32.23' } } }
       end
       let(:params) { base_params }
-
 
       include_context 'with mocked puppetdb functions', 'somedc', %w[thisnode haproxy2 scotch soda third_server], 'nebula::profile::haproxy' => %w[thisnode haproxy2]
 
@@ -198,14 +197,14 @@ describe 'nebula::profile::haproxy' do
         it { is_expected.to contain_file(file).with_content(%r{notification_email_from root@default.invalid}) }
 
         context 'on a master node' do
-          let(:params) { base_params.merge({ master: true }) }
+          let(:params) { base_params.merge(master: true) }
 
           it { is_expected.to contain_file(file).with_content(%r{priority 101}) }
           it { is_expected.to contain_file(file).with_content(%r{state MASTER}) }
         end
 
         context 'on a backup node' do
-          let(:params) { base_params.merge({ master: false }) }
+          let(:params) { base_params.merge(master: false) }
 
           it { is_expected.to contain_file(file).with_content(%r{priority 100}) }
           it { is_expected.to contain_file(file).with_content(%r{state BACKUP}) }


### PR DESCRIPTION
allows us to use deep merge strategy in hiera - not making that the
default here though