### PR TITLE
AEIM-1502: install i40e-dkms if intel x710 network card is installed

### DIFF
--- a/lib/facter/network_cards.rb
+++ b/lib/facter/network_cards.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Facter.add(:network_cards) do
+  setcode do
+    Facter::Core::Execution.execute(
+      "lspci | grep Ethernet | cut -f 3 -d ':'",
+    ).strip.split("\n")
+  end
+end

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -60,4 +60,5 @@ class nebula::profile::base (
 
   include nebula::profile::base::stop_mcollective
   include nebula::profile::base::blacklist_hpwdt
+  include nebula::profile::base::i40e
 }

--- a/manifests/profile/base/i40e.pp
+++ b/manifests/profile/base/i40e.pp
@@ -1,0 +1,15 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::base::i40e
+#
+# Use Intel-provided i40e driver if the Intel X710 card is present
+#
+# @example
+#   include nebula::profile::base::i40e
+class nebula::profile::base::i40e {
+  if $facts['network_cards'] and $facts['network_cards'].filter |$card| { $card =~ /Intel.*X710/ } {
+    package { 'i40e-dkms': }
+  }
+}

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -119,6 +119,16 @@ describe 'nebula::profile::base' do
 
         it { is_expected.not_to contain_kmod__blacklist('hpwdt') }
       end
+
+      it { is_expected.not_to contain_package('i40e-dkms') }
+
+      context 'with an Intel X710 network card' do
+        let(:facts) do
+          super().merge('network_cards' => ['Intel Corporation Ethernet Controller X710 for 10GbE SFP+ (rev 01)'])
+        end
+
+        it { is_expected.to contain_package('i40e-dkms') }
+      end
     end
   end
 end


### PR DESCRIPTION
The default driver that comes with Debian Stretch is not stable. See JIRA issue and commit messages for more details.