### PR TITLE
Add cron jobs

### DIFF
--- a/manifests/profile/geoip.pp
+++ b/manifests/profile/geoip.pp
@@ -21,9 +21,9 @@ class nebula::profile::geoip () {
   }
 
   $http_files = lookup('nebula::http_files')
-  file { "/usr/local/bin/geoipupdate":
-    ensure  => 'present',
-    mode    => '0755',
+  file { '/usr/local/bin/geoipupdate':
+    ensure => 'present',
+    mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/geoipupdate"
   }
 

--- a/manifests/profile/geoip.pp
+++ b/manifests/profile/geoip.pp
@@ -11,4 +11,13 @@
 #   include nebula::profile::geoip
 class nebula::profile::geoip () {
   package { 'geoip-bin': }
+
+  cron { 'update GeoIP database':
+    command => '/l/local/bin/geoipupdate -f /etc/GeoIP.conf -d /usr/share/GeoIP',
+    user    => 'root',
+    minute  => '37',
+    hour    => '7',
+    weekday => '1'
+  }
+
 }

--- a/manifests/profile/geoip.pp
+++ b/manifests/profile/geoip.pp
@@ -13,11 +13,18 @@ class nebula::profile::geoip () {
   package { 'geoip-bin': }
 
   cron { 'update GeoIP database':
-    command => '/l/local/bin/geoipupdate -f /etc/GeoIP.conf -d /usr/share/GeoIP',
+    command => '/usr/local/bin/geoipupdate -f /etc/GeoIP.conf -d /usr/share/GeoIP',
     user    => 'root',
     minute  => '37',
     hour    => '7',
     weekday => '1'
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/geoipupdate":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/geoipupdate"
   }
 
 }

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -178,7 +178,7 @@ class nebula::profile::hathitrust::apache (
   }
 
   cron { 'apache restart':
-    command => '( /etc/init.d/apache2 stop; /bin/sleep 10; /etc/init.d/apache2 start ) > /dev/null',
+    command => '( /bin/systemctl stop apache2; /bin/sleep 10; /bin/systemctl start apache2 ) > /dev/null',
     user    => 'root',
     minute  => '1',
     hour    => '0',

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -165,9 +165,16 @@ class nebula::profile::hathitrust::apache (
   }
 
   cron { 'apache connection count check':
-    command => '/l/local/bin/ckapacheconn',
+    command => '/usr/local/bin/ckapacheconn',
     user    => 'root',
     minute  => '*/15',
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/ckapacheconn":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/ckapacheconn"
   }
 
   cron { 'apache restart':

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -164,4 +164,17 @@ class nebula::profile::hathitrust::apache (
     }
   }
 
+  cron { 'apache connection count check':
+    command => '/l/local/bin/ckapacheconn',
+    user    => 'root',
+    minute  => '*/15',
+  }
+
+  cron { 'apache restart':
+    command => '( /etc/init.d/apache2 stop; /bin/sleep 10; /etc/init.d/apache2 start ) > /dev/null',
+    user    => 'root',
+    minute  => '1',
+    hour    => '0',
+  }
+
 }

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -171,9 +171,9 @@ class nebula::profile::hathitrust::apache (
   }
 
   $http_files = lookup('nebula::http_files')
-  file { "/usr/local/bin/ckapacheconn":
-    ensure  => 'present',
-    mode    => '0755',
+  file { '/usr/local/bin/ckapacheconn':
+    ensure => 'present',
+    mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/ckapacheconn"
   }
 

--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -19,6 +19,20 @@ class nebula::profile::hathitrust::apache::babel (
   String $gwt_code
 ) {
 
+  cron { 'log anon cron':
+    command => "/htapps/babel/stats/bin/cron_apache_log.sh 2>&1 > /tmp/anon.out || /usr/bin/mail -s '${hostname} log anon cron failed' lit-ae-automation@umich.edu 2>&1 > /dev/null",
+    user    => 'root',
+    minute  => '0',
+    hour    => '2',
+  }
+
+  cron { 'purge caches':
+    command => '/htapps/babel/mdp-misc/scripts/managecache.sh /htapps/babel/cache/download:99:1 /htapps/babel/cache:99:7 /ram/choke:50:7',
+    user    => 'nobody',
+    minute  => '23',
+    hour    => '1',
+  }
+
   $servername = "${prefix}babel.${domain}"
 
   $imgsrv_address = lookup('nebula::profile::hathitrust::imgsrv::bind');

--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -20,7 +20,7 @@ class nebula::profile::hathitrust::apache::babel (
 ) {
 
   cron { 'log anon cron':
-    command => "/htapps/babel/stats/bin/cron_apache_log.sh 2>&1 > /tmp/anon.out || /usr/bin/mail -s '${hostname} log anon cron failed' lit-ae-automation@umich.edu 2>&1 > /dev/null",
+    command => "/htapps/babel/stats/bin/cron_apache_log.sh 2>&1 > /tmp/anon.out || /usr/bin/mail -s '${::hostname} log anon cron failed' lit-ae-automation@umich.edu 2>&1 > /dev/null",
     user    => 'root',
     minute  => '0',
     hour    => '2',

--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -20,7 +20,19 @@ class nebula::profile::hathitrust::apache::catalog (
 
   $servername = "${prefix}catalog.${domain}"
 
+  cron { 'purge catalog apache access logs':
+    command => '/usr/bin/find /var/log/apache2/catalog -type f -name "access_log*" -mtime +7 -exec /bin/rm {} \; > /dev/null 2>&1',
+    user    => 'root',
+    minute  => '27',
+    hour    => '1',
+  }
 
+  cron { 'compress catalog apache access logs':
+    command => '/usr/bin/find /var/log/apache2/catalog -type f -name "access_log*" ! -name "*.gz" -mtime +0 -exec /usr/bin/pigz -9 {} \; > /dev/null 2>&1',
+    user    => 'root',
+    minute  => '28',
+    hour    => '1',
+  }
 
   apache::vhost { "${servername} ssl":
     servername        => $servername,

--- a/manifests/profile/hathitrust/apache/logs.pp
+++ b/manifests/profile/hathitrust/apache/logs.pp
@@ -1,0 +1,28 @@
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::apache::logs
+#
+# hathitrust.org logs virtual host
+#
+# @example
+#   include nebula::profile::hathitrust::apache::logs
+class nebula::profile::hathitrust::apache::logs {
+
+  cron { 'purge apache error logs':
+    command => '/usr/bin/find /var/log/apache2 -type f -name "error_log*" -mtime +14 -exec /bin/rm {} \; > /dev/null 2>&1 ',
+    user    => 'root',
+    minute  => '17',
+    hour    => '1',
+  }
+
+  cron { 'compress apache error logs':
+    command => '/usr/bin/find /var/log/apache2 -type f -name "error_log*" ! -name "*.gz" -mtime +0 -exec /usr/bin/pigz -9 {} \; > /dev/null 2>&1',
+    user    => 'root',
+    minute  => '18',
+    hour    => '1',
+  }
+
+}

--- a/manifests/profile/hathitrust/apache/statistics.pp
+++ b/manifests/profile/hathitrust/apache/statistics.pp
@@ -56,10 +56,10 @@ class nebula::profile::hathitrust::apache::statistics {
   }
 
   cron { 'get pod volumes':
-    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/extra_perl/get_pod_volumes.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.6 2>&1 || /usr/bin/mail -s 'Get POD Volumes Cronjob failed' eliotwsc@umich.edu",
-    user    => 'libadm',
-    minute  => '0',
-    hour    => '0',
+    command  => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/extra_perl/get_pod_volumes.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.6 2>&1 || /usr/bin/mail -s 'Get POD Volumes Cronjob failed' eliotwsc@umich.edu",
+    user     => 'libadm',
+    minute   => '0',
+    hour     => '0',
     monthday => '1'
   }
 

--- a/manifests/profile/hathitrust/apache/statistics.pp
+++ b/manifests/profile/hathitrust/apache/statistics.pp
@@ -1,0 +1,74 @@
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::apache::statistics
+#
+# hathitrust.org statistics virtual host
+#
+# @example
+#   include nebula::profile::hathitrust::apache::statistics
+class nebula::profile::hathitrust::apache::statistics {
+
+  cron { 'callnumber prefix counts':
+    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/modules/custom/callnumber_prefix_counts.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.0 2>&1 || /usr/bin/mail -s 'Callnumber prefix Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+    hour    => '3',
+  }
+
+  cron { 'pd callnumber prefix counts':
+    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/modules/custom/PD_callnumber_prefix_counts.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.1 2>&1 || /usr/bin/mail -s 'PD Callnumber prefix Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '10',
+    hour    => '3',
+  }
+
+  cron { 'pd callnumber statistics':
+    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/extra_perl/Solr/PD_stats.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.2 2>&1 || /usr/bin/mail -s 'PD Callnumber Statistics Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '50',
+    hour    => '3',
+  }
+
+  cron { 'rss create statistics':
+    command => "SDRROOT=/htapps/www /usr/bin/php /htapps/www/sites/www.hathitrust.org/modules/custom/RSSGenerateStatisticsFile.php > /htapps/www/sites/www.hathitrust.org/cron_reporting.3 2>&1 || /usr/usr/bin/mail -s 'RSS Create Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+    hour    => '3',
+    weekday => '1'
+  }
+
+  cron { 'callnumber statistics':
+    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/extra_perl/Solr/stats.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.4 2>&1 || /usr/bin/mail -s 'Callnumber Statistics Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+    hour    => '4',
+  }
+
+  cron { 'rss create':
+    command => "SDRROOT=/htapps/www /usr/bin/php /htapps/www/sites/www.hathitrust.org/modules/custom/RSScreate.php > /htapps/www/sites/www.hathitrust.org/cron_reporting.5 2>&1 || /usr/bin/mail -s 'RSS Create Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+    hour    => '4',
+    weekday => '1'
+  }
+
+  cron { 'get pod volumes':
+    command => "SDRROOT=/htapps/www perl /htapps/www/sites/www.hathitrust.org/extra_perl/get_pod_volumes.pl > /htapps/www/sites/www.hathitrust.org/cron_reporting.6 2>&1 || /usr/bin/mail -s 'Get POD Volumes Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+    hour    => '0',
+    monthday => '1'
+  }
+
+  cron { 'hourly reporting':
+    command => "SDRROOT=/htapps/www /usr/bin/php /htapps/www/command-line-cron.php > /htapps/www/sites/www.hathitrust.org/cron_reporting.7 2>&1 || /usr/bin/mail -s 'Once-an-hour Cronjob failed' eliotwsc@umich.edu",
+    user    => 'libadm',
+    minute  => '0',
+  }
+
+
+
+}

--- a/manifests/profile/hathitrust/apache/test.pp
+++ b/manifests/profile/hathitrust/apache/test.pp
@@ -12,11 +12,10 @@
 class nebula::profile::hathitrust::apache::test {
 
   cron { 'purge apache access logs':
-    command => "/usr/bin/find /var/log/apache2 -regextype posix-egrep -type f -mtime +14 -regex '.*/(access|error)_log.*-.*' -exec /bin/rm {} \; > /dev/null 2>&1"
-',
-    user    => 'root',
-    minute  => '7',
-    hour    => '1',
+    command  => "/usr/bin/find /var/log/apache2 -regextype posix-egrep -type f -mtime +14 -regex '.*/(access|error)_log.*-.*' -exec /bin/rm {} ';' > /dev/null 2>&1",
+    user     => 'root',
+    minute   => '7',
+    hour     => '1',
     monthday => '*'
   }
 

--- a/manifests/profile/hathitrust/apache/test.pp
+++ b/manifests/profile/hathitrust/apache/test.pp
@@ -1,0 +1,23 @@
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::apache::test
+#
+# hathitrust.org test virtual host
+#
+# @example
+#   include nebula::profile::hathitrust::apache::test
+class nebula::profile::hathitrust::apache::test {
+
+  cron { 'purge apache access logs':
+    command => "/usr/bin/find /var/log/apache2 -regextype posix-egrep -type f -mtime +14 -regex '.*/(access|error)_log.*-.*' -exec /bin/rm {} \; > /dev/null 2>&1"
+',
+    user    => 'root',
+    minute  => '7',
+    hour    => '1',
+    monthday => '*'
+  }
+
+}

--- a/manifests/profile/hathitrust/apache/www.pp
+++ b/manifests/profile/hathitrust/apache/www.pp
@@ -18,6 +18,20 @@ class nebula::profile::hathitrust::apache::www (
   String $docroot = '/htapps/www'
 ) {
 
+  cron { 'purge non-babel apache access logs':
+    command => '/usr/bin/find /var/log/apache2/www -type f -name "access_log*" -mtime +7 -exec /bin/rm {} \; > /dev/null 2>&1',
+    user    => 'root',
+    minute  => '27',
+    hour    => '1',
+  }
+
+  cron { 'compress non-babel apache access logs':
+    command => '/usr/bin/find /var/log/apache2/www -type f -name "access_log*" ! -name "*.gz" -mtime +0 -exec /usr/bin/pigz -9 {} \; > /dev/null 2>&1',
+    user    => 'root',
+    minute  => '28',
+    hour    => '1',
+  }
+
   $servername = "${prefix}www.${domain}"
 
   apache::vhost { "${servername} ssl":

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -43,15 +43,15 @@ class nebula::profile::hathitrust::imgsrv (
 
 
   $http_files = lookup('nebula::http_files')
-  file { "/usr/local/bin/check_imgsrv":
-    ensure  => 'present',
-    mode    => '0755',
+  file { '/usr/local/bin/check_imgsrv':
+    ensure => 'present',
+    mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/check_imgsrv"
   }
 
-  file { "/usr/local/bin/startup_app":
-    ensure  => 'present',
-    mode    => '0755',
+  file { '/usr/local/bin/startup_app':
+    ensure => 'present',
+    mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/startup_app"
   }
 

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -36,9 +36,23 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   cron { 'imgsrv responsiveness check':
-    command => '/l/local/bin/check_imgsrv',
+    command => '/usr/local/bin/check_imgsrv',
     user    => 'root',
     minute  => '*/2',
+  }
+
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/check_imgsrv":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/check_imgsrv"
+  }
+
+  file { "/usr/local/bin/startup_app":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/startup_app"
   }
 
 }

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -35,4 +35,10 @@ class nebula::profile::hathitrust::imgsrv (
     hasrestart =>  true
   }
 
+  cron { 'imgsrv responsiveness check':
+    command => '/l/local/bin/check_imgsrv',
+    user    => 'root',
+    minute  => '*/2',
+  }
+
 }

--- a/manifests/profile/hathitrust/shibboleth.pp
+++ b/manifests/profile/hathitrust/shibboleth.pp
@@ -66,9 +66,16 @@ class nebula::profile::hathitrust::shibboleth () {
   }
 
   cron { 'shibd existence check':
-    command => '/l/local/bin/ckshibd',
+    command => '/usr/local/bin/ckshibd',
     user    => 'root',
     minute  => '*/10',
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/ckshibd":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/ckshibd"
   }
 
 }

--- a/manifests/profile/hathitrust/shibboleth.pp
+++ b/manifests/profile/hathitrust/shibboleth.pp
@@ -72,9 +72,9 @@ class nebula::profile::hathitrust::shibboleth () {
   }
 
   $http_files = lookup('nebula::http_files')
-  file { "/usr/local/bin/ckshibd":
-    ensure  => 'present',
-    mode    => '0755',
+  file { '/usr/local/bin/ckshibd':
+    ensure => 'present',
+    mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/ckshibd"
   }
 

--- a/manifests/profile/hathitrust/shibboleth.pp
+++ b/manifests/profile/hathitrust/shibboleth.pp
@@ -64,4 +64,11 @@ class nebula::profile::hathitrust::shibboleth () {
       Service['shibd']
     ]
   }
+
+  cron { 'shibd existence check':
+    command => '/l/local/bin/ckshibd',
+    user    => 'root',
+    minute  => '*/10',
+  }
+
 }

--- a/manifests/role/webhost/htvm/prod.pp
+++ b/manifests/role/webhost/htvm/prod.pp
@@ -1,0 +1,12 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Webhost hosting hathitrust.org
+#
+# @example
+#   include nebula::role::webhost::htvm::prod
+class nebula::role::webhost::htvm::prod {
+  include nebula::role::webhost::htvm
+  include nebula::profile::hathitrust::apache::logs
+}

--- a/manifests/role/webhost/htvm/prod/primary.pp
+++ b/manifests/role/webhost/htvm/prod/primary.pp
@@ -1,0 +1,12 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Webhost hosting hathitrust.org
+#
+# @example
+#   include nebula::role::webhost::htvm::prod::primary
+class nebula::role::webhost::htvm::prod::primary {
+  include nebula::role::webhost::htvm::prod
+  include nebula::profile::hathitrust::apache::statistics
+}

--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -1,0 +1,15 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Webhost hosting hathitrust.org
+#
+# @example
+#   include nebula::role::webhost::htvm::test
+class nebula::role::webhost::htvm::test {
+  nebula::balanced_frontend { 'test-hathitrust': }
+  include nebula::role::webhost::htvm
+  include nebula::role::hathitrust::dev::app_host
+  include nebula::profile::hathitrust::apache::test
+
+}


### PR DESCRIPTION
Resolves AEIM-1426

This adds the existing cron jobs from our Hathitrust web servers, both common and not-so-common.

Adding the cron tasks themselves was straightforward. The complexity arose from choosing where they should go. In the end, I chose to focus on putting the tasks in the profiles to which they belong. This resulted in a couple new sub-profiles, and some new sub-roles.

It is the topography of the roles-profiles-crontasks that is most in need of review.

See [here](https://tools.lib.umich.edu/jira/secure/attachment/57434/tabs.txt) for a summary of the cron jobs as they existed on our servers, the profile in which they ended up, and the most general role that includes said profile.