### PR TITLE
AEIM-1430 - Install PEAR modules with puppet/php

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -33,6 +33,9 @@ fixtures:
     reboot:
       repo: "puppetlabs/reboot"
       ref: "2.0.0"
+    php:
+      repo: "puppet/php"
+      ref: "6.0.2"
     debconf:
       repo: "stm/debconf"
       ref: "2.1.0"

--- a/manifests/profile/hathitrust/php.pp
+++ b/manifests/profile/hathitrust/php.pp
@@ -18,27 +18,52 @@ class nebula::profile::hathitrust::php () {
       'php7.0-common',
       'php7.0-curl',
       'php7.0-gd',
-      'php-geoip',
+      'php-geoip', # PECL
       'php7.0-ldap',
       'php7.0-mysql',
       'php7.0-xsl',
-      'php-date',
-      'php-db',
-      'php-http-request',
-      'php-log',
-      'php-mail',
-      'php-mdb2',
-      'php-net-smtp',
-      'php-net-url2',
       'php-pear',
       'libapache2-mod-php7.0',
       'pear-channels'
     ]:
   }
 
-#      to install via pear
-#      'php-pager',
-#      'php-xml-parser',
-#      'php-xml-serializer',
+  class { '::php':
+    ensure => present,     # Don't touch stuff from above; should be equivalent
+    manage_repos => false, # Set true to add dotdeb repos
+    fpm => false,          # We only use mod_php at present
+    dev => false,          # Extensions are only added by PECL debs for now
+    composer => false,     # System-wide composer seems iffy unless using dotdeb
+    pear => true,          # We're using this for PEAR, so set to true
+    phpunit => true,       # Unsure whether this should be system or app-level
 
+    extensions => {
+      Archive_Tar:           { ensure => '1.4.3',   package_prefix => '', provider => 'pear' },
+      Console_Getopt:        { ensure => '1.4.1',   package_prefix => '', provider => 'pear' },
+      DB:                    { ensure => '1.7.14',  package_prefix => '', provider => 'pear' },
+      DB_DataObject:         { ensure => '1.11.2',  package_prefix => '', provider => 'pear' },
+      Date:                  { ensure => '1.4.7',   package_prefix => '', provider => 'pear' },
+      File_MARC:             { ensure => '1.1.1',   package_prefix => '', provider => 'pear' },
+      HTTP_Request:          { ensure => '1.4.4',   package_prefix => '', provider => 'pear' },
+      HTTP_Request2:         { ensure => '2.2.0',   package_prefix => '', provider => 'pear' },
+      HTTP_Session2:         { ensure => '0.7.3',   package_prefix => '', provider => 'pear' },
+      Log:                   { ensure => '1.12.8',  package_prefix => '', provider => 'pear' },
+      MDB2:                  { ensure => '2.5.0b5', package_prefix => '', provider => 'pear' },
+      MDB2_Driver_mysql:     { ensure => '1.4.1',   package_prefix => '', provider => 'pear' },
+      Mail:                  { ensure => '1.2.0',   package_prefix => '', provider => 'pear' },
+      Net_SMTP:              { ensure => '1.6.2',   package_prefix => '', provider => 'pear' },
+      Net_Socket:            { ensure => '1.0.14',  package_prefix => '', provider => 'pear' },
+      Net_URL:               { ensure => '1.0.15',  package_prefix => '', provider => 'pear' },
+      Net_URL2:              { ensure => '2.0.7',   package_prefix => '', provider => 'pear' },
+      PEAR:                  { ensure => '1.10.5',  package_prefix => '', provider => 'pear' },
+      Pager:                 { ensure => '2.4.8',   package_prefix => '', provider => 'pear' },
+      PhpDocumentor:         { ensure => '1.4.4',   package_prefix => '', provider => 'pear' },
+      Structures_DataGrid:   { ensure => '0.9.3',   package_prefix => '', provider => 'pear' },
+      Structures_Graph:      { ensure => '1.1.1',   package_prefix => '', provider => 'pear' },
+      Structures_LinkedList: { ensure => '0.2.2',   package_prefix => '', provider => 'pear' },
+      XML_Parser:            { ensure => '1.3.4',   package_prefix => '', provider => 'pear' },
+      XML_Serializer:        { ensure => '0.20.2',  package_prefix => '', provider => 'pear' },
+      XML_Util:              { ensure => '1.4.2',   package_prefix => '', provider => 'pear' },
+    },
+  }
 }

