### PR TITLE
Initialize solr core for new named instance

### DIFF
--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -49,7 +49,7 @@ define nebula::named_instance(
   # Add sudoers and passed users to the group
   (lookup('nebula::usergroup::membership')['sudo'] + $users).each |$user| {
     exec { "${user} ${title} membership":
-      unless  => "/bin/grep -q ${title}\\S*${user} /etc/group",
+      unless  => "/bin/grep -q '${title}\\S*${user}' /etc/group",
       onlyif  => "/usr/bin/id ${user}",
       command => "/usr/sbin/usermod -aG ${title} ${user}",
     }

--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -21,11 +21,7 @@ define nebula::named_instance(
   String        $url_root = '/',
   String        $protocol = 'http',         # proxy protocol, not user to front-end
   String        $hostname = "app-${title}", # app host
-  String        $solr_host = 'localhost',
-  Integer       $solr_port = 8081,
-  Optional[String] $solr_home = undef, # directory containing all solr cores
-  String        $solr_core = $title,
-  Boolean       $use_solr = false,
+  Hash          $solr_cores = {},
   String        $static_path = "${path}/current/public",
   Boolean       $static_directories = false,
   Boolean       $ssl = true,
@@ -218,39 +214,13 @@ define nebula::named_instance(
     }
   }
 
-  if $use_solr and $solr_home {
-    $solr_path = "${solr_home}/${solr_core}"
+  create_resources(nebula::named_instance::solr_core,
+    $solr_cores,
+    {
+      instance_title => $title,
+      instance_path    => $path
+    }
+  )
 
-    # make a stub version 0
-    file {
-      ["${path}/releases","${path}/releases/0","${path}/releases/0/solr",$solr_path]:
-        ensure => 'directory',
-        mode   => '2775',
-        owner  => 'solr',
-        group  => 'solr',
-    }
-    file { "${path}/releases/0/solr/conf":
-      ensure => 'link',
-      target => '/l/local/solr-current/server/solr/configsets/basic_configs/conf'
-    }
-    file { "${solr_path}/conf":
-      ensure => 'link',
-      target => "${path}/current/solr/conf",
-    }
-
-    # link to version 0 if there isn't a real version linked yet
-    file { "${path}/current":
-      ensure  => 'link',
-      target  => "${path}/releases/0",
-      replace => false,
-    }
-
-    exec { 'init-solr-core':
-      # need to transform title-like-this to snake_case
-      # missing core_title
-      unless  => "/usr/bin/wget --quiet http://${solr_host}:${solr_port}/solr/${solr_core}/admin/ping",
-      command => "/usr/bin/wget --quiet \"http://${solr_host}:${solr_port}/solr/admin/cores?action=CREATE&name=${solr_core}&instanceDir=${solr_path}&config=solrconfig.xml&dataDir=data\"",
-    }
-  }
 
 }

--- a/manifests/named_instance/solr_core.pp
+++ b/manifests/named_instance/solr_core.pp
@@ -1,0 +1,72 @@
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# A named instance
+#
+# @example
+define nebula::named_instance::solr_core (
+  String $instance_path,
+  String $instance_title,
+  String $solr_home = lookup('nebula::named_instance::solr_core::solr_home'),
+  String $config_dir = 'conf',
+  String $host = 'localhost',
+  Integer $port = 8081,
+  String $default_config = lookup('nebula::named_instance::solr_core::default_config'),
+  String $solr_user = 'solr',
+  String $solr_group = 'solr',
+) {
+  $core_path = "${solr_home}/${title}"
+
+  # ensure the named instance has some solr config we can use
+  ensure_resource('file',
+    [
+      "${instance_path}/releases",
+      "${instance_path}/releases/0",
+      "${instance_path}/releases/0/solr"
+    ],
+    {
+      ensure => 'directory',
+      mode   => '2775',
+      owner  => $instance_title,
+      group  => $instance_title
+    }
+  )
+
+  ensure_resource('file',
+    "${instance_path}/releases/0/solr/${config_dir}",
+    {
+      ensure => 'link',
+      target => $default_config
+    }
+  )
+
+  # link to version 0 if there isn't a real version linked yet
+  ensure_resource('file',
+    "${instance_path}/current",
+    {
+      ensure  => 'link',
+      target  => "${instance_path}/releases/0",
+      replace => false,
+    }
+  )
+
+  file { $core_path:
+    ensure => 'directory',
+    mode   => '2775',
+    owner  => 'solr',
+    group  => 'solr',
+  }
+
+  file { "${core_path}/conf":
+    ensure => 'link',
+    target => "${instance_path}/current/solr/${config_dir}",
+  }
+
+  exec { "initialize solr core ${title}":
+    unless  => "/usr/bin/wget -O - --quiet http://${host}:${port}/solr/${title}/admin/ping > /dev/null",
+    command => "/usr/bin/wget -O - --quiet \"http://${host}:${port}/solr/admin/cores?action=CREATE&name=${title}&instanceDir=${core_path}&config=solrconfig.xml&dataDir=data\" > /dev/null",
+  }
+
+}

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -258,19 +258,44 @@ describe 'nebula::named_instance' do
       end
 
       describe 'solr' do
-        it { is_expected.not_to contain_exec('init-solr-core') }
+        it { is_expected.to have_nebula__named_instance__solr_core_resource_count(0) }
         it { is_expected.not_to contain_file("#{path}/current") }
 
         context 'with solr params' do
           let(:params) do
             super().merge(
-              use_solr: true,
-              solr_home: '/nonexistent/solr/cores',
+              solr_cores: {
+                'somecore' => {
+                  'solr_home' => '/nonexistent/solr',
+                },
+              },
             )
-
-            it { is_expected.to contain_exec('init-solr-core') }
-            it { is_expected.to contain_file("#{path}/current") }
           end
+
+          it do
+            is_expected.to contain_nebula__named_instance__solr_core('somecore').with(
+              instance_title: title,
+              instance_path: path,
+            )
+          end
+        end
+
+        context 'with two solr cores' do
+          let(:params) do
+            super().merge(
+              solr_cores: {
+                'core1' => {
+                  'solr_home' => '/nonexistent/solr',
+                },
+                'core2' => {
+                  'solr_home' => '/nonexistent/solr',
+                },
+              },
+            )
+          end
+
+          it { is_expected.to contain_nebula__named_instance__solr_core('core1') }
+          it { is_expected.to contain_nebula__named_instance__solr_core('core2') }
         end
       end
     end

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -256,6 +256,23 @@ describe 'nebula::named_instance' do
           it { is_expected.not_to contain_mysql__db(title) }
         end
       end
+
+      describe 'solr' do
+        it { is_expected.not_to contain_exec('init-solr-core') }
+        it { is_expected.not_to contain_file("#{path}/current") }
+
+        context 'with solr params' do
+          let(:params) do
+            super().merge(
+              use_solr: true,
+              solr_home: '/nonexistent/solr/cores',
+            )
+
+            it { is_expected.to contain_exec('init-solr-core') }
+            it { is_expected.to contain_file("#{path}/current") }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/defines/solr_core_spec.rb
+++ b/spec/defines/solr_core_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018-2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::named_instance::solr_core' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with required/default params' do
+        let(:title) { 'mycore' }
+        let(:params) do
+          {
+            instance_path: '/nonexistent/myapp-testing',
+            instance_title: 'myapp-testing',
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/nonexistent/myapp-testing/releases/0/solr')
+            .with_owner('myapp-testing')
+        end
+
+        it do
+          is_expected.to contain_file('/nonexistent/myapp-testing/releases/0/solr/conf')
+            .with(ensure: 'link',
+                  # from hiera
+                  target: '/nonexistent/solr/conf')
+        end
+
+        it do
+          is_expected.to contain_file('/nonexistent/solr_home/mycore')
+            .with(ensure: 'directory', owner: 'solr')
+        end
+
+        it do
+          is_expected.to contain_file('/nonexistent/myapp-testing/current')
+            .with(ensure: 'link', target: '/nonexistent/myapp-testing/releases/0', replace: 'false')
+        end
+
+        it do
+          is_expected.to contain_file('/nonexistent/solr_home/mycore/conf')
+            .with(ensure: 'link', target: '/nonexistent/myapp-testing/current/solr/conf')
+        end
+
+        it do
+          is_expected.to contain_exec('initialize solr core mycore').with(
+            unless: '/usr/bin/wget -O - --quiet http://localhost:8081/solr/mycore/admin/ping > /dev/null',
+            command: '/usr/bin/wget -O - --quiet "http://localhost:8081/solr/admin/cores?action=CREATE&name=mycore&' \
+                     'instanceDir=/nonexistent/solr_home/mycore&config=solrconfig.xml&dataDir=data" > /dev/null',
+          )
+        end
+      end
+
+      context 'overriding all params' do
+        let(:title) { 'anothercore' }
+        let(:params) do
+          {
+            instance_path: '/somewhere/something-testing',
+            instance_title: 'something-testing',
+            solr_home: '/somewhere/solr_cores',
+            config_dir: 'anothercore-conf',
+            host: 'solrhost',
+            port: 12_345,
+            default_config: '/somewhere/default-config',
+            solr_user: 'solruser',
+            solr_group: 'solrgroup',
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/somewhere/something-testing/releases/0/solr/anothercore-conf')
+            .with(ensure: 'link',
+                  # from hiera
+                  target: '/somewhere/default-config')
+        end
+
+        it do
+          is_expected.to contain_file('/somewhere/solr_cores/anothercore')
+            .with(ensure: 'directory', owner: 'solr')
+        end
+
+        it do
+          is_expected.to contain_file('/somewhere/solr_cores/anothercore/conf')
+            .with(ensure: 'link', target: '/somewhere/something-testing/current/solr/anothercore-conf')
+        end
+
+        it do
+          is_expected.to contain_exec('initialize solr core anothercore').with(
+            unless: '/usr/bin/wget -O - --quiet http://solrhost:12345/solr/anothercore/admin/ping > /dev/null',
+            command: '/usr/bin/wget -O - --quiet "http://solrhost:12345/solr/admin/cores?action=CREATE&name=anothercore&' \
+                     'instanceDir=/somewhere/solr_cores/anothercore&config=solrconfig.xml&dataDir=data" > /dev/null',
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -128,3 +128,6 @@ nebula::usergroup::membership: {sudo: []}
 nebula::profile::groups::all_groups: {}
 nebula::virtual::users::default_group: staff
 nebula::virtual::users::all_users: {}
+
+nebula::named_instance::solr_core::default_config: '/nonexistent/solr/conf'
+nebula::named_instance::solr_core::solr_home: '/nonexistent/solr_home'


### PR DESCRIPTION
Creare dummy "release 0" for each named instance
If there isn't a released version yet, link this one and init the solr core