### PR TITLE
HTREPO-179: add libdbd-mock-perl

### DIFF
--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -39,6 +39,7 @@ class nebula::profile::hathitrust::perl () {
     'libdata-page-perl',
     'libdate-calc-perl',
     'libdate-manip-perl',
+    'libdbd-mock-perl',
     'libdbd-mysql-perl',
     'libdevel-globaldestruction-perl',
     'libdigest-sha-perl',


### PR DESCRIPTION
The previous attempt for this used DBD::Mem, but that module is only available in newer distributions of DBI than what is provided in stretch.

This is a consequence of how the single image validator is tied in to the rest of the ingest code - it still opens a database connection even though it never uses it.