### PR TITLE
[WIP] AEIM-1760 - Export instances for Apache configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /pkg/
 /spec/fixtures/manifests/
 /spec/fixtures/modules/
+/spec/examples.txt
 /tmp/
 /vendor/
 /convert_report.txt

--- a/manifests/profile/named_instances.pp
+++ b/manifests/profile/named_instances.pp
@@ -14,7 +14,7 @@ class nebula::profile::named_instances (
   String      $fauxpaas_pubkey,
   String      $fauxpaas_puma_config,
   String      $puma_wrapper,
-  Array[Hash] $instances = [],
+  Hash[String,Hash] $instances = {}
 ) {
 
   class { 'nebula::profile::named_instances::puma_wrapper':
@@ -23,16 +23,11 @@ class nebula::profile::named_instances (
     rbenv_root  => lookup('nebula::profile::ruby::install_dir'),
   }
 
-  $instances.each |$instance| {
-    nebula::named_instance { $instance['name']:
-      path         => $instance['path'],
-      uid          => $instance['uid'],
-      gid          => $instance['gid'],
-      users        => $instance['users'],
-      subservices  => $instance['subservices'],
-      puma_wrapper => $puma_wrapper,
-      pubkey       => $fauxpaas_pubkey,
-      puma_config  => $fauxpaas_puma_config,
-    }
+  $defaults = {
+    puma_wrapper    => $puma_wrapper,
+    pubkey          => $fauxpaas_pubkey,
+    puma_config     => $fauxpaas_puma_config,
   }
+
+  create_resources(nebula::named_instance, $instances, $defaults)
 }

--- a/manifests/proxied_app.pp
+++ b/manifests/proxied_app.pp
@@ -1,0 +1,67 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Declaration of a service to be made available via reverse proxy. This
+# should be exported by an app and then collected by the web server role or
+# profile.
+
+# There are many keys in hiera for each instance, including some new ones
+# for this profile:
+#   public_hostname: hostname users access
+#   url_root: root url segment/suffix on the public hostname; defaults to /
+#   protocol: which protocol the app serves; defaults to http
+#   hostname: the hostname for the app as reachable by the web server; defaults to app-<title>
+#   port: port the app listens on
+#   ssl: boolean of whether to use SSL or not; defaults to true
+#   ssl_crt: the name (not full path) of the SSL certificate file;
+#            defaults to <public_hostname>.crt
+#   ssl_key: the name (not full path) of the SSL key file;
+#            defaults to <public_hostname>.key
+#   sendfile_path: if set, make this path available for X-Sendfile
+#
+# The defaults are applied at the named_instance class, not here.
+
+define nebula::proxied_app(
+  String  $public_hostname,
+  String  $url_root,
+  String  $protocol,          # protocol to the app, not of the vhost
+  String  $hostname,
+  Integer $port,
+  Boolean $ssl,
+  String  $ssl_crt,
+  String  $ssl_key,
+  String  $static_path,
+  Optional[String]  $sendfile_path,     # If set, XSendFile will be enabled here
+){
+  # These are straightforward translations to maintain parity with the
+  # ansible template. All of these names and semantics should be revisited
+  # and likely decomposed into resources/fragments that can be assembled
+  # by the web host after being exported or virtualized wherever needed.
+  $apache_app_hostname  = $hostname
+  $apache_app_name      = $title
+  $apache_cosign_factor = 'UMICH.EDU'
+  $apache_domain        = $public_hostname
+  $apache_port          = $port
+  $apache_terminate_ssl = $ssl
+  $apache_ssl_crt       = $ssl_crt
+  $apache_ssl_key       = $ssl_key
+  $apache_static_path   = $static_path
+  $apache_url_root      = $url_root
+
+  # TODO: Get these flags from instance config
+  $apache_cosign_deny_friend = false
+  $apache_static_directories = true
+  $apache_use_cosign         = true
+
+  # TODO: Determine the current needs for aliases/whitelisting and
+  # decide the best way to manage them. These are stubbed for now.
+  $apache_aliases = []
+  $apache_whitelisted_ips = []
+
+  # Not yet for actual management/distribution; verification pending
+  file { "/sysadmin/archive/app-proxies/${title}.conf":
+    ensure  => 'present',
+    content => template('nebula/apache/proxy_vhost.erb'),
+  }
+}

--- a/manifests/role/sysadmin_box.pp
+++ b/manifests/role/sysadmin_box.pp
@@ -15,4 +15,7 @@ class nebula::role::sysadmin_box {
   class { 'nebula::profile::puppet::query':
     ssl_group => 'sudo',
   }
+
+  # Generate app instance configs; not yet for distribution
+  Nebula::Profile::Proxied_app <<| |>>
 }

--- a/spec/classes/profile/named_instances_spec.rb
+++ b/spec/classes/profile/named_instances_spec.rb
@@ -12,6 +12,8 @@ describe 'nebula::profile::named_instances' do
       let(:myapp_testing) do
         {
           name: 'myapp-testing',
+          public_hostname: 'myapp-testing.default.invalid',
+          port: 456,
           path: '/my/app/path/myapp-testing',
           uid: 20_001,
           gid: 30_001,
@@ -22,6 +24,8 @@ describe 'nebula::profile::named_instances' do
       let(:hydra_staging) do
         {
           name: 'hydra-staging',
+          public_hostname: 'myapp-testing.default.invalid',
+          port: 123,
           path: '/hydra-dev/hydra-staging',
           uid: 20_002,
           gid: 30_002,
@@ -31,7 +35,14 @@ describe 'nebula::profile::named_instances' do
       end
 
       context 'with instances' do
-        let(:params) { { instances: [myapp_testing, hydra_staging] } }
+        let(:params) do
+          {
+            instances: {
+              'myapp-testing' => myapp_testing,
+              'hydra-staging' => hydra_staging,
+            },
+          }
+        end
 
         describe 'puma wrapper' do
           let(:klass) { 'nebula::profile::named_instances::puma_wrapper' }

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -10,19 +10,25 @@ describe 'nebula::named_instance' do
   let(:subservices) { subservice_list }
   let(:path) { '/hydra-dev/some/where/myapp-mystage' }
   let(:title) { 'myapp-mystage' }
+  let(:public_hostname) { 'app.default.invalid' }
+  let(:port) { 30_000 }
   let(:uid) { 30_001 }
   let(:gid) { 20_001 }
   let(:pubkey) { 'somepublickey' }
+  let(:sendfile_path) { '/app/storage' }
   let(:puma_wrapper) { '/l/local/bin/puma_wrapper' }
   let(:puma_config) { 'config/fauxpaas_puma.rb' }
   let(:users) { %w[alice solr] }
   let(:params) do
     {
       path: path,
+      public_hostname: public_hostname,
+      port: port,
       uid: uid,
       gid: gid,
       subservices: subservices,
       pubkey: pubkey,
+      sendfile_path: sendfile_path,
       puma_wrapper: puma_wrapper,
       puma_config: puma_config,
       users: users,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 RSpec.configure do |c|
   c.mock_with :rspec
+  c.example_status_persistence_file_path = 'spec/examples.txt'
 end
 
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/templates/profile/apache/proxy_vhost.erb
+++ b/templates/profile/apache/proxy_vhost.erb
@@ -1,0 +1,113 @@
+# Managed by puppet (nebula/profile/apache/proxy_vhost.erb)
+
+### Access Macro.
+# Given a whitelist, will deny from all others
+# Given no whitelist, will use default allow non-bad robots
+<Macro access>
+  <Location />
+<% if @apache_whitelisted_ips %>
+    Order Deny,Allow
+    Deny from all
+  <% @apache_whitelisted_ips.each do |ip| %>
+    Allow from <%= ip %>
+  <% end %>
+<% else %>
+    Use access_nobaddies
+<% end %>
+  </Location>
+</Macro>
+
+<VirtualHost *:80>
+  ServerName <%= @apache_domain %>
+  <% @apache_aliases.each do |apache_alias| %>
+  ServerAlias <%= apache_alias %>
+  <% end %>
+
+  Use logging <%= @apache_app_name %>
+  LogLevel info
+
+  Use access
+
+  # Redirect all access to https
+  RewriteEngine on
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [L,R,NE]
+</VirtualHost>
+
+<VirtualHost *:443>
+  ServerName <%= @apache_domain %>
+  <% @apache_aliases.each do |apache_alias| %>
+  ServerAlias <%= apache_alias %>
+  <% end %>
+
+  Use logging <%= @apache_app_name %>
+  LogLevel info
+
+<% if @apache_terminate_ssl %>
+  Use ssl <%= @apache_ssl_key %> <%= @apache_ssl_crt %>
+<% end %>
+
+  Use access
+
+<% if @apache_use_cosign %>
+  # Cosign is enabled by default.
+  # Entire site is public access save for one path
+  # This means the application will have to manage auth'd sessions.
+  Use cosign <%= @apache_domain %> <%= @apache_ssl_key %> <%= @apache_ssl_crt %>
+  CosignAllowPublicAccess On
+
+  # Protect single path with cosign.  App should redirect here for auth needs.
+  <Location <%= [@apache_url_root,"login"].join("/").gsub("//","/") %> >
+    <% if @apache_cosign_deny_friend %>
+    CosignRequireFactor <%= @apache_cosign_factor %>
+    <% end %>
+    CosignAllowPublicAccess Off
+  </Location>
+
+  # Set remote user header to allow app to use http header auth.
+  RequestHeader set X-Remote-User     "expr=%{REMOTE_USER}"
+<% end %>
+
+  RequestHeader set X-Forwarded-Proto 'https'
+  RequestHeader unset X-Forwarded-For
+  Header set "Strict-Transport-Security" "max-age=3600"
+
+  # Specify DocumentRoot to avoid using a default value.
+  DocumentRoot "<%= @apache_static_path %>"
+
+  # Directory for serving static files
+  <Directory "<%= @apache_static_path %>">
+    Options FollowSymlinks
+    AllowOverride None
+  </Directory>
+
+  RewriteEngine on
+
+  # Serve static assets through apache
+<% if @apache_static_directories %>
+  RewriteCond <%= @apache_static_path %>/$1 -d [OR]
+<% end %>
+  RewriteCond <%= @apache_static_path %>/$1 -f
+<% if @apache_url_root == '/' %>
+  RewriteRule ^<%= @apache_url_root %>(.*)$  <%= @apache_static_path %>/$1 [L]
+<% else %>
+  RewriteRule ^<%= @apache_url_root %>(.*)$  <%= @apache_static_path %>$1 [L]
+<% end %>
+
+<% if @apache_url_root == '/' and @apache_use_cosign %>
+  # Don't reverse-proxy cosign/valid if deployed at domain root
+  RewriteCond %{REQUEST_URI} !^/cosign/valid
+<% end %>
+  # Reverse proxy application to app hostname and port
+  RewriteRule ^(<%= @apache_url_root %>.*)$ <%= @protocol %>://<%= @apache_app_hostname %>:<%= @apache_port %>$1 [P]
+  ProxyPassReverse <%= @apache_url_root %> <%= @protocol %>://<%= @apache_app_hostname %>:<%= @apache_port %>/
+
+<% if @sendfile_path %>
+XSendFile On
+RequestHeader Set X-Sendfile-Type X-Sendfile
+XSendFilePath <%= @sendfile_path %>
+<% end %>
+
+</VirtualHost>
+
+# Use UndefMacro directive so subsequent macros using the same name don't cause conflicts.
+UndefMacro access


### PR DESCRIPTION
This introduces a new resource type to be exported by the named instance
and collected by the appropriate web servers. There are definitely some
rough edges, like the number of values that are shuttled along between
the components, but it's a good start. The template is ported almost
verbatim from ansible-predeploy, with the exception being that the
"extra config" is pruned in favor of "sendfile_path", the one feature of
the inlined config that has been used so far. If we need to model
instances more richly, we can do that, but I hesitate to preserve a
literal expansion from hiera.

The instances in lens will need a number of new keys for this to work.