### PR TITLE
Export moku systemd_services correctly

### DIFF
--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -168,7 +168,7 @@ define nebula::named_instance(
       content => {'deploy' => {'env' => {'rack_env' => 'production', 'rails_env' => 'production'}}}.to_json;
 
     "${title} deploy init deploy.systemd_services":
-      content => {deploy => {systemd_services => $subservices}}.to_json;
+      content => {deploy => {systemd_services => ["${title}.target"]}}.to_json;
 
     "${title} deploy init deploy.sites.user":
       content => {deploy => {sites => {user => $title}}}.to_json;

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -77,7 +77,7 @@ describe 'nebula::named_instance' do
             'infrastructure.bind'               => '{"infrastructure":{"bind":"tcp://10.1.2.3:3000"}}',
             'deploy.deploy_dir'                 => '{"deploy":{"deploy_dir":"/www-invalid/first-instance/app"}}',
             'deploy.env'                        => '{"deploy":{"env":{"rack_env":"production","rails_env":"production"}}}',
-            'deploy.systemd_services'           => '{"deploy":{"systemd_services":["one_subservice","another_subservice"]}}',
+            'deploy.systemd_services'           => '{"deploy":{"systemd_services":["first-instance.target"]}}',
             'deploy.sites.user'                 => '{"deploy":{"sites":{"user":"first-instance"}}}',
           }.each do |fragment_title, content|
             describe fragment_title do
@@ -192,7 +192,7 @@ describe 'nebula::named_instance' do
             'permissions.edit'                  => '{"permissions":{"edit":[]}}',
             'deploy.deploy_dir'                 => '{"deploy":{"deploy_dir":"/www-invalid/minimal/app"}}',
             'deploy.env'                        => '{"deploy":{"env":{"rack_env":"production","rails_env":"production"}}}',
-            'deploy.systemd_services'           => '{"deploy":{"systemd_services":[]}}',
+            'deploy.systemd_services'           => '{"deploy":{"systemd_services":["minimal-instance.target"]}}',
             'deploy.sites.user'                 => '{"deploy":{"sites":{"user":"minimal-instance"}}}',
             'infrastructure.bind'               => '{"infrastructure":{"bind":"tcp://localhost:3001"}}',
           }.each do |fragment_title, content|


### PR DESCRIPTION
We had assumed a false equivalency between moku's `systemd_services` and puppet's systemd `subservices`. It turns out that given our current strategy, moku always just needs `instance-name.target` only.