### PR TITLE
Add nodejs to app_host and deploy_host

### DIFF
--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -1,0 +1,32 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::nodejs
+#
+# Install the LTS release of nodejs
+#
+# @example
+#   include nebula::profile::nodejs
+class nebula::profile::nodejs () {
+  include nebula::profile::apt
+
+    apt::source { 'nodesource.come':
+      comment       => 'Nodesource apt source for recent nodejs',
+      location      => 'https://deb.nodesource.com/node_10.x',
+      release       => $facts['os']['distro']['codename'],
+      repos         => 'main',
+      notify_update => true,
+      key           => {
+        'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
+        'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+        'server' => 'keyserver.ubuntu.com',
+      },
+      include       => {
+        'src' => false,
+        'deb' => true,
+    }
+  }
+
+  package { 'nodejs': }
+}

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -11,7 +11,7 @@
 class nebula::profile::nodejs () {
   include nebula::profile::apt
 
-    apt::source { 'nodesource.come':
+    apt::source { 'nodesource.com':
       comment       => 'Nodesource apt source for recent nodejs',
       location      => 'https://deb.nodesource.com/node_10.x',
       release       => $facts['os']['distro']['codename'],

--- a/manifests/role/app_host/dev.pp
+++ b/manifests/role/app_host/dev.pp
@@ -11,5 +11,6 @@
 class nebula::role::app_host::dev {
   include nebula::role::umich
   include nebula::profile::ruby
+  include nebula::profile::nodejs
   include nebula::profile::named_instances
 }

--- a/manifests/role/app_host/prod.pp
+++ b/manifests/role/app_host/prod.pp
@@ -11,5 +11,6 @@
 class nebula::role::app_host::prod {
   include nebula::role::umich
   include nebula::profile::ruby
+  include nebula::profile::nodejs
   include nebula::profile::named_instances
 }

--- a/manifests/role/deploy_host.pp
+++ b/manifests/role/deploy_host.pp
@@ -11,5 +11,6 @@
 class nebula::role::deploy_host {
   include nebula::role::umich
   include nebula::profile::ruby
+  include nebula::profile::nodejs
   include nebula::profile::moku
 }


### PR DESCRIPTION
* Adds the nodejs profile
* Adds the profile to the app_host:dev, app_host:prod, and deploy_host roles

We abstain from including tests here because the data is static, and any tests would likely be brittle.