### PR TITLE
AWS: Set search domain via dhclient, don't set dns servers

### DIFF
--- a/manifests/profile/dns/aws.pp
+++ b/manifests/profile/dns/aws.pp
@@ -1,0 +1,33 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::dns::aws
+#
+# Configure dhclient for AWS hosts to add our search domain to resolv.conf,
+# also suppresses AWS/DHCP supplied search domain.
+#
+# @example
+#   include nebula::profile::dns::aws
+class nebula::profile::dns::aws {
+
+  $searchpaths = lookup('nebula::resolv_conf::searchpath')
+  $searchpath_str = join($searchpaths, ' ')
+
+  exec { 'restart_networking':
+    command     => '/bin/systemctl restart networking',
+    refreshonly => true,
+  }
+
+  file_line {
+    default:
+      path   => '/etc/dhcp/dhclient.conf',
+      notify => Exec['restart_networking'],
+    ;
+    'search_domain':
+      line => "supersede domain-search \"${searchpath_str}\";",
+    ;
+    'domain_name':
+      line => 'supersede domain-name "";',
+  }
+}

--- a/manifests/role/aws.pp
+++ b/manifests/role/aws.pp
@@ -21,7 +21,7 @@ class nebula::role::aws {
     }
   }
 
-  include nebula::profile::dns::standard
+  include nebula::profile::dns::aws
   include nebula::profile::elastic::metricbeat
   include nebula::profile::elastic::filebeat::prospectors::ulib
 

--- a/spec/classes/profile/dns/aws_spec.rb
+++ b/spec/classes/profile/dns/aws_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::dns::aws' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.not_to contain_class('resolv_conf')   }
+      it { is_expected.to contain_exec('restart_networking') }
+      it { is_expected.to contain_file_line('domain_name') }
+      # search_domain should match content of nebula::resolv_conf::searchpath
+      it do
+        is_expected.to contain_file_line('search_domain').with_line(
+          'supersede domain-search "searchpath.default.invalid";',
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
For AWS hosts, EC2 service sets correct DNS via DHCP. Keep this, but override the search domain in dhclient.conf. Restarts networking, it's coarse, but I couldn't find anything cleaner (dhclient -r only looks for a new lease, doesn't appear to reload the config).