### PR TITLE
AEIM-2097: sort the results of nodes_for_class

### DIFF
--- a/lib/puppet/functions/nodes_for_class.rb
+++ b/lib/puppet/functions/nodes_for_class.rb
@@ -15,7 +15,7 @@ Puppet::Functions.create_function(:nodes_for_class) do
                   ['from', 'resources',
                    ['extract', ['certname'],
                     ['=', 'title', capitalize_each_namespace(class_title)]]])
-      .map { |resource| resource['certname'] }
+      .map { |resource| resource['certname'] }.sort
   end
 
   private

--- a/spec/functions/nodes_for_class_spec.rb
+++ b/spec/functions/nodes_for_class_spec.rb
@@ -35,4 +35,14 @@ describe 'nodes_for_class' do
                         .and_return(%w[node_1 node_2 node_3])
     end
   end
+
+  context 'it returns the nodes sorted by name' do
+    let(:class_title) { 'My_role' }
+    let(:nodes) { %w[node_b node_a node_z] }
+
+    it do
+      is_expected.to run.with_params('my_role')
+                        .and_return(%w[node_a node_b node_z])
+    end
+  end
 end


### PR DESCRIPTION
This should keep anything that relies on the output of nodes_for_class
from seeing arbitrary changes in catalogs based on ordering.