### PR TITLE
PFDR-178: get chipmunk role working

### DIFF
--- a/manifests/profile/geoip.pp
+++ b/manifests/profile/geoip.pp
@@ -17,8 +17,8 @@
 #     user_id        => '12345
 #   }
 class nebula::profile::geoip (
-  String $license_key,
-  String $user_id,
+  String $license_key = 'CHANGEME',
+  String $user_id = 'CHANGEME',
   # MaxMind GeoIP Country
   String $product_id = '106'
 ) {

--- a/manifests/profile/hathitrust/dependencies.pp
+++ b/manifests/profile/hathitrust/dependencies.pp
@@ -11,7 +11,7 @@
 class nebula::profile::hathitrust::dependencies () {
   include nebula::profile::imagemagick
 
-  package {
+  ensure_packages (
     [
       'git',
       'libjs-jquery',
@@ -21,8 +21,8 @@ class nebula::profile::hathitrust::dependencies () {
       'netpbm-sf',
       'kakadu',
       'rsync'
-    ]:
-  }
+    ]
+  )
 
   file { '/l/local':
     ensure => 'directory'

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::role::chipmunk' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
adds default parameters for geoip username & license key so it can be
installed but (effectively) unconfigured. the alternative would be
setting it in the specs in hiera, but it makes no sense to force a hiera
configuration for a component we don't even use for chipmunk. longer
term it would be better to include only the dependencies we actually
need for feed.