### PR TITLE
Apply necessary updates for migrating from jessie to stretch

### DIFF
--- a/manifests/profile/duo.pp
+++ b/manifests/profile/duo.pp
@@ -24,12 +24,22 @@ class nebula::profile::duo (
   package { 'sudo': }
   package { 'libpam-duo': }
 
+  package { 'duo-unix':
+    ensure => absent
+  }
+
   ['sshd', 'sudo'].each |$pamfile| {
     file_line { "/etc/pam.d/${pamfile}: pam_duo":
       path    => "/etc/pam.d/${pamfile}",
       line    => 'auth required pam_duo.so',
       after   => '^@include common-auth',
       require => Package['sudo', 'libpam-duo'],
+    }
+
+    file_line { "/etc/pam.d/${pamfile}: remove /lib64/security/pam_duo":
+      ensure => absent,
+      path   => "/etc/pam.d/${pamfile}",
+      line   => 'auth required /lib64/security/pam_duo.so'
     }
   }
 

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -15,6 +15,12 @@ class nebula::profile::networking::firewall ( Hash $rules = {} ) {
   # Include standard SSH rules by default
   include nebula::profile::networking::firewall::ssh
 
+  package { ['netfilter-persistent','iptables-persistent']: }
+
+  package { 'lokkit':
+    ensure => absent
+  }
+
   resources { 'firewall':
     purge => true,
   }

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -57,6 +57,9 @@ describe 'nebula::profile::networking::firewall' do
       end
 
       it { is_expected.to have_firewall_resource_count(5) }
+
+      it { is_expected.to contain_package('iptables-persistent') }
+      it { is_expected.to contain_package('netfilter-persistent') }
     end
   end
 end


### PR DESCRIPTION
- Removes old duo package & declaration in pam.d
- Ensures that packages that would have been installed on a fresh stretch machine are present (and removes lokkit)

Because it uses `ensure => absent` rather than `ensure => purge`, the config files for duo and lokkit will be left in place so that settings can be migrated if necessary.