### PR TITLE
install jhove on hathitrust ingest from debian testing

### DIFF
--- a/manifests/profile/apt/testing.pp
+++ b/manifests/profile/apt/testing.pp
@@ -1,0 +1,25 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Add Debian testing apt repo by code name
+#
+# @example
+#   include nebula::profile::apt::testing
+class nebula::profile::apt::testing {
+  # pinning first so we don't install things we don't want
+  apt::pin { 'testing':
+    explanation => 'Deprioritize packages from Debian Testing',
+    release     => 'testing',
+    priority    => -10,
+    packages    => '*',
+    before      => Apt::Source['testing']
+  }
+
+  # add apt repo
+  apt::source { 'testing':
+    location => lookup('nebula::profile::apt::mirror'),
+    release  => 'testing',
+    repos    => 'main contrib non-free',
+  }
+}

--- a/manifests/profile/hathitrust/dependencies/ingest_indexing.pp
+++ b/manifests/profile/hathitrust/dependencies/ingest_indexing.pp
@@ -1,0 +1,41 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::dependencies
+#
+# Install miscellaneous package dependencies for HathiTrust applications
+#
+# @example
+#   include nebula::profile::hathitrust::dependencies::ingest_indexing
+class nebula::profile::hathitrust::dependencies::ingest_indexing () {
+
+  # install jhove, pin it to buster if we're on stretch
+  $package = 'jhove'
+  if $facts['os']['release']['major'] == '9' {
+    include nebula::profile::apt::testing
+    $release = 'buster'
+    apt::pin { "${release}-${package}":
+      explanation => "Prioritze ${package} from ${release}",
+      codename    => $release,
+      priority    => 700,
+      packages    => [$package],
+      require     => Class['nebula::profile::apt::testing']
+    }
+
+    package {
+      $package:
+      require => Apt::Pin["${release}-${package}"]
+    }
+  }
+  else {
+    package {
+      $package:
+    }
+  }
+
+  package {
+    'openjdk-8-jdk-headless':
+  }
+
+}

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -16,5 +16,6 @@ class nebula::role::hathitrust::ingest_indexing (String $private_address_templat
   include nebula::profile::hathitrust::ingest_hosts
   include nebula::profile::hathitrust::mounts
   include nebula::profile::hathitrust::dependencies
+  include nebula::profile::hathitrust::dependencies::ingest_indexing
   include nebula::profile::hathitrust::perl
 }


### PR DESCRIPTION
Installs jhove (specifically from buster if we're on Debian 9) and openjdk-8-headless. 

Use of 'testing' for apt repo and 'buster' for jhove prioritization are each intentional as this will not break when we upgrade to buster, and provides a reusable profile to add testing repo for any future pinning needs.