### PR TITLE
Include system packages commonly required by ruby

### DIFF
--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -20,6 +20,22 @@ class nebula::profile::ruby (
   Array  $plugins,
   Array  $gems,
 ) {
+
+  package {[
+    'autoconf',
+    'build-essential',
+    'bison',
+    'libssl-dev',
+    'libyaml-dev',
+    'libreadline6-dev',
+    'zlib1g-dev',
+    'libsqlite3-dev',
+    'libncurses5-dev',
+    'libffi-dev',
+    'libgdbm5',
+    'libgdbm-dev'
+  ]:}
+
   class { 'rbenv':
     install_dir => $install_dir,
   }


### PR DESCRIPTION
This adds a number of system packages that are commonly required by ruby gems that build native extensions.

These are all system packages I've required at some point or another. Unfortunately, I don't have the mappings of what required them.  At the very least, we should include libsqlite3-dev.