### PR TITLE
AEIM-2055 - Don't create separate directory for app

### DIFF
--- a/manifests/named_instance/app.pp
+++ b/manifests/named_instance/app.pp
@@ -73,7 +73,7 @@ define nebula::named_instance::app (
   # Create the application user's home directory
   file { "/var/local/${title}":
     ensure => 'directory',
-    mode   => '0700',
+    mode   => '2775',
     owner  => $uid,
     group  => $gid,
   }
@@ -86,12 +86,14 @@ define nebula::named_instance::app (
     key    => $pubkey,
   }
 
-  # Create the application directory
-  file { $path:
-    ensure => 'directory',
-    mode   => '2775',
-    owner  => $uid,
-    group  => $gid,
+  # Create the application directory if it is separate
+  if $path != "/var/local/${title}" {
+    file { $path:
+      ensure => 'directory',
+      mode   => '2775',
+      owner  => $uid,
+      group  => $gid,
+    }
   }
 
   # Create the application data directory

--- a/spec/defines/named_instance/app_spec.rb
+++ b/spec/defines/named_instance/app_spec.rb
@@ -107,7 +107,7 @@ describe 'nebula::named_instance::app' do
         let(:home) { "/var/local/#{title}" }
 
         it { is_expected.to contain_file(home).with(ensure: 'directory') }
-        it { is_expected.to contain_file(home).with(mode: '0700') }
+        it { is_expected.to contain_file(home).with(mode: '2775') }
         it { is_expected.to contain_file(home).with(owner: uid) }
         it { is_expected.to contain_file(home).with(group: gid) }
       end
@@ -120,10 +120,26 @@ describe 'nebula::named_instance::app' do
       end
 
       describe 'path' do
-        it { is_expected.to contain_file(path).with(ensure: 'directory') }
-        it { is_expected.to contain_file(path).with(mode: '2775') }
-        it { is_expected.to contain_file(path).with(owner: uid) }
-        it { is_expected.to contain_file(path).with(group: gid) }
+        # We test both variations expressly to make sure that there isn't a
+        # duplicate resource error in the default case where the app is
+        # deployed to the user's home directory.
+        context 'when the app directory is not the user home' do
+          let(:path) { '/some/app/path' }
+
+          it { is_expected.to contain_file(path).with(ensure: 'directory') }
+          it { is_expected.to contain_file(path).with(mode: '2775') }
+          it { is_expected.to contain_file(path).with(owner: uid) }
+          it { is_expected.to contain_file(path).with(group: gid) }
+        end
+
+        context 'when the app directory is the user home' do
+          let(:path) { "/var/local/#{title}" }
+
+          it { is_expected.to contain_file(path).with(ensure: 'directory') }
+          it { is_expected.to contain_file(path).with(mode: '2775') }
+          it { is_expected.to contain_file(path).with(owner: uid) }
+          it { is_expected.to contain_file(path).with(group: gid) }
+        end
       end
 
       describe 'data_path' do


### PR DESCRIPTION
When a named_instance::app should be deployed to the app user's home
directory, do not create a separate file resource.