### PR TITLE
AEIM-2027 - Ensure required parent directories exist

### DIFF
--- a/manifests/named_instance/proxy.pp
+++ b/manifests/named_instance/proxy.pp
@@ -67,5 +67,14 @@ define nebula::named_instance::proxy(
   file { "/sysadmin/archive/app-proxies/${title}.conf":
     ensure  => 'present',
     content => template('nebula/named_instance/proxy_vhost.erb'),
+    require => File['/sysadmin/archive/app-proxies'],
   }
+
+  ensure_resource('file', '/sysadmin/archive/app-proxies',
+    {'ensure' => 'directory', 'require' => File['/sysadmin/archive']})
+
+  ensure_resource('file', '/sysadmin/archive',
+    {'ensure' => 'directory', 'require' => File['/sysadmin']})
+
+  ensure_resource('file', '/sysadmin', {'ensure' => 'directory'})
 }

--- a/spec/defines/named_instance/proxy_spec.rb
+++ b/spec/defines/named_instance/proxy_spec.rb
@@ -54,7 +54,32 @@ describe 'nebula::named_instance::proxy' do
       let(:content)      { catalogue.resource('file', proxy_config).send(:parameters)[:content] }
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_file(proxy_config) }
+
+      it do
+        is_expected.to contain_file(proxy_config).with(
+          require: 'File[/sysadmin/archive/app-proxies]',
+        )
+      end
+
+      it do
+        is_expected.to contain_file('/sysadmin/archive/app-proxies').with(
+          ensure: 'directory',
+          require: 'File[/sysadmin/archive]',
+        )
+      end
+
+      it do
+        is_expected.to contain_file('/sysadmin/archive').with(
+          ensure: 'directory',
+          require: 'File[/sysadmin]',
+        )
+      end
+
+      it do
+        is_expected.to contain_file('/sysadmin').with(
+          ensure: 'directory',
+        )
+      end
 
       describe 'access macro' do
         context 'with no whitelisted ips' do


### PR DESCRIPTION
I feel like `/sysadmin/archive` would be better represented as a thing of its own profile and/or something in hiera, but neither is currently needed by anything, and both add complications that I'm not inclined to get into.