### PR TITLE
AEIM-2028 - Add architecture to the local apt source

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -60,9 +60,10 @@ class nebula::profile::apt (
 
     if $local_repo {
       apt::source { 'local':
-        *       => $local_repo,
-        release => $::lsbdistcodename,
-        repos   => 'main',
+        *            => $local_repo,
+        release      => $::lsbdistcodename,
+        repos        => 'main',
+        architecture => $::os['architecture'],
       }
     }
 

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -37,7 +37,7 @@ describe 'nebula::profile::apt' do
         )
       end
 
-      it { is_expected.to contain_apt__source('local') }
+      it { is_expected.to contain_apt__source('local').with_architecture('amd64') }
 
       it do
         is_expected.to contain_apt__source('security').with(
@@ -75,6 +75,7 @@ describe 'nebula::profile::apt' do
 
           it do
             is_expected.to contain_apt__source('local').with(location: 'http://somehost.example.invalid/debs',
+                                                             architecture: 'amd64',
                                                              release: 'stretch',
                                                              key: params[:local_repo]['key'],
                                                              repos: 'main')


### PR DESCRIPTION
It looks like the issue with our local apt repo is that it doesn't have any i386 packages, and for some reason apt expects those to exist even when run on an amd64 computer? Adding `[arch=amd64]` to the sources.list does fix the problem, and this is the code that should add that to the sources.list, although I had to look at the apt module source to be sure, and it's possible we'll need to upgrade to a newer apt module version, but this should prevent apt from trying to grab i386 binaries.