### PR TITLE
AEIM-1897: Restrict AFS and human users to roles that need it

### DIFF
--- a/manifests/role/aleph/marcedit.pp
+++ b/manifests/role/aleph/marcedit.pp
@@ -8,6 +8,10 @@
 #   include nebula::role::aleph::marcedit
 class nebula::role::aleph::marcedit {
   include nebula::role::umich
+
+  include nebula::profile::afs
+  include nebula::profile::users
+
   include nebula::profile::apt::mono
   include nebula::profile::apt::yaz
 }

--- a/manifests/role/app_host/dev.pp
+++ b/manifests/role/app_host/dev.pp
@@ -10,6 +10,10 @@
 #   include nebula::role::app_host::dev
 class nebula::role::app_host::dev {
   include nebula::role::umich
+
+  include nebula::profile::afs
+  include nebula::profile::users
+
   include nebula::profile::ruby
   include nebula::profile::nodejs
   include nebula::profile::named_instances

--- a/manifests/role/umich.pp
+++ b/manifests/role/umich.pp
@@ -15,13 +15,11 @@ class nebula::role::umich (
   include nebula::role::minimum
 
   if $facts['os']['release']['major'] == '9' {
-    include nebula::profile::afs
     include nebula::profile::duo
     include nebula::profile::exim4
     include nebula::profile::grub
     include nebula::profile::ntp
     include nebula::profile::tiger
-    include nebula::profile::users
     class { 'nebula::profile::networking':
       bridge => $bridge_network,
       keytab => true

--- a/spec/classes/role/aleph_marcedit_spec.rb
+++ b/spec/classes/role/aleph_marcedit_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::role::aleph::marcedit' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_class('nebula::profile::afs') }
+      it { is_expected.to contain_class('nebula::profile::users') }
+    end
+  end
+end

--- a/spec/classes/role/app_host_dev_spec.rb
+++ b/spec/classes/role/app_host_dev_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::role::app_host::dev' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_class('nebula::profile::afs') }
+      it { is_expected.to contain_class('nebula::profile::users') }
+    end
+  end
+end

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -58,6 +58,9 @@ describe 'nebula::role::webhost::htvm' do
         end
 
         it { is_expected.to contain_class('nebula::profile::networking::firewall') }
+
+        it { is_expected.to contain_class('nebula::profile::afs') }
+        it { is_expected.to contain_class('nebula::profile::users') }
       end
 
       # not specified explicitly as a usergroup, just brought in as part of 'all groups'

--- a/spec/classes/role/umich_spec.rb
+++ b/spec/classes/role/umich_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::role::umich' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it { is_expected.not_to contain_profile('nebula::profile::afs') }
+      it { is_expected.not_to contain_profile('nebula::profile::users') }
+    end
+  end
+end

--- a/spec/classes/role/vmhost_spec.rb
+++ b/spec/classes/role/vmhost_spec.rb
@@ -17,6 +17,9 @@ describe 'nebula::role::vmhost' do
       unless os == 'debian-8-x86_64'
         it { is_expected.to contain_sysctl.with_bridge(true) }
       end
+
+      it { is_expected.not_to contain_class('nebula::profile::afs') }
+      it { is_expected.not_to contain_class('nebula::profile::users') }
     end
   end
 end


### PR DESCRIPTION
- AFS and human users were not installed via puppet on Debian 8 hosts
anyway

- Puppet won't automatically remove AFS & human users anywhere, just not add them in the future to nodes with that role, so we can control the deprovisioning

- This does keep AFS & human users on ht dev mysql for now, where it is not really needed (by virtue of inclusion of AFS & human users on all HT hosts) but we can/should adjust that when that role is fully puppetized.