### PR TITLE
AEIM-1772: Bind htvm web hosts to haproxy

### DIFF
--- a/manifests/haproxy/binding.pp
+++ b/manifests/haproxy/binding.pp
@@ -18,6 +18,12 @@ define nebula::haproxy::binding(
   $cookie = "cookie s${last_octet}"
   $track = "track ${service}-${datacenter}-https-back/${hostname}"
 
+  if($https_offload) {
+    $ssl_opts = ''
+  } else {
+    $ssl_opts = ' ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt'
+  }
+
   # TODO - handle case where https_offload = false - ie proxy https to server
 
   @concat_fragment { "${service}-${datacenter}-http ${hostname} binding":
@@ -30,7 +36,7 @@ define nebula::haproxy::binding(
   @concat_fragment { "${service}-${datacenter}-https ${hostname} binding":
     target  => "/etc/haproxy/services.d/${service}-https.cfg",
     order   => '04',
-    content => "server ${hostname} ${ipaddress}:443 check ${cookie}\n",
+    content => "server ${hostname} ${ipaddress}:443${ssl_opts} check ${cookie}\n",
     tag     => "${service}-${datacenter}-https_binding"
   }
 
@@ -44,7 +50,7 @@ define nebula::haproxy::binding(
   @concat_fragment { "${service}-${datacenter}-https ${hostname} exempt binding":
     target  => "/etc/haproxy/services.d/${service}-https.cfg",
     order   => '06',
-    content => "server ${hostname} ${ipaddress}:443 ${track} ${cookie}\n",
+    content => "server ${hostname} ${ipaddress}:443${ssl_opts} ${track} ${cookie}\n",
     tag     => "${service}-${datacenter}-https_exempt_binding"
   }
 

--- a/manifests/role/webhost/htvm.pp
+++ b/manifests/role/webhost/htvm.pp
@@ -11,8 +11,13 @@ class nebula::role::webhost::htvm (
 ) {
   include nebula::role::hathitrust
 
-  # not ready for this yet
-  # nebula::balanced_frontend { 'htvm': }
+  @@nebula::haproxy::binding { "${::hostname} hathitrust":
+    service       => 'hathitrust',
+    https_offload => false,
+    datacenter    => $::datacenter,
+    hostname      => $::hostname,
+    ipaddress     => $::ipaddress
+  }
 
   class { 'nebula::profile::networking::private':
     address_template => $private_address_template

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -11,7 +11,13 @@ require_relative '../../support/contexts/with_mocked_nodes'
 describe 'nebula::role::webhost::htvm' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
+      let(:facts) do
+        os_facts.merge(
+          hostname: 'thisnode',
+          datacenter: 'somedc',
+          networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} },
+        )
+      end
       let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
       let(:haproxy) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'haproxy' } }
       let(:rolenode) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'rolenode' } }
@@ -19,6 +25,11 @@ describe 'nebula::role::webhost::htvm' do
       include_context 'with mocked puppetdb functions', 'somedc', %w[haproxy rolenode], 'nebula::profile::haproxy' => %w[haproxy]
 
       it { is_expected.to compile }
+
+      it 'exports a haproxy::binding resource for hathitrust' do
+        expect(exported_resources).to contain_nebula__haproxy__binding('thisnode hathitrust')
+          .with(service: 'hathitrust', datacenter: 'somedc', https_offload: false)
+      end
 
       it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
 

--- a/spec/defines/haproxy_binding_spec.rb
+++ b/spec/defines/haproxy_binding_spec.rb
@@ -67,6 +67,20 @@ describe 'nebula::haproxy::binding' do
       end
 
       it { is_expected.to contain_nebula__haproxy__service('myservice') }
+
+      context 'no https offload' do
+        let(:params) { super().merge(https_offload: false) }
+
+        it do
+          is_expected.to contain_concat_fragment('myservice-dc-https thishost binding')
+            .with_content("server thishost 10.1.2.123:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check cookie s123\n")
+        end
+
+        it do
+          is_expected.to contain_concat_fragment('myservice-dc-https thishost exempt binding')
+            .with_content("server thishost 10.1.2.123:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt track myservice-dc-https-back/thishost cookie s123\n")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Implements https_offload: false case for haproxy to apache binding for
the new HT web server role where apache and haproxy both terminate ssl