### PR TITLE
AEIM-1928: cron jobs for atlassian backups

### DIFF
--- a/files/pg_backup
+++ b/files/pg_backup
@@ -1,0 +1,27 @@
+#! /bin/sh
+
+# backup postgres database using the 'custom' archive format
+# which has default compression and allows for the most flexible recovery
+# using pg_restore
+
+DUMP=/usr/bin/pg_dump
+PGDB=$1
+TODAYSBKP=${PGDB}_`date +'%Y%m%d'`.dump
+
+echo "dumping $PGDB database..."
+$DUMP -Fc --create $PGDB > $TODAYSBKP
+
+# only rotate if today's backup exists
+if [ -f $TODAYSBKP ]; then
+  echo "rotating backup files..."
+
+  mv $PGDB.dump.5 $PGDB.dump.6
+  mv $PGDB.dump.4 $PGDB.dump.5
+  mv $PGDB.dump.3 $PGDB.dump.4
+  mv $PGDB.dump.2 $PGDB.dump.3
+  mv $PGDB.dump.1 $PGDB.dump.2
+  mv $PGDB.dump   $PGDB.dump.1
+  mv $TODAYSBKP     $PGDB.dump
+fi
+
+echo "done"

--- a/manifests/profile/tools_lib/confluence.pp
+++ b/manifests/profile/tools_lib/confluence.pp
@@ -19,6 +19,7 @@
 
 class nebula::profile::tools_lib::confluence (
   String $domain,
+  String $mail_recipient,
   String $homedir = '/var/opt/confluence',
   Optional[String] $s3_backup_dest = null
 ) {
@@ -45,10 +46,11 @@ class nebula::profile::tools_lib::confluence (
     ensure_packages(['awscli'])
 
     cron { 'backup confluence xml dump to s3':
-      command => "/usr/bin/aws s3 cp --quiet ${homedir}/backups/backup.zip ${s3_backup_dest}/confluence.zip",
-      user    => 'root',
-      hour    => 3,
-      minute  => 10
+      command     => "/usr/bin/aws s3 cp --quiet ${homedir}/backups/backup.zip ${s3_backup_dest}/confluence.zip",
+      user        => 'root',
+      hour        => 3,
+      minute      => 10,
+      environment => ["MAILTO=${mail_recipient}"];
     }
   }
 

--- a/manifests/profile/tools_lib/postgres.pp
+++ b/manifests/profile/tools_lib/postgres.pp
@@ -4,19 +4,29 @@
 
 # nebula::profile::tools_lib::postgres
 #
-# Configure postgres for tools.lib
+# Configure postgres for tools.lib. Sets up a database both for jira and for
+# confluence, a postgres backup cron job, and cron jobs for shipping the
+# backups to S3 (if configured)
 #
+# @param s3_backup_dest The URL to the S3 bucket where the backups should be
+# deposited, for example s3://my-backups/somewhere. If provided, the postgres
+# database backups will be shipped to this S3 bucket on a daily basis.
+#
+# @param $pg_backup_dir The directory in which postgres backups will be placed.
+
 # @example
 #   include nebula::profile::tools_lib::postgres
 
-class nebula::profile::tools_lib::postgres {
+class nebula::profile::tools_lib::postgres (
+  Optional[String] $s3_backup_dest = null,
+  String $pg_backup_dir = '/var/local/pgbackup'
+) {
   class { 'postgresql::globals':
     encoding => 'UTF-8',
     locale   => 'C.UTF-8',
   }
 
-  class { 'postgresql::server':
-  }
+  include 'postgresql::server'
 
   postgresql::server::db {
     'jira':
@@ -27,4 +37,44 @@ class nebula::profile::tools_lib::postgres {
       user     => 'confluence',
       password => postgresql_password('confluence', lookup('nebula::profile::tools_lib::db::confluence::password')),
   }
+
+  file { $pg_backup_dir:
+    ensure => 'directory',
+    mode   => '2775',
+    owner  => 'root',
+    group  => 'postgres'
+  }
+
+  file { "${pg_backup_dir}/backup":
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/nebula/pg_backup'
+  }
+
+  cron { 'backup postgres databases':
+    command => "cd ${pg_backup_dir} && ( ./backup confluence; ./backup jira ) > pgbackup.log 2>&1",
+    user    => 'postgres',
+    hour    => 0,
+    minute  => 7
+  }
+
+  if($s3_backup_dest) {
+    ensure_packages(['awscli'])
+
+    cron { 'backup postgres confluence dump to s3':
+      command => "/usr/bin/aws s3 cp --quiet ${pg_backup_dir}/confluence.dump ${s3_backup_dest}",
+      user    => 'root',
+      minute  => 10,
+      hour    => 1
+    }
+
+    cron { 'backup postgres jira dump to s3':
+      command => "/usr/bin/aws s3 cp --quiet ${pg_backup_dir}/jira.dump ${s3_backup_dest}",
+      user    => 'root',
+      minute  => 10,
+      hour    => 1
+    }
+  }
+
 }

--- a/manifests/role/tools_lib.pp
+++ b/manifests/role/tools_lib.pp
@@ -18,9 +18,6 @@ class nebula::role::tools_lib (
   class { 'nebula::profile::tools_lib::apache':
     servername => $domain,
   }
-  include nebula::profile::tools_lib::postgres
-
-  include nebula::profile::tools_lib::jdk
 
   # fonts needed for jira and confluence
   package { 'fonts-dejavu-core': }

--- a/manifests/role/tools_lib.pp
+++ b/manifests/role/tools_lib.pp
@@ -11,6 +11,7 @@
 #   include nebula::role::tools_lib
 class nebula::role::tools_lib (
   String $domain,
+  String $mail_recipient
 ) {
 
   include nebula::role::aws
@@ -24,11 +25,13 @@ class nebula::role::tools_lib (
   package { 'fontconfig': }
 
   class { 'nebula::profile::tools_lib::confluence':
-    domain  => $domain,
+    domain         => $domain,
+    mail_recipient =>  $mail_recipient
   }
 
   class { 'nebula::profile::tools_lib::jira':
-    domain  => $domain,
+    domain         => $domain,
+    mail_recipient =>  $mail_recipient
   }
 
 }

--- a/spec/classes/profile/tools_lib/confluence_spec.rb
+++ b/spec/classes/profile/tools_lib/confluence_spec.rb
@@ -10,7 +10,12 @@ describe 'nebula::profile::tools_lib::confluence' do
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { 'spec/fixtures/hiera/tools_lib_config.yaml' }
-      let(:params) { { domain: 'something.whatever.edu' } }
+      let(:params) do
+        {
+          domain: 'something.whatever.edu',
+          mail_recipient: 'nobody@default.invalid',
+        }
+      end
 
       it { is_expected.to contain_class('confluence') }
 

--- a/spec/classes/profile/tools_lib/confluence_spec.rb
+++ b/spec/classes/profile/tools_lib/confluence_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::tools_lib::confluence' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/tools_lib_config.yaml' }
+      let(:params) { { domain: 'something.whatever.edu' } }
+
+      it { is_expected.to contain_class('confluence') }
+
+      context 'with configured s3 backup destination' do
+        let(:params) { super().merge(s3_backup_dest: 's3://somewhere/whatever') }
+
+        it do
+          is_expected.to contain_cron('backup confluence xml dump to s3')
+            .with_command(%r{aws s3 cp .* /var/opt/confluence/backups/backup.zip s3://somewhere/whatever/confluence.zip})
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/tools_lib/jira_spec.rb
+++ b/spec/classes/profile/tools_lib/jira_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::tools_lib::jira' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/tools_lib_config.yaml' }
+      let(:params) { { domain: 'something.whatever.edu' } }
+
+      it { is_expected.to contain_class('jira') }
+
+      context 'with configured s3 backup destination' do
+        let(:params) { super().merge(s3_backup_dest: 's3://somewhere/whatever') }
+
+        it do
+          is_expected.to contain_cron('backup jira xml dump to s3')
+            .with_command(%r{aws s3 cp .* /var/opt/jira/export/`date \+\\%Y\\%m\\%d`.zip s3://somewhere/whatever/jira.zip})
+        end
+
+        it do
+          is_expected.to contain_cron('remove old jira backup')
+            .with_command(%r{rm /var/opt/jira/export/`date \+\\%Y\\%m\\%d`.zip})
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/tools_lib/jira_spec.rb
+++ b/spec/classes/profile/tools_lib/jira_spec.rb
@@ -10,7 +10,12 @@ describe 'nebula::profile::tools_lib::jira' do
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { 'spec/fixtures/hiera/tools_lib_config.yaml' }
-      let(:params) { { domain: 'something.whatever.edu' } }
+      let(:params) do
+        {
+          domain: 'something.whatever.edu',
+          mail_recipient: 'nobody@default.invalid',
+        }
+      end
 
       it { is_expected.to contain_class('jira') }
 

--- a/spec/classes/profile/tools_lib/postgres_spec.rb
+++ b/spec/classes/profile/tools_lib/postgres_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::tools_lib::postgres' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/tools_lib_config.yaml' }
+
+      it { is_expected.to contain_postgresql__server__db('jira') }
+      it { is_expected.to contain_postgresql__server__db('confluence') }
+
+      it { is_expected.to contain_file('/var/local/pgbackup/backup') }
+      it { is_expected.to contain_cron('backup postgres databases').with_command(%r{.*backup.*}) }
+
+      context 'with configured s3 backup destination' do
+        let(:params) { { s3_backup_dest: 's3://somewhere/whatever' } }
+
+        it do
+          is_expected.to contain_cron('backup postgres confluence dump to s3')
+            .with_command(%r{aws s3 cp .* /var/local/pgbackup/confluence.dump s3://somewhere/whatever})
+        end
+
+        it do
+          is_expected.to contain_cron('backup postgres jira dump to s3')
+            .with_command(%r{aws s3 cp .* /var/local/pgbackup/jira.dump s3://somewhere/whatever})
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/hiera/tools_lib.yaml
+++ b/spec/fixtures/hiera/tools_lib.yaml
@@ -1,4 +1,5 @@
 nebula::role::tools_lib::domain: atlassian.example.com
+nebula::role::tools_lib::mail_recipient: nobody@default.invalid
 nebula::profile::ssl_keypair::chain_crt: intermediate_ca.crt
 nebula::profile::tools_lib::db::jira::password: jirapw
 nebula::profile::tools_lib::db::confluence::password: confpw


### PR DESCRIPTION
Adds some documentation to the tools_lib profiles as well.

Moves the includes for postgres & jdk to the confluence & jira profiles,
so that we can test those profiles without the need for a preamble.