### PR TITLE
AEIM-2055 - Second pass to fix directory modes

### DIFF
--- a/manifests/named_instance/app.pp
+++ b/manifests/named_instance/app.pp
@@ -73,7 +73,7 @@ define nebula::named_instance::app (
   # Create the application user's home directory
   file { "/var/local/${title}":
     ensure => 'directory',
-    mode   => '2775',
+    mode   => '0755',
     owner  => $uid,
     group  => $gid,
   }
@@ -90,7 +90,7 @@ define nebula::named_instance::app (
   if $path != "/var/local/${title}" {
     file { $path:
       ensure => 'directory',
-      mode   => '2775',
+      mode   => '0755',
       owner  => $uid,
       group  => $gid,
     }
@@ -99,7 +99,7 @@ define nebula::named_instance::app (
   # Create the application data directory
   file { $data_path:
     ensure => 'directory',
-    mode   => '2775',
+    mode   => '0750',
     owner  => $uid,
     group  => $gid,
   }
@@ -107,7 +107,7 @@ define nebula::named_instance::app (
   # Create the application log directory
   file { $log_path:
     ensure => 'directory',
-    mode   => '2775',
+    mode   => '0750',
     owner  => $uid,
     group  => $gid,
   }
@@ -115,7 +115,7 @@ define nebula::named_instance::app (
   # Create the application tmp directory
   file { $tmp_path:
     ensure => 'directory',
-    mode   => '2775',
+    mode   => '0750',
     owner  => $uid,
     group  => $gid,
   }

--- a/spec/defines/named_instance/app_spec.rb
+++ b/spec/defines/named_instance/app_spec.rb
@@ -107,7 +107,7 @@ describe 'nebula::named_instance::app' do
         let(:home) { "/var/local/#{title}" }
 
         it { is_expected.to contain_file(home).with(ensure: 'directory') }
-        it { is_expected.to contain_file(home).with(mode: '2775') }
+        it { is_expected.to contain_file(home).with(mode: '0755') }
         it { is_expected.to contain_file(home).with(owner: uid) }
         it { is_expected.to contain_file(home).with(group: gid) }
       end
@@ -127,7 +127,7 @@ describe 'nebula::named_instance::app' do
           let(:path) { '/some/app/path' }
 
           it { is_expected.to contain_file(path).with(ensure: 'directory') }
-          it { is_expected.to contain_file(path).with(mode: '2775') }
+          it { is_expected.to contain_file(path).with(mode: '0755') }
           it { is_expected.to contain_file(path).with(owner: uid) }
           it { is_expected.to contain_file(path).with(group: gid) }
         end
@@ -136,7 +136,7 @@ describe 'nebula::named_instance::app' do
           let(:path) { "/var/local/#{title}" }
 
           it { is_expected.to contain_file(path).with(ensure: 'directory') }
-          it { is_expected.to contain_file(path).with(mode: '2775') }
+          it { is_expected.to contain_file(path).with(mode: '0755') }
           it { is_expected.to contain_file(path).with(owner: uid) }
           it { is_expected.to contain_file(path).with(group: gid) }
         end
@@ -144,21 +144,21 @@ describe 'nebula::named_instance::app' do
 
       describe 'data_path' do
         it { is_expected.to contain_file(data_path).with(ensure: 'directory') }
-        it { is_expected.to contain_file(data_path).with(mode: '2775') }
+        it { is_expected.to contain_file(data_path).with(mode: '0750') }
         it { is_expected.to contain_file(data_path).with(owner: uid) }
         it { is_expected.to contain_file(data_path).with(group: gid) }
       end
 
       describe 'log_path' do
         it { is_expected.to contain_file(log_path).with(ensure: 'directory') }
-        it { is_expected.to contain_file(log_path).with(mode: '2775') }
+        it { is_expected.to contain_file(log_path).with(mode: '0750') }
         it { is_expected.to contain_file(log_path).with(owner: uid) }
         it { is_expected.to contain_file(log_path).with(group: gid) }
       end
 
       describe 'tmp_path' do
         it { is_expected.to contain_file(tmp_path).with(ensure: 'directory') }
-        it { is_expected.to contain_file(tmp_path).with(mode: '2775') }
+        it { is_expected.to contain_file(tmp_path).with(mode: '0750') }
         it { is_expected.to contain_file(tmp_path).with(owner: uid) }
         it { is_expected.to contain_file(tmp_path).with(group: gid) }
       end


### PR DESCRIPTION
This addresses a problem with the home directory being group writeable.
It also goes back to the notion that we can remove setgid and group
write for the rest of the dirs. It did not end up simplifying to
preserve the 2775.