### PR TITLE
AEIM-1453 - Add ingest role

### DIFF
--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -1,0 +1,18 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Ingest and indexing servers for hathitrust.org
+#
+# @example
+#   include nebula::role::hathitrust::ingest_indexing
+class nebula::role::hathitrust::ingest_indexing () {
+  include nebula::role::hathitrust_new_firewall
+
+  include nebula::profile::networking::private
+
+  include nebula::profile::hathitrust::dbhost
+  include nebula::profile::hathitrust::mounts
+  include nebula::profile::hathitrust::dependencies
+  include nebula::profile::hathitrust::perl
+}

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -6,10 +6,12 @@
 #
 # @example
 #   include nebula::role::hathitrust::ingest_indexing
-class nebula::role::hathitrust::ingest_indexing () {
+class nebula::role::hathitrust::ingest_indexing (String $private_address_template = '192.168.0.%s') {
   include nebula::role::hathitrust_new_firewall
 
-  include nebula::profile::networking::private
+  class { 'nebula::profile::networking::private':
+    address_template => $private_address_template
+  }
 
   include nebula::profile::hathitrust::dbhost
   include nebula::profile::hathitrust::mounts

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::role::hathitrust::ingest_indexing' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_package('nfs-common') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
+
+      # default from hiera
+      it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
+    end
+  end
+end


### PR DESCRIPTION
This adds a simple role for ingest in one commit. It depends on the cleanup happening for AEIM-1449. Once that is merged, this should be rebased to master. It should be considered blocked for now.