### PR TITLE
Make only one partition on new VMs

### DIFF
--- a/templates/virtual_machine/stretch.cfg.erb
+++ b/templates/virtual_machine/stretch.cfg.erb
@@ -165,7 +165,7 @@ d-i clock-setup/ntp boolean true
 # - regular: use the usual partition types for your architecture
 # - lvm:     use LVM to partition the disk
 # - crypto:  use LVM within an encrypted partition
-d-i partman-auto/method string lvm
+d-i partman-auto/method string regular
 
 # If one of the disks that are going to be automatically partitioned
 # contains an old LVM configuration, the user will normally receive a
@@ -188,6 +188,8 @@ d-i partman-lvm/confirm_nooverwrite boolean true
 # just point at it.
 #d-i partman-auto/expert_recipe_file string /hd-media/recipe
 
+# partman fields are: Min Priority Max
+
 # If not, you can put an entire recipe into the preconfiguration file in one
 # (logical) line. This example creates a small /boot partition, suitable
 # swap, and uses the rest of the space for the root partition:
@@ -207,42 +209,17 @@ d-i partman-lvm/confirm_nooverwrite boolean true
 #              64 512 300% linux-swap                          \
 #                      method{ swap } format{ }                \
 #              .
+
+# Create a root partition filling the whole disk, fail if the disk is under
+# 2GB. Note that this intentionally lacks swap; we shouldn't run out of RAM
+# and if we do swap will only the delay crashing, not prevent it.
 d-i partman-auto/expert_recipe string                 \
     partman-auto/text/pixie ::                        \
-        2048 100 2048 ext4                            \
+        2048 100 1000000000 ext4                      \
             $primary{ } $bootable{ }                  \
             method{ format } format{ }                \
             use_filesystem{ } filesystem{ ext4 }      \
             label{ root } mountpoint{ / }             \
-        .                                             \
-        2048 100 2048 linux-swap                      \
-            $primary{ }                               \
-            method{ swap } format{ }                  \
-        .                                             \
-        4096 100 4096 ext4                            \
-            method{ format } format{ }                \
-            use_filesystem{ } filesystem{ ext4 }      \
-            label{ tmp } mountpoint{ /tmp }           \
-        .                                             \
-        4096 100 4096 ext4                            \
-            method{ lvm } $lvmok{ } format{ }         \
-            use_filesystem{ } filesystem{ ext4 }      \
-            lvname { var } mountpoint{ /var }         \
-        .                                             \
-        2048 100 2048 ext4                            \
-            method{ lvm } $lvmok{ } format{ }         \
-            use_filesystem{ } filesystem{ ext4 }      \
-            lv_name{ l } mountpoint{ /l }             \
-        .                                             \
-        4096 100 4096 ext4                            \
-            method{ lvm } $lvmok{ } format{ }         \
-            use_filesystem{ } filesystem{ ext4 }      \
-            lv_name{ usr } mountpoint{ /usr }         \
-        .                                             \
-        1 1000000000 1000000000 ext4                  \
-            method{ lvm } $lvmok{ } format{ }         \
-            filesystem{ ext4 }                        \
-            lv_name{ blank }                          \
         .
 d-i partman-auto/choose_recipe select pixie
 
@@ -259,6 +236,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/no_swap boolean false
 
 # When disk encryption is enabled, skip wiping the partitions beforehand.
 #d-i partman-auto-crypto/erase_disks boolean false


### PR DESCRIPTION
Remove our complex partition scheme for VMs and just make one partition. Also eliminates swap.