### PR TITLE
Make expected naming for IP blocks consistent

### DIFF
--- a/manifests/profile/networking/firewall/http_datacenters.pp
+++ b/manifests/profile/networking/firewall/http_datacenters.pp
@@ -9,7 +9,7 @@
 # @example
 #   include nebula::profile::networking::firewall::ssh
 class nebula::profile::networking::firewall::http_datacenters (
-  Array $blocks = [],
+  Array $networks = [],
 ) {
 
   $params = {
@@ -19,14 +19,14 @@ class nebula::profile::networking::firewall::http_datacenters (
     action => 'accept'
   }
 
-  $blocks.flatten.each |$block| {
-    firewall { "200 HTTP: ${block['name']}":
-      source => $block['source'],
+  $networks.flatten.each |$network| {
+    firewall { "200 HTTP: ${network['name']}":
+      source => $network['block'],
       *      => $params
     }
   }
 
-  $block_datacenters = $blocks.flatten.map |$block| { $block['datacenter'] }.sort.unique
+  $datacenters = $networks.flatten.map |$network| { $network['datacenter'] }.sort.unique
 
   $other_dc_nodes_query = ['from','facts',
     ['extract', ['certname','value'],
@@ -37,7 +37,7 @@ class nebula::profile::networking::firewall::http_datacenters (
             ['and',
               ['=','name','datacenter'],
               ['not', ['in','value',
-              ['array', $block_datacenters]]]]]]]]]]
+              ['array', $datacenters]]]]]]]]]]
 
   puppetdb_query($other_dc_nodes_query).each |$node| {
     firewall { "200 HTTP: ${node['certname']}":

--- a/manifests/profile/networking/firewall/ssh.pp
+++ b/manifests/profile/networking/firewall/ssh.pp
@@ -9,14 +9,14 @@
 # @example
 #   include nebula::profile::networking::firewall::ssh
 class nebula::profile::networking::firewall::ssh (
-  Array $blocks = [],
+  Array $networks = [],
 ) {
 
-  $blocks.flatten.each |$block| {
-    firewall { "100 SSH: ${block['name']}":
+  $networks.flatten.each |$network| {
+    firewall { "100 SSH: ${network['name']}":
       proto  => 'tcp',
       dport  => 22,
-      source => $block['source'],
+      source => $network['block'],
       state  => 'NEW',
       action => 'accept',
     }

--- a/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
+++ b/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
@@ -20,7 +20,7 @@ describe 'nebula::profile::networking::firewall::http_datacenters' do
       context 'with a CIDR range' do
         include_context 'with mocked query for nodes in other datacenters', ['somedc'], []
 
-        let(:params) { { blocks: [{ 'name' => 'somedc', 'source' => '10.1.2.0/24', 'datacenter' => 'somedc' }] } }
+        let(:params) { { networks: [{ 'name' => 'somedc', 'block' => '10.1.2.0/24', 'datacenter' => 'somedc' }] } }
 
         it { is_expected.to contain_firewall('200 HTTP: somedc').with_source('10.1.2.0/24') }
       end
@@ -32,14 +32,14 @@ describe 'nebula::profile::networking::firewall::http_datacenters' do
 
         let(:params) do
           {
-            blocks: [
+            networks: [
               [
-                { 'name' => 'test range 1-1', 'source' => '10.1.1.0/24', 'datacenter' => 'dc1' },
-                { 'name' => 'test range 1-2', 'source' => '10.1.2.0/24', 'datacenter' => 'dc2' },
+                { 'name' => 'test range 1-1', 'block' => '10.1.1.0/24', 'datacenter' => 'dc1' },
+                { 'name' => 'test range 1-2', 'block' => '10.1.2.0/24', 'datacenter' => 'dc2' },
               ],
               [
-                { 'name' => 'test range 2-1', 'source' => '10.2.1.0/24', 'datacenter' => 'dc2' },
-                { 'name' => 'test range 2-2', 'source' => '10.2.2.0/24', 'datacenter' => 'dc2' },
+                { 'name' => 'test range 2-1', 'block' => '10.2.1.0/24', 'datacenter' => 'dc2' },
+                { 'name' => 'test range 2-2', 'block' => '10.2.2.0/24', 'datacenter' => 'dc2' },
               ],
             ],
           }

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -15,7 +15,7 @@ describe 'nebula::profile::networking::firewall::ssh' do
       it { is_expected.to have_firewall_resource_count(0) }
 
       context 'with a CIDR range' do
-        let(:params) { { blocks: [{ 'name' => 'test range', 'source' => '10.1.2.0/24' }] } }
+        let(:params) { { networks: [{ 'name' => 'test range', 'block' => '10.1.2.0/24' }] } }
 
         it { is_expected.to contain_firewall('100 SSH: test range').with_source('10.1.2.0/24') }
       end
@@ -23,14 +23,14 @@ describe 'nebula::profile::networking::firewall::ssh' do
       context 'with deeply-nested ranges' do
         let(:params) do
           {
-            blocks: [
+            networks: [
               [
-                { 'name' => 'test range 1-1', 'source' => '10.1.1.0/24' },
-                { 'name' => 'test range 1-2', 'source' => '10.1.2.0/24' },
+                { 'name' => 'test range 1-1', 'block' => '10.1.1.0/24' },
+                { 'name' => 'test range 1-2', 'block' => '10.1.2.0/24' },
               ],
               [
-                { 'name' => 'test range 2-1', 'source' => '10.2.1.0/24' },
-                { 'name' => 'test range 2-2', 'source' => '10.2.2.0/24' },
+                { 'name' => 'test range 2-1', 'block' => '10.2.1.0/24' },
+                { 'name' => 'test range 2-2', 'block' => '10.2.2.0/24' },
               ],
             ],
           }


### PR DESCRIPTION
Naming was a little bit different between firewall and mod_status stuff
- whether the block was called 'block' or 'source'.

Now, the parameter name is 'networks', and each "network" should have a 'name',
'block', and optional 'datacenter' key.