### PR TITLE
Install bundler 2.x as well as 1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,4 +210,4 @@ DEPENDENCIES
   semantic_puppet
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -15,6 +15,7 @@
 #   include nebula::profile::ruby
 class nebula::profile::ruby (
   String $global_version,
+  String $bundler_version,
   Array  $supported_versions,
   String $install_dir,
   Array  $plugins,
@@ -44,13 +45,14 @@ class nebula::profile::ruby (
   }
 
   rbenv::build { $global_version:
-    bundler_version => '~>1.14',
+    bundler_version => $bundler_version,
     global          => true,
   }
 
   $gems.each |$gem| {
-    rbenv::gem { "${gem} ${global_version}":
-      gem          => $gem,
+    rbenv::gem { "${gem[gem]} ${global_version}":
+      gem          => $gem['gem'],
+      version      => $gem['version'],
       ruby_version => $global_version,
       require      => Rbenv::Build[$global_version],
     }
@@ -61,12 +63,13 @@ class nebula::profile::ruby (
     unless $::os['release']['major'] == '9' and $version =~ /^2\.3\./ {
       unless $version == $global_version {
         rbenv::build { $version:
-          bundler_version => '~>1.14',
+          bundler_version => $bundler_version,
         }
 
         $gems.each |$gem| {
-          rbenv::gem { "${gem} ${version}":
-            gem          => $gem,
+          rbenv::gem { "${gem[gem]} ${version}":
+            gem          => $gem['gem'],
+            version      => $gem['version'],
             ruby_version => $version,
             require      => Rbenv::Build[$version],
           }

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -27,9 +27,7 @@ describe 'nebula::profile::ruby' do
 
       ['2.4.3', '2.5.0'].each do |version|
         it do
-          is_expected.to contain_rbenv__build(version).with(
-            bundler_version: '~>1.14',
-          )
+          is_expected.to contain_rbenv__build(version)
         end
 
         %w[puma rspec].each do |gem|
@@ -74,7 +72,7 @@ describe 'nebula::profile::ruby' do
       end
 
       context 'when given global_version of 2.4.1' do
-        let(:params) { { global_version: '2.4.1' } }
+        let(:params) { { global_version: '2.4.1', bundler_version: '~>1.14' } }
 
         it do
           is_expected.to contain_rbenv__build('2.4.1').with(
@@ -85,7 +83,14 @@ describe 'nebula::profile::ruby' do
       end
 
       context 'when given gems ["pry", "json"]' do
-        let(:params) { { gems: %w[pry json] } }
+        let(:params) do
+          {
+            gems: [
+              { gem: 'pry', version: '>= 0' },
+              { gem: 'json', version: '>= 0' },
+            ],
+          }
+        end
 
         it { is_expected.to contain_rbenv__gem('pry 2.4.3') }
         it { is_expected.to contain_rbenv__gem('pry 2.5.0') }

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -37,13 +37,14 @@ nebula::profile::ruby::plugins:
 - rbenv/rbenv-default-gems
 - tpope/rbenv-aliases
 nebula::profile::ruby::global_version: '2.4.3'
+nebula::profile::ruby::bundler_version: '~>1.17'
 nebula::profile::ruby::supported_versions:
 - '2.3.4'
 - '2.4.5'
 - '2.5.0'
 nebula::profile::ruby::gems:
-- rspec
-- puma
+- { gem: rspec, version: '>= 0' }
+- { gem: puma, version: '>= 0' }
 nebula::profile::vmhost::host::vms: {}
 nebula::profile::vmhost::host::defaults: {}
 


### PR DESCRIPTION
* Adds $bundler_version parameter to profile::ruby
* Gems are now specified as an array of hashes. The hashes two elements `gem` and `version`. The default behavior of the rbenv module for version is to use `>= 0`
* Makes appropriate changes in the fixtures and specs for above

This requires a corresponding change in hiera. I have that ready to push.

~~Also, this PR cannot be made to work in travis, as travis no longer wants to accept bundler before 2.x. If we made that change here, we'd never be able to run puppet to apply it to our serves. Chicken and egg.~~