### PR TITLE
AEIM-2180: set GSSAPIAuthenticationYes only if keytab file exists

### DIFF
--- a/manifests/profile/afs.pp
+++ b/manifests/profile/afs.pp
@@ -32,6 +32,9 @@ class nebula::profile::afs (
   String  $cell,
   String  $realm,
 ) {
+
+  include nebula::profile::networking::keytab
+
   if nebula::date_is_in_the_future($allow_auto_reboot_until) {
     reboot { 'afs':
       apply     => 'finished',

--- a/manifests/profile/networking.pp
+++ b/manifests/profile/networking.pp
@@ -15,23 +15,13 @@
 
 class nebula::profile::networking (
   Boolean $bridge = false,
-  Boolean $keytab = false,
 ) {
 
   class { 'nebula::profile::networking::sysctl':
     bridge => $bridge,
   }
 
-  if $keytab {
-    include nebula::profile::networking::keytab
-    class { 'nebula::profile::networking::sshd':
-      gssapi_auth => true,
-    }
-  } else {
-    class { 'nebula::profile::networking::sshd':
-      gssapi_auth => false,
-    }
-  }
+  include nebula::profile::networking::sshd
 
   # Fix AEIM-1064. This prevents `systemctl is-active` from returning
   # a false negative when either of these is unmasked.

--- a/manifests/profile/networking/sshd.pp
+++ b/manifests/profile/networking/sshd.pp
@@ -13,8 +13,11 @@
 #   include nebula::profile::networking::sshd
 class nebula::profile::networking::sshd (
   Array[String] $whitelist,
-  Boolean       $gssapi_auth = false,
 ) {
+
+  # This will do nothing if the keytab doesn't exist
+  include nebula::profile::networking::keytab
+  $gssapi_auth = defined(File['/etc/krb5.keytab'])
 
   service { 'sshd':
     ensure     => 'running',

--- a/manifests/role/aws.pp
+++ b/manifests/role/aws.pp
@@ -18,7 +18,6 @@ class nebula::role::aws {
     include nebula::profile::tiger
     class { 'nebula::profile::networking':
       bridge => false,
-      keytab => false
     }
   }
 

--- a/manifests/role/hathitrust.pp
+++ b/manifests/role/hathitrust.pp
@@ -20,7 +20,6 @@ class nebula::role::hathitrust {
     include nebula::profile::users
     class { 'nebula::profile::networking':
       bridge => false,
-      keytab => true
     }
   }
 

--- a/manifests/role/umich.pp
+++ b/manifests/role/umich.pp
@@ -22,7 +22,6 @@ class nebula::role::umich (
     include nebula::profile::tiger
     class { 'nebula::profile::networking':
       bridge => $bridge_network,
-      keytab => true
     }
   }
 

--- a/spec/classes/profile/networking/sshd_spec.rb
+++ b/spec/classes/profile/networking/sshd_spec.rb
@@ -58,8 +58,23 @@ describe 'nebula::profile::networking::sshd' do
         end
       end
 
-      context 'when gssapi_auth is true' do
-        let(:params) { { gssapi_auth: true } }
+      context 'with no keytab' do
+        it do
+          is_expected.not_to contain_sshd.with_content(
+            %r{^GSSAPIAuthentication yes$}m,
+          )
+        end
+      end
+
+      context 'with a keytab' do
+        let(:pre_condition) do
+          <<~EOT
+            class { 'nebula::profile::networking::keytab':
+              keytab => 'nebula/keytab.fake',
+              keytab_source => 'alternate source'
+            }
+          EOT
+        end
 
         it do
           is_expected.to contain_sshd.with_content(

--- a/spec/classes/profile/networking_spec.rb
+++ b/spec/classes/profile/networking_spec.rb
@@ -14,36 +14,16 @@ describe 'nebula::profile::networking' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'when keytab==false, bridge==false' do
-        let(:params) { { keytab: false, bridge: false } }
+      context 'when bridge==false' do
+        let(:params) { { bridge: false } }
 
         it { is_expected.to contain_network_class('sysctl').with_bridge(false) }
-        it { is_expected.not_to contain_network_class('keytab') }
-        it { is_expected.to contain_network_class('sshd').with_gssapi_auth(false) }
       end
 
-      context 'when keytab==true, bridge==false' do
-        let(:params) { { keytab: true, bridge: false } }
-
-        it { is_expected.to contain_network_class('sysctl').with_bridge(false) }
-        it { is_expected.to contain_network_class('keytab') }
-        it { is_expected.to contain_network_class('sshd').with_gssapi_auth(true) }
-      end
-
-      context 'when keytab==false, bridge==true' do
-        let(:params) { { keytab: false, bridge: true } }
+      context 'when bridge==true' do
+        let(:params) { { bridge: true } }
 
         it { is_expected.to contain_network_class('sysctl').with_bridge(true) }
-        it { is_expected.not_to contain_network_class('keytab') }
-        it { is_expected.to contain_network_class('sshd').with_gssapi_auth(false) }
-      end
-
-      context 'when keytab==true, bridge==true' do
-        let(:params) { { keytab: true, bridge: true } }
-
-        it { is_expected.to contain_network_class('sysctl').with_bridge(true) }
-        it { is_expected.to contain_network_class('keytab') }
-        it { is_expected.to contain_network_class('sshd').with_gssapi_auth(true) }
       end
 
       # This is an ugly hack for fixing AEIM-1064. See base.pp for


### PR DESCRIPTION
On Ubuntu, there are ssh errors with the GSSAPI authentication method if
the keytab file isn't actually there, and in general advertising that
method only leads to confusion if it doesn't actually work.

This change:

- always includes the keytab profile (it is a no-op if there is no
actual keytab file to install)

- only sets GSSAPIAuthentication Yes if the keytab profile installed a
keytab