### PR TITLE
AEIM-2146 - Allow keepalived to bind non-haproxy IPs

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -11,6 +11,7 @@ class nebula::profile::haproxy(
   Hash $monitoring_user,
   Boolean $master = false,
   Optional[String] $cert_source = undef,
+  Hash $extra_floating_ips = {},
 ) {
   include nebula::profile::haproxy::prereqs
   include nebula::profile::networking::sysctl

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -213,6 +213,17 @@ describe 'nebula::profile::haproxy' do
           end
         end
 
+        context 'with an extra_floating_ip set to 10.0.1.2' do
+          let(:params) do
+            { extra_floating_ips: { 'extra' => '10.0.1.2' } }
+          end
+
+          it do
+            is_expected.to contain_concat_fragment('keepalived preamble')
+              .with_content(%r{virtual_ipaddress {\n\s*10\.0\.1\.2\n\s*}}m)
+          end
+        end
+
         it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{unicast_src_ip #{my_ip}}) }
 
         it 'exports its IP address for collection by other haproxy nodes' do

--- a/templates/profile/haproxy/keepalived/keepalived_pre.erb
+++ b/templates/profile/haproxy/keepalived/keepalived_pre.erb
@@ -30,6 +30,9 @@ vrrp_instance haproxy {
     <%- @services.each do |_,service| -%>
       <%= service["floating_ip"] %>
     <%- end -%>
+    <%- @extra_floating_ips.each do |_,floating_ip| -%>
+      <%= floating_ip %>
+    <%- end -%>
   }
 
   unicast_src_ip <%= @networking["ip"] %>


### PR DESCRIPTION
This way, we can experiment with alternative HAProxy configurations
before we codify them into puppet formally. Puppet has to manage the
floating IPs because it manages the keepalived config file already.

Without this commit, the only way to get keepalived to bind a floating
IP address was to set up an HAProxy HTTP/S service, which isn't always
what's needed. In the long term, this parameter should be considered a
smell, since it implies some hand-crafted HAProxy configuration that has
yet to be folded into puppet.