### PR TITLE
AEIM-1758: configure databases for moku-deployed apps via puppet

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,6 +24,9 @@ fixtures:
     lvm:
       repo: "puppetlabs/lvm"
       ref: "1.0.1"
+    mysql:
+      repo: "puppetlabs/mysql"
+      ref: "8.0.0"
     postgresql:
       repo: "puppetlabs/postgresql"
       ref: "5.2.1"

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -14,6 +14,7 @@ define nebula::named_instance(
   String        $pubkey,
   String        $puma_config,
   String        $puma_wrapper,
+  String        $mysql_exec_path = '',
   Optional[String] $mysql_user = undef,
   Optional[String] $mysql_password = undef,
   Optional[String] $mysql_host = undef,
@@ -204,7 +205,7 @@ define nebula::named_instance(
   }
 
   mysql::db { $title:
-    mysql_exec_path => 'nowhere',
+    mysql_exec_path => $mysql_exec_path,
     user            => $mysql_user,
     password        => $mysql_password,
     host            => $mysql_host,

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -14,6 +14,9 @@ define nebula::named_instance(
   String        $pubkey,
   String        $puma_config,
   String        $puma_wrapper,
+  Optional[String] $mysql_user = undef,
+  Optional[String] $mysql_password = undef,
+  Optional[String] $mysql_host = undef,
   String        $url_root = '/',
   String        $protocol = 'http',         # proxy protocol, not user to front-end
   String        $hostname = "app-${title}", # app host
@@ -200,5 +203,10 @@ define nebula::named_instance(
     content => template('nebula/named_instance/sudoers.erb'),
   }
 
+  mysql::db { $title:
+    mysql_exec_path => 'nowhere',
+    user            => $mysql_user,
+    password        => $mysql_password,
+    host            => $mysql_host,
+  }
 }
-

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -17,7 +17,8 @@ define nebula::named_instance(
   String        $mysql_exec_path = '',
   Optional[String] $mysql_user = undef,
   Optional[String] $mysql_password = undef,
-  Optional[String] $mysql_host = undef,
+  String        $mysql_host = localhost,
+  Boolean       $create_database = true,
   String        $url_root = '/',
   String        $protocol = 'http',         # proxy protocol, not user to front-end
   String        $hostname = "app-${title}", # app host
@@ -204,10 +205,12 @@ define nebula::named_instance(
     content => template('nebula/named_instance/sudoers.erb'),
   }
 
-  mysql::db { $title:
-    mysql_exec_path => $mysql_exec_path,
-    user            => $mysql_user,
-    password        => $mysql_password,
-    host            => $mysql_host,
+  if  $create_database and $mysql_user and $mysql_password  {
+    mysql::db { $title:
+      mysql_exec_path => $mysql_exec_path,
+      user            => $mysql_user,
+      password        => $mysql_password,
+      host            => $mysql_host,
+    }
   }
 }

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -17,7 +17,6 @@ define nebula::named_instance(
   String        $mysql_exec_path = '',
   Optional[String] $mysql_user = undef,
   Optional[String] $mysql_password = undef,
-  String        $mysql_host = localhost,
   Boolean       $create_database = true,
   String        $url_root = '/',
   String        $protocol = 'http',         # proxy protocol, not user to front-end
@@ -210,7 +209,7 @@ define nebula::named_instance(
       mysql_exec_path => $mysql_exec_path,
       user            => $mysql_user,
       password        => $mysql_password,
-      host            => $mysql_host,
+      host            => '%',
     }
   }
 }

--- a/manifests/profile/named_instances.pp
+++ b/manifests/profile/named_instances.pp
@@ -14,6 +14,7 @@ class nebula::profile::named_instances (
   String      $fauxpaas_pubkey,
   String      $fauxpaas_puma_config,
   String      $puma_wrapper,
+  Boolean     $create_databases = true,
   Hash[String,Hash] $instances = {}
 ) {
 
@@ -27,6 +28,7 @@ class nebula::profile::named_instances (
     puma_wrapper    => $puma_wrapper,
     pubkey          => $fauxpaas_pubkey,
     puma_config     => $fauxpaas_puma_config,
+    create_database => $create_databases
   }
 
   create_resources(nebula::named_instance, $instances, $defaults)

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,7 @@
     {"name": "puppetlabs/firewall", "version_requirement": ">= 1.1.3 < 2.0.0"},
     {"name": "puppetlabs/inifile", "version_requirement": ">= 1.1.3 < 3.0.0"},
     {"name": "puppetlabs/lvm", "version_requirement": ">= 1.0.1"},
+    {"name": "puppetlabs/mysql", "version_requirement": ">= 8.0.0 < 9.0.0"},
     {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},

--- a/spec/classes/profile/named_instances_spec.rb
+++ b/spec/classes/profile/named_instances_spec.rb
@@ -17,6 +17,8 @@ describe 'nebula::profile::named_instances' do
           path: '/my/app/path/myapp-testing',
           uid: 20_001,
           gid: 30_001,
+          mysql_user: 'myapp-testing',
+          mysql_password: '12345',
           users: %w[alice bob],
           subservices: ['resque-pool', 'mailman'],
         }
@@ -29,6 +31,8 @@ describe 'nebula::profile::named_instances' do
           path: '/hydra-dev/hydra-staging',
           uid: 20_002,
           gid: 30_002,
+          mysql_user: 'myapp-testing',
+          mysql_password: '12345',
           users: %w[solr bill],
           subservices: [],
         }
@@ -74,6 +78,17 @@ describe 'nebula::profile::named_instances' do
             users: hydra_staging[:users],
             subservices: hydra_staging[:subservices],
           )
