### PR TITLE
Pfdr 225/mysql redis

### DIFF
--- a/manifests/profile/mysql.pp
+++ b/manifests/profile/mysql.pp
@@ -1,0 +1,25 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+#
+# nebula::profile::mysql
+#
+# @param password The root password, as stored by root's .my.cnf.
+class nebula::profile::mysql (
+  String $password
+) {
+
+  # Install and configure mysql server
+  class { 'mysql::server':
+    create_root_user        => true,
+    create_root_my_cnf      => true,
+    root_password           => $password,
+    remove_default_accounts => true,
+  }
+
+  # Install the mysql client
+  class { 'mysql::client':
+    bindings_enable => false
+  }
+
+}

--- a/manifests/profile/redis.pp
+++ b/manifests/profile/redis.pp
@@ -1,0 +1,9 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+#
+# nebula::profile::redis
+#
+class nebula::profile::redis {
+  package { 'redis-server': }
+}

--- a/manifests/role/chipmunk.pp
+++ b/manifests/role/chipmunk.pp
@@ -2,4 +2,6 @@ class nebula::role::chipmunk {
   include nebula::role::app_host::prod
   include nebula::profile::hathitrust::dependencies
   include nebula::profile::hathitrust::perl
+  include nebula::profile::mysql
+  include nebula::profile::redis
 }

--- a/spec/classes/profile/mysql_spec.rb
+++ b/spec/classes/profile/mysql_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::mysql' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) { { password: 'some_password' } }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/profile/redis_spec.rb
+++ b/spec/classes/profile/redis_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::redis' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -10,6 +10,7 @@ dmi: {}
 installed_backports: []
 datacenter: "mydatacenter"
 mountpoints: {}
+root_home: "/root"
 
 # required by camptocamp/kmod 2.1.0
 augeasversion: '1.4.0'


### PR DESCRIPTION
Adds a profile for each of mysql and redis, and adds them to the app_host::dev and app_host::prod roles only.