### PR TITLE
Add bins from /l/local/bin to /usr/local/bin

### DIFF
--- a/manifests/profile/geoip.pp
+++ b/manifests/profile/geoip.pp
@@ -13,11 +13,18 @@ class nebula::profile::geoip () {
   package { 'geoip-bin': }
 
   cron { 'update GeoIP database':
-    command => '/l/local/bin/geoipupdate -f /etc/GeoIP.conf -d /usr/share/GeoIP',
+    command => '/usr/local/bin/geoipupdate -f /etc/GeoIP.conf -d /usr/share/GeoIP',
     user    => 'root',
     minute  => '37',
     hour    => '7',
     weekday => '1'
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/geoipupdate":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/geoipupdate"
   }
 
 }

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -151,9 +151,16 @@ class nebula::profile::hathitrust::apache (
   }
 
   cron { 'apache connection count check':
-    command => '/l/local/bin/ckapacheconn',
+    command => '/usr/local/bin/ckapacheconn',
     user    => 'root',
     minute  => '*/15',
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/ckapacheconn":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/ckapacheconn"
   }
 
   cron { 'apache restart':

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -36,9 +36,23 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   cron { 'imgsrv responsiveness check':
-    command => '/l/local/bin/check_imgsrv',
+    command => '/usr/local/bin/check_imgsrv',
     user    => 'root',
     minute  => '*/2',
+  }
+
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/check_imgsrv":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/check_imgsrv"
+  }
+
+  file { "/usr/local/bin/startup_app":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/startup_app"
   }
 
 }

--- a/manifests/profile/hathitrust/shibboleth.pp
+++ b/manifests/profile/hathitrust/shibboleth.pp
@@ -66,9 +66,16 @@ class nebula::profile::hathitrust::shibboleth () {
   }
 
   cron { 'shibd existence check':
-    command => '/l/local/bin/ckshibd',
+    command => '/usr/local/bin/ckshibd',
     user    => 'root',
     minute  => '*/10',
+  }
+
+  $http_files = lookup('nebula::http_files')
+  file { "/usr/local/bin/ckshibd":
+    ensure  => 'present',
+    mode    => '0755',
+    source => "https://${http_files}/ae-utils/bins/ckshibd"
   }
 
 }


### PR DESCRIPTION
Resolves AEIM-1633

This PR is based on aeim-1426/common_crons, as it must be complete in order for that PR to be viable.

This adds the five files described in the commit subjects to their respective profiles. The files are downloaded from ae-files, where they have been uploaded via ae-utils--see that git project for an exact list.

The files were added to /usr/local/bin as we intend /l/local/bin to be a symlink to that directory. Leaving /l/local/bin out of the picture for this issue prevents any race conditions that would need to be resolved via dependency.

See the JIRA for why some files were excluded from this PR.