### PR TITLE
AEIM-2162 / PFDR-178: configuration for standalone apache server

### DIFF
--- a/manifests/profile/named_instances/apache.pp
+++ b/manifests/profile/named_instances/apache.pp
@@ -1,0 +1,45 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::named_instances::apache
+#
+# Configure Apache to serve applications via mod_proxy
+# This does not configure any virtual hosts.
+#
+# @example
+#   include nebula::profile::named_instances::apache
+
+class nebula::profile::named_instances::apache (
+  $ssl_cn = $::fqdn
+) {
+
+  class { 'nebula::profile::ssl_keypair':
+    common_name => $ssl_cn
+  }
+
+  class { 'apache':
+    default_mods      => false,
+    default_vhost     => false,
+    default_ssl_vhost => false,
+    purge_vhost_dir   => false
+  }
+
+  apache::mod { 'access_compat': }
+  # apache::mod { 'authz_host': }
+  include apache::mod::proxy
+  include apache::mod::proxy_http
+  include apache::mod::headers
+  include apache::mod::ssl
+  include apache::mod::rewrite
+  include apache::mod::setenvif
+
+  apache::mod { 'cosign':
+    package => 'libapache2-mod-cosign'
+  }
+
+  apache::listen { ['80','443']: }
+
+  include nebula::profile::networking::firewall::http_datacenters
+
+}

--- a/manifests/profile/named_instances/apache.pp
+++ b/manifests/profile/named_instances/apache.pp
@@ -18,6 +18,17 @@ class nebula::profile::named_instances::apache (
     common_name => $ssl_cn
   }
 
+  file { '/etc/ssl/chain':
+    ensure  => 'directory',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    recurse => true,
+    purge   => true,
+    links   => 'manage',
+    source  => 'puppet:///ssl-certs/chain'
+  }
+
   class { 'apache':
     default_mods      => false,
     default_vhost     => false,

--- a/manifests/role/app_host/standalone.pp
+++ b/manifests/role/app_host/standalone.pp
@@ -1,0 +1,22 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::role::app_host::prod
+#
+# Standalone application host including apache & mysql
+#
+# @example
+#   include nebula::role::app_host::standalone
+class nebula::role::app_host::standalone {
+  include nebula::role::umich
+
+  include nebula::profile::ruby
+  include nebula::profile::nodejs
+
+  include nebula::profile::named_instances
+  include nebula::profile::named_instances::apache
+
+  include nebula::profile::mysql
+  include nebula::profile::redis
+}

--- a/manifests/role/chipmunk.pp
+++ b/manifests/role/chipmunk.pp
@@ -1,7 +1,10 @@
 class nebula::role::chipmunk {
-  include nebula::role::app_host::prod
+  include nebula::role::app_host::standalone
+
   include nebula::profile::hathitrust::dependencies
   include nebula::profile::hathitrust::perl
-  include nebula::profile::mysql
-  include nebula::profile::redis
+
+  # should be conditionally included from named_instances::apache when the
+  # vhost config is deployed on the web node
+  include apache::mod::xsendfile
 }

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -4,10 +4,13 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
+require_relative '../../support/contexts/with_mocked_nodes'
 
 describe 'nebula::role::chipmunk' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      include_context 'with mocked query for nodes in other datacenters'
+
       let(:facts) { os_facts }
       let(:hiera_config) { 'spec/fixtures/hiera/chipmunk_config.yaml' }
 

--- a/spec/fixtures/hiera/chipmunk.yaml
+++ b/spec/fixtures/hiera/chipmunk.yaml
@@ -1,1 +1,2 @@
 nebula::profile::mysql::password: changeme
+nebula::profile::ssl_keypair::chain_crt: intermediate_ca.crt


### PR DESCRIPTION
- Doesn't deploy any vhost config; you still need to manually put it in place
- Breaks up standalone apache / app server and chipmunk-specific stuff