### PR TITLE
AEIM-1707 - Specify puppet's reports directory

### DIFF
--- a/manifests/profile/puppet/master.pp
+++ b/manifests/profile/puppet/master.pp
@@ -10,6 +10,7 @@ class nebula::profile::puppet::master (
   $autosign_whitelist,
   $fileservers,
   $r10k_source,
+  $reports_dir,
 ) {
   $rbenv = lookup('nebula::profile::ruby::install_dir')
 
@@ -99,7 +100,7 @@ class nebula::profile::puppet::master (
     }
   }
 
-  tidy { '/opt/puppetlabs/server/data/puppetserver/reports':
+  tidy { $reports_dir:
     age     => '1w',
     recurse => true,
   }

--- a/spec/classes/profile/puppet/master_spec.rb
+++ b/spec/classes/profile/puppet/master_spec.rb
@@ -152,6 +152,13 @@ describe 'nebula::profile::puppet::master' do
           recurse: true,
         )
       end
+
+      context 'when told reports live in /var/lib' do
+        let(:params) { { reports_dir: '/var/lib' } }
+
+        it { is_expected.to contain_tidy('/var/lib').with_age('1w') }
+        it { is_expected.to contain_tidy('/var/lib').with_recurse(true) }
+      end
     end
   end
 end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -91,6 +91,7 @@ nebula::profile::puppet::master::fileservers:
       group: wheel
       mode: '0700'
 nebula::profile::puppet::master::autosign_whitelist: []
+nebula::profile::puppet::master::reports_dir: '/opt/puppetlabs/server/data/puppetserver/reports'
 
 nebula::profile::vmhost::host::build: 'invalid-default'
 nebula::profile::vmhost::host::cpus: 0


### PR DESCRIPTION
It's currently pointing at a symlink, which it refuses to tidy. This way
it can point at the actually directory, and /var can stop filling up.