### PR TITLE
AEIM-1629: make smartconnect depend on /etc/resolv.conf

### DIFF
--- a/manifests/profile/dns/smartconnect.pp
+++ b/manifests/profile/dns/smartconnect.pp
@@ -50,6 +50,8 @@ class nebula::profile::dns::smartconnect (
     require     => Service['bind9']
   }
 
+  Service['bind9'] -> File['/etc/resolv.conf']
+
   file { '/etc/bind':
     ensure  => 'directory',
     owner   => 'root',

--- a/manifests/profile/hathitrust/mounts.pp
+++ b/manifests/profile/hathitrust/mounts.pp
@@ -39,7 +39,7 @@ class nebula::profile::hathitrust::mounts (
   $nfs_mount_options = {
     ensure  => 'mounted',
     fstype  => 'nfs',
-    require => ['Package[nfs-common]','Class[resolv_conf]'],
+    require => ['Package[nfs-common]','File[/etc/resolv.conf]'],
     tag     => 'private_network'
   }
 

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -31,6 +31,11 @@ describe 'nebula::role::webhost::htvm' do
       it { is_expected.to contain_php__extension('File_MARC').with_provider('pear') }
       it { is_expected.to contain_nebula__cpan('EBook::EPUB').that_requires('Package[libmoose-perl]') }
 
+      it { is_expected.to contain_file('/etc/resolv.conf').with_content(%r{nameserver 127.0.0.1}) }
+      it { is_expected.to contain_service('bind9') }
+      it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
+      it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
+
       # default from hiera
       it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
 
@@ -47,8 +52,6 @@ describe 'nebula::role::webhost::htvm' do
           end
 
           it { is_expected.to contain_mount('/htapps').that_requires('Exec[ifup ens4]') }
-          it { is_expected.to contain_mount('/htapps').that_requires('Class[resolv_conf]') }
-          it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
           it { is_expected.to contain_mount('/sdr1').that_requires('Exec[ifup ens4]') }
           it { is_expected.to contain_service('bind9').that_requires('Exec[ifup ens4]') }
         end


### PR DESCRIPTION
Although tests for Class[resolv_conf] passed, in reality it gives the
error:

Error 500 on SERVER: Server Error: Invalid relationship: Mount[/htapps]
{ require => Class[resolv_conf] }, because Class[resolv_conf] doesn't
seem to be in the catalog

This changes it to depend on File[/etc/resolv.conf] instead, which also
has the benefit that it won't break if we generate resolv.conf directly
instead of using the (potentially dubious) resolv_conf forge module.