### PR TITLE
AEIM-1661 - Set strict cipher suite for HT web nodes

### DIFF
--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -135,7 +135,7 @@ class nebula::profile::hathitrust::apache (
     haproxy_ips    => $haproxy_ips,
     ssl_params     => {
       ssl            => true,
-      ssl_protocol   => 'all -SSLv3 +TLSv1 +TLSv1.1 +TLSv1.2',
+      ssl_protocol   => '+TLSv1.2',
       ssl_cipher     => 'ECDHE-RSA-AES256-GCM-SHA384',
       ssl_cert       => $ssl_cert,
       ssl_key        => $ssl_key,

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -135,6 +135,8 @@ class nebula::profile::hathitrust::apache (
     haproxy_ips    => $haproxy_ips,
     ssl_params     => {
       ssl            => true,
+      ssl_protocol   => 'all -SSLv3 +TLSv1 +TLSv1.1 +TLSv1.2',
+      ssl_cipher     => 'ECDHE-RSA-AES256-GCM-SHA384',
       ssl_cert       => $ssl_cert,
       ssl_key        => $ssl_key,
       ssl_chain      => $ssl_chain,

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -62,6 +62,8 @@ describe 'nebula::profile::hathitrust::apache' do
             is_expected.to contain_apache__vhost("#{vhost}.hathitrust.org ssl").with(
               servername: "#{vhost}.hathitrust.org",
               ssl: true,
+              ssl_protocol: 'all -SSLv3 +TLSv1 +TLSv1.1 +TLSv1.2',
+              ssl_cipher: 'ECDHE-RSA-AES256-GCM-SHA384',
               ssl_cert: '/etc/ssl/certs/www.hathitrust.org.crt',
               ssl_key: '/etc/ssl/private/www.hathitrust.org.key',
               ssl_chain: '/etc/ssl/certs/incommon_sha2.crt',


### PR DESCRIPTION
This sets all of the SSL vhosts to use only ECDHE-RSA-AES256-GCM-SHA384
and explicitly sets only TLSv1, 1.1, 1.2 for the protocol. The HAProxy
config already supports this cipher, so no changes are needed there.