### PR TITLE
AEIM-1646: Support firewall resources in hiera

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -11,13 +11,21 @@
 #
 # @example
 #   include nebula::profile::networking::firewall
-class nebula::profile::networking::firewall {
+class nebula::profile::networking::firewall ( Hash $rules = {} ) {
   # Include standard SSH rules by default
   include nebula::profile::networking::firewall::ssh
 
   resources { 'firewall':
     purge => true,
   }
+
+  $firewall_defaults = {
+    proto  => 'tcp',
+    state  => 'NEW',
+    action => 'accept'
+  }
+
+  create_resources(firewall,$rules,$firewall_defaults)
 
   # Default items, sorted by title
   firewall { '001 accept related established rules':

--- a/spec/classes/profile/firewall_spec.rb
+++ b/spec/classes/profile/firewall_spec.rb
@@ -13,6 +13,23 @@ describe 'nebula::profile::networking::firewall' do
       let(:hiera_config) { 'spec/fixtures/hiera/firewall_config.yaml' }
 
       it do
+        is_expected.to contain_firewall('001 accept related established rules').with(
+          proto: 'all',
+          state: %w[RELATED ESTABLISHED],
+          action: 'accept',
+        )
+      end
+
+      it do
+        is_expected.to contain_firewall('001 accept all to lo interface').with(
+          proto: 'all',
+          iniface: 'lo',
+          action: 'accept',
+        )
+      end
+
+      it do
+        # from hiera
         is_expected.to contain_firewall('200 HTTP: custom rule').with(
           proto: 'tcp',
           dport: %w[8081 8082],
@@ -20,6 +37,9 @@ describe 'nebula::profile::networking::firewall' do
           state: 'NEW',
           action: 'accept',
         )
+      end
+
+      it do
         is_expected.to contain_firewall('200 NTP: custom rule').with(
           proto: 'udp',
           dport: 123,
@@ -28,6 +48,15 @@ describe 'nebula::profile::networking::firewall' do
           action: 'accept',
         )
       end
+
+      it do
+        is_expected.to contain_firewall('999 drop all').with(
+          proto: 'all',
+          action: 'drop',
+        )
+      end
+
+      it { is_expected.to have_firewall_resource_count(5) }
     end
   end
 end

--- a/spec/classes/profile/firewall_spec.rb
+++ b/spec/classes/profile/firewall_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::profile::networking::firewall' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/firewall_config.yaml' }
+
+      it do
+        is_expected.to contain_firewall('200 HTTP: custom rule').with(
+          proto: 'tcp',
+          dport: %w[8081 8082],
+          source: '10.2.3.4',
+          state: 'NEW',
+          action: 'accept',
+        )
+        is_expected.to contain_firewall('200 NTP: custom rule').with(
+          proto: 'udp',
+          dport: 123,
+          source: '10.4.5.6',
+          state: 'NEW',
+          action: 'accept',
+        )
+      end
+    end
+  end
+end

--- a/spec/fixtures/hiera/firewall.yaml
+++ b/spec/fixtures/hiera/firewall.yaml
@@ -1,0 +1,14 @@
+nebula::profile::hathitrust::apache::redirection::alias_domains:
+  - domain.one
+  - domain.two
+
+nebula::profile::networking::firewall::rules:
+  "200 HTTP: custom rule":
+    source: 10.2.3.4
+    dport:
+      - 8081
+      - 8082
+  "200 NTP: custom rule":
+    source: 10.4.5.6
+    dport: 123
+    proto: udp

--- a/spec/fixtures/hiera/firewall_config.yaml
+++ b/spec/fixtures/hiera/firewall_config.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - default
+  - firewall
+:yaml:
+  :datadir: 'spec/fixtures/hiera'


### PR DESCRIPTION
Defaults are tcp, NEW, and 'accept', but hiera can override them