### PR TITLE
AEIM-1672 - Add log rotation for Apache

### DIFF
--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -140,6 +140,10 @@ class nebula::profile::hathitrust::apache (
     purge  => true
   }
 
+  file { '/etc/logrotate.d/apache2':
+    ensure  => file,
+    content => template('nebula/profile/apache/logrotate.d/apache2.erb'),
+  }
 
   $default_vhost_params = {
     sdrroot        => $sdrroot,

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -56,6 +56,10 @@ describe 'nebula::profile::hathitrust::apache' do
                 target: '/etc/apache2/mods-available/access_compat.load')
       end
 
+      it do
+        is_expected.to contain_file('/etc/logrotate.d/apache2')
+      end
+
       describe 'Production HT hostnames' do
         %w[babel catalog www].each do |vhost|
           it {

--- a/templates/profile/apache/logrotate.d/apache2.erb
+++ b/templates/profile/apache/logrotate.d/apache2.erb
@@ -1,0 +1,24 @@
+# Managed by puppet (nebula/templates/profile/apache/logrotate.d/apache2.erb)
+/var/log/apache2/*.log /var/log/apache2/*/*.log {
+	daily
+	missingok
+	rotate 14
+# tag by date - 2018-08-23 aelkiss
+	dateext
+	dateyesterday
+	compress
+	delaycompress
+	notifempty
+	create 644 root adm
+	sharedscripts
+	postrotate
+                if /etc/init.d/apache2 status > /dev/null ; then \
+                    /etc/init.d/apache2 reload > /dev/null; \
+                fi;
+	endscript
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi; \
+	endscript
+}


### PR DESCRIPTION
- Add a static template for the config
- Add a File using the template for HT Apache profile

This is a provisional directory structure. We don't yet have a base
Apache profile, but I expect one soon. It wasn't obvious whether this
was more of an Apache concern or a logrotate concern, but it seems more
on the Apache side.