### PR TITLE
AEIM-1410: Allow adding an "only if" condition for throttling

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -23,7 +23,6 @@ nebula::profile::elastic::logstash_hosts:
 nebula::profile::elastic::filebeat::prospectors::mgetit::log_path: /var/log/mgetit.default.invalid
 nebula::profile::elastic::period: 90
 nebula::profile::haproxy::services: {}
-nebula::profile::haproxy::cert_source: ''
 nebula::profile::haproxy::monitoring_user:
   name: haproxyctl
   home: /var/haproxyctl

--- a/manifests/haproxy_service.pp
+++ b/manifests/haproxy_service.pp
@@ -7,12 +7,13 @@
 # @example
 #   nebula::haproxy_service { 'namevar': }
 define nebula::haproxy_service(
-  String          $floating_ip,
-  Array[String]   $node_names = [],
-  String          $cert_source = '',
-  Integer         $max_requests_per_sec = 0,
-  Integer         $max_requests_burst = 0,
-  Hash            $whitelists = {}
+  String           $floating_ip,
+  Array[String]    $node_names = [],
+  Optional[String] $cert_source = undef,
+  Optional[String] $throttle_condition = undef,
+  Integer          $max_requests_per_sec = 0,
+  Integer          $max_requests_burst = 0,
+  Hash             $whitelists = {}
 ) {
 
   include nebula::profile::haproxy::prereqs
@@ -46,7 +47,7 @@ define nebula::haproxy_service(
     notify  => Service['haproxy'],
   }
 
-  if $cert_source != '' {
+  if $cert_source {
     file { "/etc/ssl/private/${service}":
       ensure  => 'directory',
       mode    => '0700',

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -10,7 +10,7 @@ class nebula::profile::haproxy(
   Hash $services,
   Hash $monitoring_user,
   Boolean $master = false,
-  String $cert_source = '',
+  Optional[String] $cert_source = undef,
 ) {
   include nebula::profile::haproxy::prereqs
   include nebula::profile::networking::sysctl

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -17,8 +17,7 @@ describe 'nebula::haproxy_service' do
       let(:third_server) { { 'ip' => '222.222.222.235', 'hostname' => 'third_server' } }
       let(:base_params) do
         { floating_ip: '1.2.3.4',
-          node_names: %w[scotch soda],
-          cert_source: '' }
+          node_names: %w[scotch soda] }
       end
       let(:params) { base_params }
 
@@ -156,6 +155,15 @@ describe 'nebula::haproxy_service' do
 
             it { is_expected.to contain_file('/etc/haproxy/svc1_whitelist_path_beg.txt').with_content("/some/where\n/another/path\n") }
             it { is_expected.to contain_file('/etc/haproxy/svc1_whitelist_path_end.txt').with_content(".abc\n.def\n") }
+          end
+
+          context 'with throttling condition' do
+            let(:params) do
+              throttling_params.merge(throttle_condition: 'path_beg /whatever')
+            end
+
+            it { is_expected.to contain_file(service_config).with_content(%r{acl throttle_condition path_beg /whatever}) }
+            it { is_expected.to contain_file(service_config).with_content(%r{use_backend svc1-hatcher-http-back-exempt if !throttle_condition}) }
           end
         end
       end

--- a/templates/profile/haproxy/service.cfg.erb
+++ b/templates/profile/haproxy/service.cfg.erb
@@ -46,26 +46,46 @@ EOT
     "  server #{hostname} #{ip}:#{port} #{check} cookie s#{ip.split('.').last}"
   end
 
-  def any_whitelists?
-    @whitelists.find { |_,exemptions| exemptions.size() > 0 }
+  def nonempty_whitelists
+    @whitelists.select { |_,exemptions| exemptions.size() > 0 }
   end
 
-  def whitelist_acl_files
-    @whitelists.select { |_,exemptions| exemptions.size() > 0 }
-      .map do |whitelist,_|
+  def any_exemptions?
+    nonempty_whitelists.size() > 0 or @throttle_condition
+  end
+
+  def whitelist_file_acls
+    nonempty_whitelists.map do |whitelist,_|
       "  acl whitelist_#{whitelist} #{whitelist} -n -f /etc/haproxy/#{@service}_whitelist_#{whitelist}.txt\n"
-      end.join("")
+    end.join("")
   end
 
-  def whitelist_condition
-    @whitelists.select { |_,exemptions| exemptions.size() > 0 }
-      .map do |whitelist,_|
-        "whitelist_#{whitelist}"
-      end.join(" OR ")
+  def throttle_condition_acl
+    if @throttle_condition
+      "  acl throttle_condition #{@throttle_condition}\n"
+    else
+      ""
+    end
   end
 
-  def whitelist(service_prefix)
-    whitelist_acl_files + "  use_backend #{service_prefix}-back-exempt if #{whitelist_condition}\n"
+  def whitelist_acl_names
+    nonempty_whitelists.map do |whitelist,_|
+      "whitelist_#{whitelist}"
+    end
+  end
+
+  def exemption_condition
+    acls = whitelist_acl_names
+    acls = acls + ["!throttle_condition"] if @throttle_condition
+    acls.join(" OR ")
+  end
+
+  def exemption(service_prefix)
+    if any_exemptions?
+      "  use_backend #{service_prefix}-back-exempt if #{exemption_condition}\n"
+    else
+      ""
+    end
   end
 
   def bind_options(args)
@@ -91,7 +111,7 @@ backend <%= service_prefix %>-back
 <%= throttling(service_loc) if use_throttling? -%>
 <%= nodes.map { |hostname,ip| backend_server(hostname,ip,options[:port],check_or_track(protocol,service_loc,hostname)) }.join("\n") %>
 
-<% if any_whitelists? -%>
+<% if any_exemptions? -%>
 backend <%= service_prefix %>-back-exempt
 <%= nodes.map { |hostname,ip| backend_server(hostname,ip,options[:port],track(service_loc,hostname)) }.join("\n") %>
 <% end -%>
@@ -104,7 +124,9 @@ frontend <%= service_prefix %>-front
 <% end -%>
   http-request set-header X-Client-IP %ci
   http-request set-header X-Forwarded-Proto <%= protocol %>
-<%= whitelist(service_prefix) if any_whitelists? -%>
+<%= whitelist_file_acls -%>
+<%= throttle_condition_acl -%>
+<%= exemption(service_prefix) -%>
   default_backend <%= service_prefix %>-back
 
 <% end %>


### PR DESCRIPTION
To minimize disruption to the existing setup with the default backend
throttled and a separate backend exempt from throttling, this is
expressed as a negated condition for the exemption back end - that is,
use the backend exempt from throttling only if the incoming request does
NOT match a particular pattern.

This also changes the optional string parameters to Optional[String]
with a default of undef rather than '' - this seems to be the more
idiomatic way to handle it in puppet given that we still needed
conditionality to handle ''.