### PR TITLE
AEIM-1628 - Look up staff networks for mod_status

### DIFF
--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -27,6 +27,9 @@ class nebula::profile::hathitrust::apache (
     fact_for($nodename, 'networking')['ip']
   }
 
+  $staff_networks = lookup('hathitrust::networks::staff', default_value => []).flatten.unique.map |$network| {
+    "ip ${network['block']}"
+  }.sort
 
   class { 'apache':
     default_vhost          => false,
@@ -83,9 +86,9 @@ class nebula::profile::hathitrust::apache (
   }
 
   class { 'apache::mod::status':
-    requires        =>  {
+    requires => {
       enforce  => 'any',
-      requires => [ 'local' ]
+      requires => [ 'local' ] + $staff_networks
     }
   }
 

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -100,6 +100,15 @@ describe 'nebula::profile::hathitrust::apache' do
         it { is_expected.to contain_apache__vhost('babel.example.org ssl').with_servername('babel.example.org') }
 
         it {
+          is_expected.to contain_class('apache::mod::status').with(
+            requires: {
+              'enforce' => 'any',
+              'requires' => ['local', 'ip 10.0.1.0/24', 'ip 10.0.2.0/24', 'ip 10.0.3.0/24'],
+            },
+          )
+        }
+
+        it {
           is_expected.to contain_apache__vhost('hathitrust canonical name redirection').with(
             servername: 'example.org',
             serveraliases: ['domain.one', 'domain.two', 'www.domain.one', 'www.domain.two'],

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -1,6 +1,7 @@
 nebula::profile::hathitrust::apache::redirection::alias_domains:
   - domain.one
   - domain.two
+
 nebula::profile::hathitrust::dbhost::address: '10.1.2.4'
 nebula::profile::hathitrust::apache::babel::sdremail: somebody@invalid.default
 
@@ -10,3 +11,21 @@ nebula::profile::hathitrust::imgsrv::sdrview: 'sdrview'
 nebula::profile::hathitrust::imgsrv::sdrdataroot: '/sdrdataroot'
 nebula::profile::hathitrust::imgsrv::bind: '127.0.0.1:31028'
 nebula::profile::hathitrust::apache::babel::gwt_code: 'somecode'
+
+# Intentional, erroneous duplication here to verify flattening.
+# Apache would not balk at multiple requires, but other things may,
+# so we want to simulate the error and test for uniqueness.
+networks::one:
+  - name: 'Net One'
+    block: '10.0.1.0/24'
+  - name: 'VPN'
+    block: '10.0.3.0/24'
+networks::two:
+  - name: 'Net Two'
+    block: '10.0.2.0/24'
+  - name: 'VPN'
+    block: '10.0.3.0/24'
+
+hathitrust::networks::staff:
+  - "%{alias('networks::one')}"
+  - "%{alias('networks::two')}"


### PR DESCRIPTION
The approach used here does not add another parameter to the Apache
profile, but I would not be opposed to doing so. This commit does an
explicit lookup in hiera. The fixture data includes a model for mapping
networks in multiple places without repeating the actual data, using
alias interpolation.