### PR TITLE
AEIM-1651: configure monitor.pl for HT web servers; nfs_mount defined type

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
   forge_modules:
     stdlib:
       repo: "puppetlabs/stdlib"
-      ref: "4.16.0"
+      ref: "4.25.1"
     apache:
       repo: "puppetlabs/apache"
       ref: "3.4.0"

--- a/manifests/nfs_mount.pp
+++ b/manifests/nfs_mount.pp
@@ -1,0 +1,53 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::nfs_mount
+#
+# Configure an NFS mount. Optionally, configure requirements for smartconnect
+# and configure web server monitoring for the mount.
+#
+# @param remote_target The address of the server and path to mount
+# @param options The options to pass to the mount command
+# @param monitored Whether this mount should be monitored with monitor_pl
+# @param private_network Whether to wait until the private network is up before attempting to mount
+#
+# @example
+#   nebula::nfs_mount { '/mnt/whatever':
+#     remote_target => 'somehost:/whatever',
+#     options       => 'ro,auto,hard,intr,nfsvers=3',
+#     monitored     => true
+#  }
+define nebula::nfs_mount(
+  String $remote_target,
+  String $options = 'auto,hard,nfsvers=3',
+  Boolean $monitored = true,
+  Boolean $private_network = true
+) {
+  ensure_packages(['nfs-common'], {'ensure' => 'present'})
+
+  file { $title:
+    ensure => 'directory',
+  }
+
+  mount { $title:
+    ensure  => 'mounted',
+    device  => $remote_target,
+    options => $options,
+    fstype  => 'nfs',
+    require => Package[nfs-common]
+  }
+
+  if($private_network) {
+    Mount[$title] {
+      tag => 'private_network'
+    }
+  }
+
+  if($monitored) {
+    concat_fragment { "monitor nfs ${title}":
+      tag     => 'monitor_config',
+      content => { 'nfs' => [$title] }.to_yaml
+    }
+  }
+}

--- a/manifests/profile/dns/smartconnect.pp
+++ b/manifests/profile/dns/smartconnect.pp
@@ -51,6 +51,7 @@ class nebula::profile::dns::smartconnect (
   }
 
   Service['bind9'] -> File['/etc/resolv.conf']
