### PR TITLE
use puppetlabs-ntp

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -27,6 +27,9 @@ fixtures:
     mysql:
       repo: "puppetlabs/mysql"
       ref: "8.0.0"
+    ntp:
+      repo: "puppetlabs/ntp"
+      ref: "7.4.0"
     postgresql:
       repo: "puppetlabs/postgresql"
       ref: "5.2.1"

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,7 @@
     {"name": "puppetlabs/inifile", "version_requirement": ">= 1.1.3 < 3.0.0"},
     {"name": "puppetlabs/lvm", "version_requirement": ">= 1.0.1"},
     {"name": "puppetlabs/mysql", "version_requirement": ">= 8.0.0 < 9.0.0"},
+    {"name": "puppetlabs/ntp", "version_requirement": ">= 7.4.0 < 8.0.0"},
     {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},

--- a/spec/classes/profile/ntp_spec.rb
+++ b/spec/classes/profile/ntp_spec.rb
@@ -14,34 +14,15 @@ describe 'nebula::profile::ntp' do
         is_expected.to contain_service('ntp').with(
           enable: true,
           ensure: 'running',
-          require: ['Package[ntp]', 'Package[ntpstat]'],
         )
       end
 
       it { is_expected.to contain_package('ntp') }
       it { is_expected.to contain_package('ntpstat') }
 
-      it do
-        is_expected.to contain_file_line('no debian ntp servers').with(
-          ensure: 'absent',
-          path: '/etc/ntp.conf',
-          match: '(server|pool).*debian.pool',
-          match_for_absence: true,
-          multiple: true,
-          notify: 'Service[ntp]',
-          require: ['Package[ntp]', 'Package[ntpstat]'],
-        )
-      end
+      it { is_expected.to contain_file('/etc/ntp.conf').with_content(%r{^server ntp.example.invalid$}m) }
 
-      it do
-        is_expected.to contain_file_line('ntp server ntp.example.invalid').with(
-          path: '/etc/ntp.conf',
-          line: 'server ntp.example.invalid',
-          after: '^#?server',
-          notify: 'Service[ntp]',
-          require: ['Package[ntp]', 'Package[ntpstat]'],
-        )
-      end
+      it { is_expected.to contain_file('/etc/ntp.conf').that_notifies('Service[ntp]') }
 
       context 'given ntp[123].realdomain.com' do
         let(:params) do
@@ -59,10 +40,7 @@ describe 'nebula::profile::ntp' do
           'ntp2.realdomain.com',
           'ntp3.realdomain.com',
         ].each do |server|
-          it do
-            is_expected.to contain_file_line("ntp server #{server}")
-              .with_line("server #{server}")
-          end
+          it { is_expected.to contain_file('/etc/ntp.conf').with_content(%r{^server #{server}$}m) }
         end
       end
     end


### PR DESCRIPTION
changing ntp servers with file_line or using multiple ntp servers didn't
work very well

this should generate an ntp config that is similar to the debian defaults + using our servers except for collection of statistics that we don't use anyway