### PR TITLE
AEIM-2094 - Put upper bound on puppetlabs/postgresql

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     {"name": "puppetlabs/lvm", "version_requirement": ">= 1.0.1"},
     {"name": "puppetlabs/mysql", "version_requirement": ">= 8.0.0 < 9.0.0"},
     {"name": "puppetlabs/ntp", "version_requirement": ">= 7.4.0 < 8.0.0"},
-    {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1"},
+    {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1 < 6.0.0"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},
     {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 7.0.0"},


### PR DESCRIPTION
There is some dependency conflict with the recent 6.0.0 release of
puppetlabs/postgresql. We did not have an upper bound on our dependency
in metadata.json, and it appears that the Puppetfile.lock did pick up a
hard major version block, so librarian puppet was failing.