+  File['/etc/resolv.conf'] -> Nebula::Nfs_mount <| tag == 'smartconnect' |>
 
   file { '/etc/bind':
     ensure  => 'directory',

--- a/manifests/profile/hathitrust/apache/default.pp
+++ b/manifests/profile/hathitrust/apache/default.pp
@@ -20,21 +20,25 @@ class nebula::profile::hathitrust::apache::default (
 
   $servername = "${prefix}babel.${domain}"
   $docroot = $sdrroot
-  $monitor_dir = '/usr/local/lib/cgi-bin/monitor'
   $monitor_location = '/monitor'
-  $http_files = lookup('nebula::http_files')
+  $cgi_dir = '/usr/local/lib/cgi-bin'
+  $monitor_dir = "${cgi_dir}/monitor"
 
   $requires = {
     enforce  => 'any',
     requires => [ 'local' ] + $haproxy_ips.map |String $ip| { "require ip ${ip}" }
   }
 
-  file { "${monitor_dir}/monitor.pl":
-    ensure => 'file',
+  file { $cgi_dir:
+    ensure => 'directory',
     owner  => 'root',
     group  => 'root',
-    mode   => '0755',
-    source => "https://${http_files}/ae-utils/bins/monitor.pl"
+    mode   => '0755'
+  }
+
+  class { 'nebula::profile::monitor_pl':
+    directory  => $monitor_dir,
+    shibboleth => true
   }
 
   apache::vhost { 'default non-ssl':

--- a/manifests/profile/hathitrust/apache/default.pp
+++ b/manifests/profile/hathitrust/apache/default.pp
@@ -38,7 +38,9 @@ class nebula::profile::hathitrust::apache::default (
 
   class { 'nebula::profile::monitor_pl':
     directory  => $monitor_dir,
-    shibboleth => true
+    shibboleth => true,
+    solr_cores => lookup('nebula::hathitrust::monitor::solr_cores'),
+    mysql      => lookup('nebula::hathitrust::monitor::mysql')
   }
 
   apache::vhost { 'default non-ssl':

--- a/manifests/profile/hathitrust/apache/default.pp
+++ b/manifests/profile/hathitrust/apache/default.pp
@@ -20,6 +20,22 @@ class nebula::profile::hathitrust::apache::default (
 
   $servername = "${prefix}babel.${domain}"
   $docroot = $sdrroot
+  $monitor_dir = '/usr/local/lib/cgi-bin/monitor'
+  $monitor_location = '/monitor'
+  $http_files = lookup('nebula::http_files')
+
+  $requires = {
+    enforce  => 'any',
+    requires => [ 'local' ] + $haproxy_ips.map |String $ip| { "require ip ${ip}" }
+  }
+
+  file { "${monitor_dir}/monitor.pl":
+    ensure => 'file',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "https://${http_files}/ae-utils/bins/monitor.pl"
+  }
 
   apache::vhost { 'default non-ssl':
     servername         => 'localhost',
@@ -28,6 +44,13 @@ class nebula::profile::hathitrust::apache::default (
     rewrites           => [
       {
         rewrite_rule => "^(/$|/index.html$) https://${servername}/cgi/mb    [redirect=permanent,last]"
+      }
+    ],
+
+    aliases            => [
+      {
+        scriptalias => $monitor_location,
+        path        => $monitor_dir
       }
     ],
 
@@ -43,21 +66,21 @@ class nebula::profile::hathitrust::apache::default (
         provider       => 'directory',
         location       => '/',
         allow_override => ['None'],
-        requires       =>  {
-          enforce  => 'any',
-          requires => [ 'local' ] + $haproxy_ips.map |String $ip| { "require ip ${ip}" }
-        }
+        requires       => $requires
       },
 
       {
         provider       => 'directorymatch',
         path           => "^(${docroot}/(([^/]+)/(web|cgi)|widgets/([^/]+)/web|cache|mdp-web)/|/tmp/fastcgi/)(.*)",
         allow_override => ['None'],
-        requires       => {
-          enforce  => 'any',
-          requires => ['local'] + $haproxy_ips.map |String $ip| { "require ip ${ip}" }
-        }
-      }
+        requires       => $requires
+      },
+
+      {
+        provider => 'location',
+        path     => '/monitor',
+        requires => $requires
+      },
 
     ],
     manage_docroot     => false,

--- a/manifests/profile/hathitrust/mounts.pp
+++ b/manifests/profile/hathitrust/mounts.pp
@@ -55,6 +55,11 @@ class nebula::profile::hathitrust::mounts (
       *       => $nfs_mount_options
     }
 
+    concat_fragment { "monitor nfs ${mount}":
+      tag     => 'monitor_config',
+      content => { 'nfs' => [$mount] }.to_yaml
+    }
+
   }
 
   if($readonly) {
@@ -64,15 +69,22 @@ class nebula::profile::hathitrust::mounts (
   }
 
   Integer[1, 24].each |$partition| {
-    file { "/sdr${partition}":
+    $mount = "/sdr${partition}"
+
+    file { $mount:
       ensure => 'directory',
     }
 
-    mount { "/sdr${partition}":
-      name    => "/sdr${partition}",
+    mount { $mount:
+      name    => $mount,
       device  => "nas-macc.sc:/ifs/sdr/${partition}",
       options => $sdr_options,
       *       => $nfs_mount_options
+    }
+
+    concat_fragment { "monitor nfs ${mount}":
+      tag     => 'monitor_config',
+      content => { 'nfs' => [$mount] }.to_yaml
     }
   }
 }

--- a/manifests/profile/hathitrust/mounts.pp
+++ b/manifests/profile/hathitrust/mounts.pp
@@ -54,6 +54,7 @@ class nebula::profile::hathitrust::mounts (
       options => 'auto,hard',
       *       => $nfs_mount_options
     }
+
   }
 
   if($readonly) {

--- a/manifests/profile/monitor_pl.pp
+++ b/manifests/profile/monitor_pl.pp
@@ -1,0 +1,73 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+#
+# @param directory The directory to deploy the monitor script & config to
+# @param nfs_mounts NFS mounts to check (via ls)
+# @param mysql The mysql host & credentials to attempt to connect as
+# @param shibboleth Whether to check for shibd process
+#
+# @example
+# class { 'nebula::profile::monitor_pl':
+#   nfs_mounts => ['/www']
+#   solr_cores => ['http://solr-host:8080/solr/core1']
+#   mysql      => {
+#     host     => 'mysql-whatever',
+#     user     => 'someuser',
+#     password => 'somepassword',
+#     database => 'mydatabase'
+#   },
+#   shibboleth => true
+#   directory  => '/usr/lib/cgi-bin/monitor',
+#   }
+class nebula::profile::monitor_pl (
+  String  $directory,
+  Array[String] $nfs_mounts = [],
+  Array[String] $solr_cores = [],
+  Optional[Hash] $mysql = undef,
+  Boolean $shibboleth = false,
+) {
+
+  $http_files = lookup('nebula::http_files')
+
+  file { $directory:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   =>  '0755'
+  }
+
+  file { "${directory}/monitor.pl":
+    ensure => 'file',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => "https://${http_files}/ae-utils/bins/monitor.pl"
+  }
+
+  $monitor_file = "${directory}/monitor_config.yaml"
+
+  concat {  $monitor_file:
+    owner  => 'root',
+    group  => 'root',
+    format => 'yaml',
+    mode   => '0644',
+  }
+
+  concat_fragment {
+    default:
+      target  => $monitor_file;
+
+    'monitor nfs mounts':
+      content => { 'nfs' => $nfs_mounts }.to_yaml();
+    'monitor solr cores':
+      content => { 'solr' => $solr_cores }.to_yaml();
+    'monitor mysql':
+      content => { 'mysql' => $mysql }.to_yaml();
+    'monitor shibboleth':
+      content => { 'shibd' => $shibboleth }.to_yaml();
+
+  }
+
+}

--- a/manifests/profile/monitor_pl.pp
+++ b/manifests/profile/monitor_pl.pp
@@ -10,6 +10,7 @@
 #
 # @example
 # class { 'nebula::profile::monitor_pl':
+#   directory  => '/usr/lib/cgi-bin/monitor',
 #   nfs_mounts => ['/www']
 #   solr_cores => ['http://solr-host:8080/solr/core1']
 #   mysql      => {
@@ -19,8 +20,7 @@
 #     database => 'mydatabase'
 #   },
 #   shibboleth => true
-#   directory  => '/usr/lib/cgi-bin/monitor',
-#   }
+# }
 class nebula::profile::monitor_pl (
   String  $directory,
   Array[String] $nfs_mounts = [],

--- a/manifests/profile/monitor_pl.pp
+++ b/manifests/profile/monitor_pl.pp
@@ -48,7 +48,8 @@ class nebula::profile::monitor_pl (
 
   $monitor_file = "${directory}/monitor_config.yaml"
 
-  concat {  $monitor_file:
+  concat_file {  $monitor_file:
+    tag    => 'monitor_config',
     owner  => 'root',
     group  => 'root',
     format => 'yaml',
@@ -57,7 +58,7 @@ class nebula::profile::monitor_pl (
 
   concat_fragment {
     default:
-      target  => $monitor_file;
+      tag  => 'monitor_config';
 
     'monitor nfs mounts':
       content => { 'nfs' => $nfs_mounts }.to_yaml();

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -20,8 +20,8 @@ class nebula::role::hathitrust::ingest_indexing (String $private_address_templat
   }
 
   class { 'nebula::profile::hathitrust::mounts':
-    mounts   => ['/htapps','/htprep','/htsolr/lss','/htsolr/lss-reindex'],
-    readonly => false
+    smartconnect_mounts => ['/htapps','/htprep','/htsolr/lss','/htsolr/lss-reindex'],
+    readonly            => false
   }
 
   include nebula::profile::hathitrust::dependencies

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "source": "https://github.com/mlibrary/nebula",
   "issues_url": "https://github.com/mlibrary/nebula/issues",
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.16.0 < 5.0.0"},
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 5.0.0"},
     {"name": "puppetlabs/apache", "version_requirement": ">= 3.4.0 < 4.0.0"},
     {"name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 5.0.0"},
     {"name": "puppetlabs/concat", "version_requirement": ">= 4.2.0 < 5.0.0"},

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -124,6 +124,20 @@ describe 'nebula::profile::hathitrust::apache' do
           )
         }
       end
+
+      it do
+        is_expected.to contain_concat_file('/usr/local/lib/cgi-bin/monitor/monitor_config.yaml')
+      end
+
+      it do
+        is_expected.to contain_concat_fragment('monitor solr cores').with(tag: 'monitor_config',
+                                                                          content: { 'solr' => %w[solrcore1 solrcore2] }.to_yaml)
+      end
+
+      it do
+        is_expected.to contain_concat_fragment('monitor mysql').with(tag: 'monitor_config',
+                                                                     content: { 'mysql' => { 'param1' => 'value1', 'param2' => 'value2' } }.to_yaml)
+      end
     end
   end
 end

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -21,7 +21,7 @@ describe 'nebula::profile::hathitrust::apache' do
 
       include_context 'with mocked puppetdb functions', 'somedc', %w[haproxy rolenode], 'nebula::profile::haproxy' => %w[haproxy]
 
-      it { is_expected.to contain_file("/usr/local/lib/cgi-bin/monitor/monitor.pl") }
+      it { is_expected.to contain_file('/usr/local/lib/cgi-bin/monitor/monitor.pl') }
 
       snippets = [
         <<~EOT,

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -21,6 +21,8 @@ describe 'nebula::profile::hathitrust::apache' do
 
       include_context 'with mocked puppetdb functions', 'somedc', %w[haproxy rolenode], 'nebula::profile::haproxy' => %w[haproxy]
 
+      it { is_expected.to contain_file("/usr/local/lib/cgi-bin/monitor/monitor.pl") }
+
       snippets = [
         <<~EOT,
           <Directory "/htapps/babel/imgsrv/cgi">

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -1,0 +1,27 @@
+
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::hathitrust::mounts' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts.merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
+      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+
+      it { is_expected.to contain_package('nfs-common') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
+      it { is_expected.to contain_concat_fragment('monitor nfs /sdr1').with(tag: 'monitor_config', content: { 'nfs' => ['/sdr1'] }.to_yaml) }
+
+      it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
+      it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
+      it {
+        is_expected.to contain_concat_fragment('monitor nfs /htapps')
+          .with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml)
+      }
+    end
+  end
+end

--- a/spec/classes/profile/monitor_pl_spec.rb
+++ b/spec/classes/profile/monitor_pl_spec.rb
@@ -1,0 +1,68 @@
+
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::monitor_pl' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) { { directory: '/somewhere' } }
+      let(:outfile) { '/somewhere/monitor_config.yaml' }
+
+      it { is_expected.to contain_concat(outfile).with_format('yaml') }
+
+      context 'with default parameters' do
+        it {
+          is_expected.to contain_concat_fragment('monitor nfs mounts')
+            .with(target: outfile, content: "---\nnfs: []\n")
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor solr cores')
+            .with(target: outfile, content: "---\nsolr: []\n")
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor mysql')
+            .with(target: outfile, content: "---\nmysql: \n")
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor shibboleth')
+            .with(target: outfile, content: "---\nshibd: false\n")
+        }
+      end
+
+      context 'with parameter values' do
+        let(:params) do
+          {
+            directory: '/somewhere',
+            nfs_mounts: ['/nfs1', '/nfs2'],
+            solr_cores: ['http://solr-something:8081/whatever'],
+            mysql: { 'host' => 'mysql-whatever', 'user' => 'someuser',
+                     'password' => 'something', 'database' => 'mydatabase' },
+            shibboleth: true,
+          }
+        end
+
+        it {
+          is_expected.to contain_concat_fragment('monitor nfs mounts')
+            .with(target: outfile, content: YAML.dump('nfs' => params[:nfs_mounts]))
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor solr cores')
+            .with(target: outfile, content: YAML.dump('solr' => params[:solr_cores]))
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor mysql')
+            .with(target: outfile, content: YAML.dump('mysql' => params[:mysql]))
+        }
+        it {
+          is_expected.to contain_concat_fragment('monitor shibboleth')
+            .with(target: outfile, content: YAML.dump('shibd' => params[:shibboleth]))
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/profile/monitor_pl_spec.rb
+++ b/spec/classes/profile/monitor_pl_spec.rb
@@ -13,24 +13,24 @@ describe 'nebula::profile::monitor_pl' do
       let(:params) { { directory: '/somewhere' } }
       let(:outfile) { '/somewhere/monitor_config.yaml' }
 
-      it { is_expected.to contain_concat(outfile).with_format('yaml') }
+      it { is_expected.to contain_concat_file(outfile).with(format: 'yaml', tag: 'monitor_config') }
 
       context 'with default parameters' do
         it {
           is_expected.to contain_concat_fragment('monitor nfs mounts')
-            .with(target: outfile, content: "---\nnfs: []\n")
+            .with(tag: 'monitor_config', content: "---\nnfs: []\n")
         }
         it {
           is_expected.to contain_concat_fragment('monitor solr cores')
-            .with(target: outfile, content: "---\nsolr: []\n")
+            .with(tag: 'monitor_config', content: "---\nsolr: []\n")
         }
         it {
           is_expected.to contain_concat_fragment('monitor mysql')
-            .with(target: outfile, content: "---\nmysql: \n")
+            .with(tag: 'monitor_config', content: "---\nmysql: \n")
         }
         it {
           is_expected.to contain_concat_fragment('monitor shibboleth')
-            .with(target: outfile, content: "---\nshibd: false\n")
+            .with(tag: 'monitor_config', content: "---\nshibd: false\n")
         }
       end
 
@@ -48,19 +48,19 @@ describe 'nebula::profile::monitor_pl' do
 
         it {
           is_expected.to contain_concat_fragment('monitor nfs mounts')
-            .with(target: outfile, content: YAML.dump('nfs' => params[:nfs_mounts]))
+            .with(tag: 'monitor_config', content: YAML.dump('nfs' => params[:nfs_mounts]))
         }
         it {
           is_expected.to contain_concat_fragment('monitor solr cores')
-            .with(target: outfile, content: YAML.dump('solr' => params[:solr_cores]))
+            .with(tag: 'monitor_config', content: YAML.dump('solr' => params[:solr_cores]))
         }
         it {
           is_expected.to contain_concat_fragment('monitor mysql')
-            .with(target: outfile, content: YAML.dump('mysql' => params[:mysql]))
+            .with(tag: 'monitor_config', content: YAML.dump('mysql' => params[:mysql]))
         }
         it {
           is_expected.to contain_concat_fragment('monitor shibboleth')
-            .with(target: outfile, content: YAML.dump('shibd' => params[:shibboleth]))
+            .with(tag: 'monitor_config', content: YAML.dump('shibd' => params[:shibboleth]))
         }
       end
     end

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -15,7 +15,7 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
       it { is_expected.to compile }
 
       it { is_expected.to contain_package('nfs-common') }
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3') }
       it { is_expected.to contain_mount('/htprep') }
 
       # default from hiera

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -20,7 +20,7 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
 
       it do
         is_expected.to contain_file('/etc/systemd/system/shibd.service.d/increase-timeout.conf')

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -20,9 +20,7 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('nfs-common') }
       it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
-      it { is_expected.to contain_concat_fragment('monitor nfs /sdr1').with(tag: 'monitor_config', content: { 'nfs' => ['/sdr1'] }.to_yaml ) }
 
       it do
         is_expected.to contain_file('/etc/systemd/system/shibd.service.d/increase-timeout.conf')
@@ -34,22 +32,9 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to contain_file('/etc/resolv.conf').with_content(%r{nameserver 127.0.0.1}) }
       it { is_expected.to contain_service('bind9') }
-      it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
-      it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
-      it { is_expected.to contain_concat_fragment('monitor nfs /htapps')
-        .with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml ) }
 
       # default from hiera
       it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
-      it do
-        is_expected.to contain_concat_fragment('monitor solr cores').with(tag: 'monitor_config',
-              content: { 'solr' => ['solrcore1','solrcore2']}.to_yaml )
-      end
-
-      it do
-        is_expected.to contain_concat_fragment('monitor mysql').with(tag: 'monitor_config',
-          content: { 'mysql' => { 'param1' => 'value1', 'param2' => 'value2' } }.to_yaml)
-      end
 
       if os == 'debian-9-x86_64'
         context 'with ens4' do

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -36,10 +36,20 @@ describe 'nebula::role::webhost::htvm' do
       it { is_expected.to contain_service('bind9') }
       it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
       it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
-      it { is_expected.to contain_concat_fragment('monitor nfs /htapps').with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml ) }
+      it { is_expected.to contain_concat_fragment('monitor nfs /htapps')
+        .with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml ) }
 
       # default from hiera
       it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
+      it do
+        is_expected.to contain_concat_fragment('monitor solr cores').with(tag: 'monitor_config',
+              content: { 'solr' => ['solrcore1','solrcore2']}.to_yaml )
+      end
+
+      it do
+        is_expected.to contain_concat_fragment('monitor mysql').with(tag: 'monitor_config',
+          content: { 'mysql' => { 'param1' => 'value1', 'param2' => 'value2' } }.to_yaml)
+      end
 
       if os == 'debian-9-x86_64'
         context 'with ens4' do

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -22,6 +22,7 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to contain_package('nfs-common') }
       it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,ro') }
+      it { is_expected.to contain_concat_fragment('monitor nfs /sdr1').with(tag: 'monitor_config', content: { 'nfs' => ['/sdr1'] }.to_yaml ) }
 
       it do
         is_expected.to contain_file('/etc/systemd/system/shibd.service.d/increase-timeout.conf')
@@ -35,6 +36,7 @@ describe 'nebula::role::webhost::htvm' do
       it { is_expected.to contain_service('bind9') }
       it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
       it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
+      it { is_expected.to contain_concat_fragment('monitor nfs /htapps').with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml ) }
 
       # default from hiera
       it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -78,3 +78,11 @@ nebula::virtual::users::all_users:
     comment: HT Ingest User
     uid: 123457
     home: /home/htingest
+
+nebula::hathitrust::monitor::solr_cores:
+  - solrcore1
+  - solrcore2
+
+nebula::hathitrust::monitor::mysql:
+  param1: value1
+  param2: value2


### PR DESCRIPTION
monitor_pl class is generic and can be re-used by other web servers when we puppetize those.

This uses `concat` resources with the `yaml` format to generate the monitor config out of multiple resources that are specified in the same place as the `mount` resources rather than with the monitor. It could easily be extended to use exported resources for the solr & mysql monitoring in the future.

This is supported by changes in ae-utils (a version of monitor.pl that works with the stripped-down config generated here) and in lensoftruth (parameters for monitoring solr & mysql).