+        end
+
+        describe 'databases' do
+          context 'when create_databases is false' do
+            let(:params) { super().merge(create_databases: false) }
+
+            it { is_expected.to have_mysql__db_count(0) }
+          end
+
+          it { is_expected.to contain_mysql__db('myapp-testing') }
+          it { is_expected.to contain_mysql__db('hydra-staging') }
         end
       end
 

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -230,6 +230,15 @@ describe 'nebula::named_instance' do
             grant: ['ALL'],
           )
         end
+
+        # We don't understand why, but this is required on, at the very
+        # least, mattlach's macbook. It isn't required on aelkiss's
+        # Linux machine, but it also doesn't appear to harm anything, so
+        # we're leaving it here to keep the tests passing.
+        #
+        # It doesn't have to be an empty string in particular, but it
+        # does need to be set to something.
+        it { is_expected.to contain_mysql__db(title).with_mysql_exec_path('') }
       end
     end
   end

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -224,15 +224,9 @@ describe 'nebula::named_instance' do
           is_expected.to contain_mysql__db(title).with(
             user: mysql_user,
             password: mysql_password,
-            host: 'localhost',
+            host: '%',
             grant: ['ALL'],
           )
-        end
-
-        context 'with mysql host' do
-          let(:params) { super().merge(mysql_host: 'some_mysql_host') }
-
-          it { is_expected.to contain_mysql__db(title).with_host('some_mysql_host') }
         end
 
         # Without the mysql_exec_path parameter, this fails with the error:

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018-2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -19,6 +19,9 @@ describe 'nebula::named_instance' do
   let(:puma_wrapper) { '/l/local/bin/puma_wrapper' }
   let(:puma_config) { 'config/fauxpaas_puma.rb' }
   let(:users) { %w[alice solr] }
+  let(:mysql_user) { 'abcde' }
+  let(:mysql_password) { '12345' }
+  let(:mysql_host) { 'a_real_sql_host' }
   let(:params) do
     {
       path: path,
@@ -32,6 +35,9 @@ describe 'nebula::named_instance' do
       puma_wrapper: puma_wrapper,
       puma_config: puma_config,
       users: users,
+      mysql_user: mysql_user,
+      mysql_password: mysql_password,
+      mysql_host: mysql_host,
     }
   end
 
@@ -211,6 +217,17 @@ describe 'nebula::named_instance' do
         it do
           is_expected.to contain_file(new_sudoers).with_content(
             %r{^\%#{title} ALL=\(root\) NOPASSWD: /bin/journalctl$},
+          )
+        end
+      end
+
+      describe 'database' do
+        it do
+          is_expected.to contain_mysql__db(title).with(
+            user: mysql_user,
+            password: mysql_password,
+            host: mysql_host,
+            grant: ['ALL'],
           )
         end
       end


### PR DESCRIPTION
- Creates the user and the database with the puppetlabs mysql module, running on (at least one of) the hosts that the app is deployed on

- Assumes that credentials that can connect to the database and create users are in `/root/.my.cnf` on the app server (puppetlabs-mysql assumption)

- Database is only created if user/password parameters are given and create_database is true.