### PR TITLE
AEIM-1773: pin deps for jhove

### DIFF
--- a/manifests/profile/hathitrust/dependencies/ingest_indexing.pp
+++ b/manifests/profile/hathitrust/dependencies/ingest_indexing.pp
@@ -11,26 +11,27 @@
 class nebula::profile::hathitrust::dependencies::ingest_indexing () {
 
   # install jhove, pin it to buster if we're on stretch
-  $package = 'jhove'
   if $facts['os']['release']['major'] == '9' {
     include nebula::profile::apt::testing
+    $packages = ['jhove','libjaxb-api-java','libactivation-java']
     $release = 'buster'
-    apt::pin { "${release}-${package}":
-      explanation => "Prioritze ${package} from ${release}",
+
+    apt::pin { "${release}-jhove":
+      explanation => "Prioritize ${packages} from ${release}",
       codename    => $release,
       priority    => 700,
-      packages    => [$package],
+      packages    => $packages,
       require     => Class['nebula::profile::apt::testing']
     }
 
     package {
-      $package:
-      require => Apt::Pin["${release}-${package}"]
+      $packages:
+      require => Apt::Pin["${release}-jhove"]
     }
   }
   else {
     package {
-      $package:
+      'jhove':
     }
   }
 

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -31,7 +31,7 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
       when 'debian-9-x86_64'
         it do
           is_expected.to contain_apt__pin('buster-jhove')
-            .with(codename: 'buster', packages: ['jhove'])
+            .with(codename: 'buster', packages: ['jhove', 'libjaxb-api-java', 'libactivation-java'])
         end
         it { is_expected.to contain_apt__source('testing') }
         it { is_expected.to contain_apt__pin('testing').with(priority: '-10', packages: '*') }


### PR DESCRIPTION
buster version of jhove now pins to some dependencies that are only in
buster; see debian changelog for jhove 1.20.1-5:
https://metadata.ftp-master.debian.org/changelogs/non-free/j/jhove/jhove_1.20.1-5_changelog