--- a/manifests/profile/hathitrust/php.pp
+++ b/manifests/profile/hathitrust/php.pp
@@ -14,56 +14,52 @@ class nebula::profile::hathitrust::php () {
 
   package {
     [
-      'php7.0-cli',
-      'php7.0-common',
       'php7.0-curl',
       'php7.0-gd',
       'php-geoip', # PECL
       'php7.0-ldap',
       'php7.0-mysql',
       'php7.0-xsl',
-      'php-pear',
       'libapache2-mod-php7.0',
       'pear-channels'
     ]:
   }
 
   class { '::php':
-    ensure => present,     # Don't touch stuff from above; should be equivalent
+    ensure       => present,     # Don't touch stuff from above; should be equivalent
     manage_repos => false, # Set true to add dotdeb repos
-    fpm => false,          # We only use mod_php at present
-    dev => false,          # Extensions are only added by PECL debs for now
-    composer => false,     # System-wide composer seems iffy unless using dotdeb
-    pear => true,          # We're using this for PEAR, so set to true
-    phpunit => true,       # Unsure whether this should be system or app-level
+    fpm          => false,          # We only use mod_php at present
+    composer     => false,     # System-wide composer seems iffy unless using dotdeb
+    pear         => true,          # We're using this for PEAR, so set to true
+    phpunit      => true,       # Unsure whether this should be system or app-level
 
-    extensions => {
-      Archive_Tar:           { ensure => '1.4.3',   package_prefix => '', provider => 'pear' },
-      Console_Getopt:        { ensure => '1.4.1',   package_prefix => '', provider => 'pear' },
-      DB:                    { ensure => '1.7.14',  package_prefix => '', provider => 'pear' },
-      DB_DataObject:         { ensure => '1.11.2',  package_prefix => '', provider => 'pear' },
-      Date:                  { ensure => '1.4.7',   package_prefix => '', provider => 'pear' },
-      File_MARC:             { ensure => '1.1.1',   package_prefix => '', provider => 'pear' },
-      HTTP_Request:          { ensure => '1.4.4',   package_prefix => '', provider => 'pear' },
-      HTTP_Request2:         { ensure => '2.2.0',   package_prefix => '', provider => 'pear' },
-      HTTP_Session2:         { ensure => '0.7.3',   package_prefix => '', provider => 'pear' },
-      Log:                   { ensure => '1.12.8',  package_prefix => '', provider => 'pear' },
-      MDB2:                  { ensure => '2.5.0b5', package_prefix => '', provider => 'pear' },
-      MDB2_Driver_mysql:     { ensure => '1.4.1',   package_prefix => '', provider => 'pear' },
-      Mail:                  { ensure => '1.2.0',   package_prefix => '', provider => 'pear' },
-      Net_SMTP:              { ensure => '1.6.2',   package_prefix => '', provider => 'pear' },
-      Net_Socket:            { ensure => '1.0.14',  package_prefix => '', provider => 'pear' },
-      Net_URL:               { ensure => '1.0.15',  package_prefix => '', provider => 'pear' },
-      Net_URL2:              { ensure => '2.0.7',   package_prefix => '', provider => 'pear' },
-      PEAR:                  { ensure => '1.10.5',  package_prefix => '', provider => 'pear' },
-      Pager:                 { ensure => '2.4.8',   package_prefix => '', provider => 'pear' },
-      PhpDocumentor:         { ensure => '1.4.4',   package_prefix => '', provider => 'pear' },
-      Structures_DataGrid:   { ensure => '0.9.3',   package_prefix => '', provider => 'pear' },
-      Structures_Graph:      { ensure => '1.1.1',   package_prefix => '', provider => 'pear' },
-      Structures_LinkedList: { ensure => '0.2.2',   package_prefix => '', provider => 'pear' },
-      XML_Parser:            { ensure => '1.3.4',   package_prefix => '', provider => 'pear' },
-      XML_Serializer:        { ensure => '0.20.2',  package_prefix => '', provider => 'pear' },
-      XML_Util:              { ensure => '1.4.2',   package_prefix => '', provider => 'pear' },
+    extensions   => {
+      'Archive_Tar'           =>           { package_prefix => '', provider => 'pear' },
+      'Console_Getopt'        =>        { package_prefix => '', provider => 'pear' },
+      'DB'                    =>                    { package_prefix => '', provider => 'pear' },
+      'DB_DataObject'         =>         { package_prefix => '', provider => 'pear' },
+      'Date'                  =>                  { package_prefix => '', provider => 'pear' },
+      'File_MARC'             =>             { package_prefix => '', provider => 'pear' },
+      'HTTP_Request'          =>          { package_prefix => '', provider => 'pear' },
+      'HTTP_Request2'         =>         { package_prefix => '', provider => 'pear' },
+      'HTTP_Session2'         =>         { package_prefix => '', provider => 'pear' },
+      'Log'                   =>                   { package_prefix => '', provider => 'pear' },
+      'MDB2'                  =>                  { package_prefix => '', provider => 'pear' },
+      'MDB2_Driver_mysql'     =>     { package_prefix => '', provider => 'pear' },
+      'Mail'                  =>                  { package_prefix => '', provider => 'pear' },
+      'Net_SMTP'              =>              { package_prefix => '', provider => 'pear' },
+      'Net_Socket'            =>            { package_prefix => '', provider => 'pear' },
+      'Net_URL'               =>               { package_prefix => '', provider => 'pear' },
+      'Net_URL2'              =>              { package_prefix => '', provider => 'pear' },
+      'PEAR'                  =>                  { package_prefix => '', provider => 'pear' },
+      'Pager'                 =>                 { package_prefix => '', provider => 'pear' },
+      'PhpDocumentor'         =>         { package_prefix => '', provider => 'pear' },
+      'Structures_DataGrid'   =>   { package_prefix => '', provider => 'pear' },
+      'Structures_Graph'      =>      { package_prefix => '', provider => 'pear' },
+      'Structures_LinkedList' => { package_prefix => '', provider => 'pear' },
+      'XML_Parser'            =>            { package_prefix => '', provider => 'pear' },
+      'XML_Serializer'        =>        { package_prefix => '', provider => 'pear' },
+      'XML_Util'              =>              { package_prefix => '', provider => 'pear' },
     },
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,7 @@
     {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},
+    {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "stm/debconf", "version_requirement": ">= 2.1.0 < 3.0.0"},
     {"name": "camptocamp/kmod", "version_requirement": ">= 2.1.0 < 3.0.0"},
     {"name": "jdowning/rbenv", "version_requirement": ">= 2.2.0 < 3.0.0"},

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -22,6 +22,7 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to contain_package('nfs-common') }
       it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
+      it { is_expected.to contain_php__extension('File_MARC').with_provider('pear') }
     end
   end
 end


### PR DESCRIPTION
This attempts to install all of the PEAR modules through the
'puppet/php' module, which appears to be the most mature and maintained
on the forge. The usage does not install FPM, dev headers, or composer,
but each is simple to add. I chose to remove the Debian packages for the
select few PEAR modules and list them all as extensions on the PHP
resource.