### PR TITLE
Use ftp.us.debian.org instead of debian.uchicago.edu

### DIFF
--- a/templates/virtual_machine/stretch.cfg.erb
+++ b/templates/virtual_machine/stretch.cfg.erb
@@ -98,7 +98,7 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string US
-d-i mirror/http/mirror string debian.uchicago.edu
+d-i mirror/http/mirror string ftp.us.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 


### PR DESCRIPTION
This was causing an error message to appear when creating vms anytime uchicago was down, which doesn't break anything, but it does require manual intervention, so I've switched it to the generic mirror.