### PR TITLE
Add puma wrapper to profile::named_instances

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -147,5 +147,6 @@ nebula::profile::vmhost::host::netmask: '0.0.0.0'
 nebula::profile::vmhost::host::gateway: '10.1.2.3'
 nebula::profile::vmhost::host::nameservers: "%{alias('nebula::resolv_conf::nameservers')}"
 
+nebula::profile::named_instances::puma_wrapper: "/l/local/bin/profile_puma_wrap"
 nebula::profile::named_instances::fauxpaas_pubkey: "somepublickey"
 nebula::profile::named_instances::fauxpaas_puma_config: "config/fauxpaas_puma.rb"

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -11,6 +11,7 @@ define nebula::named_instance(
   Integer           $gid,
   String            $pubkey,
   String            $puma_config,
+  String            $puma_wrapper,
   Array[String]     $users = [],
   Array[String]     $subservices = [],
 ) {
@@ -74,7 +75,7 @@ define nebula::named_instance(
     ensure   => 'stopped',
     enable   => false,
     provider => 'systemd',
-    before  => Class['nebula::systemd::daemon_reload']
+    before   => Class['nebula::systemd::daemon_reload']
   }
 
   # Remove the old style systemd puma file
@@ -89,7 +90,9 @@ define nebula::named_instance(
   }
 
   # Remove the old style systemd resque-pool file
-  file { "/etc/systemd/system/resque-pool@${title}.service.d": ensure  => 'absent', recurse => true,
+  file { "/etc/systemd/system/resque-pool@${title}.service.d":
+    ensure  => 'absent',
+    recurse => true,
     force   => true,
     notify  => [
       Class['nebula::systemd::daemon_reload'],

--- a/manifests/profile/named_instances.pp
+++ b/manifests/profile/named_instances.pp
@@ -13,17 +13,24 @@
 class nebula::profile::named_instances (
   String      $fauxpaas_pubkey,
   String      $fauxpaas_puma_config,
+  String      $puma_wrapper,
   Array[Hash] $instances = [],
 ) {
+
+  class { 'nebula::profile::named_instances::puma_wrapper':
+    path => $puma_wrapper
+  }
+
   $instances.each |$instance| {
     nebula::named_instance { $instance['name']:
-      path        => $instance['path'],
-      uid         => $instance['uid'],
-      gid         => $instance['gid'],
-      users       => $instance['users'],
-      subservices => $instance['subservices'],
-      pubkey      => $fauxpaas_pubkey,
-      puma_config => $fauxpaas_puma_config,
+      path         => $instance['path'],
+      uid          => $instance['uid'],
+      gid          => $instance['gid'],
+      users        => $instance['users'],
+      subservices  => $instance['subservices'],
+      puma_wrapper => $puma_wrapper,
+      pubkey       => $fauxpaas_pubkey,
+      puma_config  => $fauxpaas_puma_config,
     }
   }
 }

--- a/manifests/profile/named_instances/puma_wrapper.pp
+++ b/manifests/profile/named_instances/puma_wrapper.pp
@@ -1,0 +1,20 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Wrapper for puma
+# It uses bundled puma if present, system puma otherwise
+# It prefers the fauxpaas puma config over the default location
+#
+# @example
+class nebula::profile::named_instances::puma_wrapper(
+  String  $path
+){
+  file { $path:
+    ensure  => 'present',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => template('nebula/profile/named_instances/puma_wrapper/script.erb'),
+  }
+}

--- a/spec/classes/profile/named_instances_spec.rb
+++ b/spec/classes/profile/named_instances_spec.rb
@@ -33,6 +33,12 @@ describe 'nebula::profile::named_instances' do
       context 'with instances' do
         let(:params) { { instances: [myapp_testing, hydra_staging] } }
 
+        describe 'puma wrapper' do
+          let(:klass) { 'nebula::profile::named_instances::puma_wrapper' }
+
+          it { is_expected.to contain_class(klass).with(path: '/l/local/bin/profile_puma_wrap') }
+        end
+
         it do
           is_expected.to contain_nebula__named_instance(myapp_testing[:name]).with(
             path: myapp_testing[:path],
@@ -53,7 +59,7 @@ describe 'nebula::profile::named_instances' do
             pubkey: 'somepublickey',
             puma_config: 'config/fauxpaas_puma.rb',
             users: hydra_staging[:users],
-            subservices: hydra_staging[:subservices]
+            subservices: hydra_staging[:subservices],
           )
         end
       end

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -13,6 +13,7 @@ describe 'nebula::named_instance' do
   let(:uid) { 30_001 }
   let(:gid) { 20_001 }
   let(:pubkey) { 'somepublickey' }
+  let(:puma_wrapper) { '/l/local/bin/puma_wrapper' }
   let(:puma_config) { 'config/fauxpaas_puma.rb' }
   let(:users) { %w[alice solr] }
   let(:params) do
@@ -22,6 +23,7 @@ describe 'nebula::named_instance' do
       gid: gid,
       subservices: subservices,
       pubkey: pubkey,
+      puma_wrapper: puma_wrapper,
       puma_config: puma_config,
       users: users,
     }
@@ -132,8 +134,8 @@ describe 'nebula::named_instance' do
         it { is_expected.to contain_file(puma).with_content(%r{^Environment=\"RBENV_ROOT=/opt/rbenv\"$}) }
         it { is_expected.to contain_file(puma).with_content(%r{^Environment=\"RAILS_ENV=production"$}) }
         it { is_expected.to contain_file(puma).with_content(%r{^WorkingDirectory=#{path}/current$}) }
-        it { is_expected.to contain_file(puma).with_content(%r{^ExecStart=/opt/rbenv/bin/rbenv exec puma -C #{puma_config}$}) }
-        it { is_expected.to contain_file(puma).with_content(%r{^TimeoutStartSec=20$}) }
+        it { is_expected.to contain_file(puma).with_content(%r{^ExecStart=#{puma_wrapper}$}) }
+        it { is_expected.to contain_file(puma).with_content(%r{^TimeoutStartSec=[0-9]+$}) }
       end
 
       describe 'subservices' do
@@ -153,7 +155,7 @@ describe 'nebula::named_instance' do
             it { is_expected.to contain_file(subservice_file).with_content(%r{^Environment=\"RAILS_ENV=production"$}) }
             it { is_expected.to contain_file(subservice_file).with_content(%r{^WorkingDirectory=#{path}/current$}) }
             it { is_expected.to contain_file(subservice_file).with_content(%r{^ExecStart=/opt/rbenv/bin/rbenv exec bundle exec bin/#{subservice}$}) }
-            it { is_expected.to contain_file(subservice_file).with_content(%r{^TimeoutStartSec=20$}) }
+            it { is_expected.to contain_file(subservice_file).with_content(%r{^TimeoutStartSec=[0-9]+$}) }
           end
         end
       end

--- a/templates/named_instance/puma.service.erb
+++ b/templates/named_instance/puma.service.erb
@@ -18,7 +18,7 @@ Group=<%= @title %>
 Environment="RBENV_ROOT=<%= @rbenv_root %>"
 Environment="RAILS_ENV=production"
 WorkingDirectory=<%= @path -%>/current
-ExecStart=<%= @rbenv_root -%>/bin/rbenv exec puma -C <%= @puma_config %>
+ExecStart=<%= @puma_wrapper %>
 
 <% if @os['release']['major'] == '8' %>
 StartLimitIntervalSec=900

--- a/templates/profile/named_instances/puma_wrapper/script.erb
+++ b/templates/profile/named_instances/puma_wrapper/script.erb
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Managed by puppet (nebula/named_instance/fauxpuma.erb)
+
+RBENV="<%= @rbenv_root -%>/bin/rbenv"
+FAUXPAAS_PUMA_CONFIG="<%= @puma_config -%>"
+DEFAULT_PUMA_CONFIG="config/puma.rb"
+
+$RBENV exec bundle exec puma --version > /dev/null 2>&1
+PUMA_STATUS=$?
+
+if [ $PUMA_STATUS -eq 0 ]
+then
+  BIN="bundle exec puma"
+else
+  BIN="puma"
+fi
+
+if [ -e "$FAUXPAAS_PUMA_CONFIG" ]
+then
+  CONFIG="$FAUXPAAS_PUMA_CONFIG"
+else
+  CONFIG="$DEFAULT_PUMA_CONFIG"
+fi
+
+echo "running: $RBENV exec $BIN -C $CONFIG"
+$RBENV exec $BIN -C $CONFIG
+


### PR DESCRIPTION
Resolves AEIM-1156

This adds a wrapper over puma that can handle applications with legacy
or modern deployments. This should aid in migrating those deployments.

The possible scenarios are (in order of how common they are):

- [x] bundled puma + no fauxpaas config (previous standard)
- [x] bundled puma + fauxpaas config (typical transition pattern)
- [x] no bundled puma + fauxpaas config (current standard)
- [x] no bundled puma + no fauxpaas config (doesn't happen)

This solution addresses all of these scenarios. Those that have been tested on live servers are checked off.  