### PR TITLE
Prometheus plus node exporters

### DIFF
--- a/lib/puppet/functions/lookup_role.rb
+++ b/lib/puppet/functions/lookup_role.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+Puppet::Functions.create_function(:lookup_role) do
+  dispatch :run do
+    return_type 'String'
+  end
+
+  def run
+    case hiera_role
+    when 'nebula::role::aws::auto'
+      ec2_tag_role
+    else
+      hiera_role
+    end
+  end
+
+  def hiera_role
+    @hiera_role ||= call_function('lookup', 'role')
+  end
+
+  def ec2_tag_role
+    @ec2_tag_role ||= closure_scope['facts']['ec2_tag_role']
+    @ec2_tag_role ||= hiera_role
+  end
+end

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -1,0 +1,64 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::prometheus (
+  Array $alert_managers = [],
+  String $version = 'latest',
+) {
+  include nebula::profile::docker
+
+  docker::run { 'prometheus':
+    image            => "prom/prometheus:${version}",
+    net              => 'host',
+    extra_parameters => ['--restart=always'],
+    volumes          => [
+      '/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml',
+      '/etc/prometheus/rules.yml:/etc/prometheus/rules.yml',
+      '/etc/prometheus/nodes.yml:/etc/prometheus/nodes.yml',
+      '/opt/prometheus:/prometheus',
+    ],
+    require          => File['/opt/prometheus'],
+  }
+
+  file { '/etc/prometheus/prometheus.yml':
+    content => template('nebula/profile/prometheus/config.yml.erb'),
+    notify  => Docker::Run['prometheus'],
+  }
+
+  file { '/etc/prometheus/rules.yml':
+    content => template('nebula/profile/prometheus/rules.yml.erb'),
+    notify  => Docker::Run['prometheus'],
+  }
+
+  concat_file { '/etc/prometheus/nodes.yml':
+    notify  => Docker::Run['prometheus'],
+    require => File['/etc/prometheus'],
+  }
+
+  Concat_fragment <<| tag == "${::datacenter}_prometheus_node_service_list" |>>
+
+  file { '/etc/prometheus':
+    ensure => 'directory',
+  }
+
+  file { '/opt/prometheus':
+    ensure => 'directory',
+    owner  => 65534,
+    group  => 65534,
+  }
+
+  nebula::exposed_port { '010 Prometheus HTTP':
+    port  => 9090,
+    block => 'umich::networks::all_trusted_machines',
+  }
+
+  @@firewall { "010 prometheus node exporter ${::hostname}":
+    tag    => "${::datacenter}_prometheus_node_exporter",
+    proto  => 'tcp',
+    dport  => 9100,
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
+  }
+}

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -6,16 +6,6 @@ class nebula::profile::prometheus::exporter::node (
   Array $covered_datacenters = [],
   String $default_datacenter = 'default',
 ) {
-  case lookup('role') {
-    'nebula::role::aws::auto': {
-      $role = pick($::ec2_tag_role, 'nebula::role::aws::auto')
-    }
-
-    default: {
-      $role = lookup('role')
-    }
-  }
-
   file { '/etc/default/prometheus-node-exporter':
     content => template('nebula/profile/prometheus/exporter/node.sh.erb'),
     notify  => Service['prometheus-node-exporter'],
@@ -24,6 +14,8 @@ class nebula::profile::prometheus::exporter::node (
 
   service { 'prometheus-node-exporter': }
   package { 'prometheus-node-exporter': }
+
+  $role = lookup_role()
 
   if $::datacenter in $covered_datacenters {
     $monitoring_datacenter = $::datacenter

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::prometheus::exporter::node (
+  Array $covered_datacenters = [],
+  String $default_datacenter = 'default',
+) {
+  case lookup('role') {
+    'nebula::role::aws::auto': {
+      $role = pick($::ec2_tag_role, 'nebula::role::aws::auto')
+    }
+
+    default: {
+      $role = lookup('role')
+    }
+  }
+
+  file { '/etc/default/prometheus-node-exporter':
+    content => template('nebula/profile/prometheus/exporter/node.sh.erb'),
+    notify  => Service['prometheus-node-exporter'],
+    require => Package['prometheus-node-exporter'],
+  }
+
+  service { 'prometheus-node-exporter': }
+  package { 'prometheus-node-exporter': }
+
+  if $::datacenter in $covered_datacenters {
+    $monitoring_datacenter = $::datacenter
+  } else {
+    $monitoring_datacenter = $default_datacenter
+  }
+
+  @@concat_fragment { "prometheus node service ${::hostname}":
+    tag     => "${monitoring_datacenter}_prometheus_node_service_list",
+    target  => '/etc/prometheus/nodes.yml',
+    content => "- targets: [ '${::fqdn}:9100' ]\n  labels: { role: '${role}' }\n",
+  }
+
+  Firewall <<| tag == "${monitoring_datacenter}_prometheus_node_exporter" |>>
+}

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -34,7 +34,7 @@ class nebula::profile::prometheus::exporter::node (
   @@concat_fragment { "prometheus node service ${::hostname}":
     tag     => "${monitoring_datacenter}_prometheus_node_service_list",
     target  => '/etc/prometheus/nodes.yml',
-    content => "- targets: [ '${::fqdn}:9100' ]\n  labels: { role: '${role}' }\n",
+    content => "- targets: [ '${::ipaddress}:9100' ]\n  labels: { role: '${role}', hostname: '${::hostname}' }\n",
   }
 
   Firewall <<| tag == "${monitoring_datacenter}_prometheus_node_exporter" |>>

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -21,6 +21,7 @@ class nebula::role::minimum (
       include nebula::profile::apt
       include nebula::profile::authorized_keys
       include nebula::profile::vim
+      include nebula::profile::prometheus::exporter::node
     }
   }
 }

--- a/manifests/role/prometheus.pp
+++ b/manifests/role/prometheus.pp
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# Prometheus for hardware monitoring
+class nebula::role::prometheus ()
+{
+  include nebula::role::minimal_docker
+  include nebula::profile::prometheus
+}

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -23,7 +23,7 @@ describe 'nebula::profile::prometheus::exporter::node' do
         expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
           .with_tag('default_prometheus_node_service_list')
           .with_target('/etc/prometheus/nodes.yml')
-          .with_content("- targets: [ '#{facts[:fqdn]}:9100' ]\n  labels: { role: 'invalid_role' }\n")
+          .with_content("- targets: [ '#{facts[:ipaddress]}:9100' ]\n  labels: { role: 'invalid_role', hostname: '#{facts[:hostname]}' }\n")
       end
 
       context 'when our datacenter is covered' do

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::prometheus::exporter::node' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it do
+        is_expected.to contain_file('/etc/default/prometheus-node-exporter')
+          .that_notifies('Service[prometheus-node-exporter]')
+          .that_requires('Package[prometheus-node-exporter]')
+      end
+
+      it { is_expected.to contain_service('prometheus-node-exporter') }
+      it { is_expected.to contain_package('prometheus-node-exporter') }
+
+      it "exports itself to the default datacenter's service discovery" do
+        expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+          .with_tag('default_prometheus_node_service_list')
+          .with_target('/etc/prometheus/nodes.yml')
+          .with_content("- targets: [ '#{facts[:fqdn]}:9100' ]\n  labels: { role: 'invalid_role' }\n")
+      end
+
+      context 'when our datacenter is covered' do
+        let(:params) { { covered_datacenters: %w[mydatacenter] } }
+
+        it "exports itself to its datacenter's service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+            .with_tag('mydatacenter_prometheus_node_service_list')
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::prometheus' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_docker__run('prometheus')
+          .with_image('prom/prometheus:latest')
+          .with_net('host')
+          .with_extra_parameters(%w[--restart=always])
+          .with_volumes(['/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml',
+                         '/etc/prometheus/rules.yml:/etc/prometheus/rules.yml',
+                         '/etc/prometheus/nodes.yml:/etc/prometheus/nodes.yml',
+                         '/opt/prometheus:/prometheus'])
+          .that_requires('File[/opt/prometheus]')
+      end
+
+      context 'with version set to v2.11.1' do
+        let(:params) { { version: 'v2.11.1' } }
+
+        it do
+          is_expected.to contain_docker__run('prometheus')
+            .with_image('prom/prometheus:v2.11.1')
+        end
+      end
+
+      it do
+        is_expected.to contain_file('/etc/prometheus/prometheus.yml')
+          .that_notifies('Docker::Run[prometheus]')
+          .that_requires('File[/etc/prometheus]')
+      end
+
+      it do
+        is_expected.to contain_file('/etc/prometheus/rules.yml')
+          .that_notifies('Docker::Run[prometheus]')
+          .that_requires('File[/etc/prometheus]')
+      end
+
+      it do
+        is_expected.to contain_concat_file('/etc/prometheus/nodes.yml')
+          .that_notifies('Docker::Run[prometheus]')
+          .that_requires('File[/etc/prometheus]')
+      end
+
+      it do
+        is_expected.to contain_file('/etc/prometheus')
+          .with_ensure('directory')
+      end
+
+      it do
+        is_expected.to contain_file('/opt/prometheus')
+          .with_ensure('directory')
+          .with_owner(65_534)
+          .with_group(65_534)
+      end
+
+      it do
+        is_expected.to contain_nebula__exposed_port('010 Prometheus HTTP')
+          .with_port(9090)
+          .with_block('umich::networks::all_trusted_machines')
+      end
+
+      it 'exports a firewall so that nodes can open 9100' do
+        expect(exported_resources).to contain_firewall("010 prometheus node exporter #{facts[:hostname]}")
+          .with_tag('mydatacenter_prometheus_node_exporter')
+          .with_proto('tcp')
+          .with_dport(9100)
+          .with_source(facts[:ipaddress])
+          .with_state('NEW')
+          .with_action('accept')
+      end
+    end
+  end
+end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -2,6 +2,8 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 ---
+role: invalid_role
+
 nebula::root_email: root@default.invalid
 nebula::puppetmaster: puppetmaster.default.invalid
 nebula::puppetdb: puppetdb.default.invalid

--- a/spec/fixtures/hiera/role_is_aws_auto.yaml
+++ b/spec/fixtures/hiera/role_is_aws_auto.yaml
@@ -1,0 +1,1 @@
+role: nebula::role::aws::auto

--- a/spec/fixtures/hiera/role_is_aws_auto_config.yaml
+++ b/spec/fixtures/hiera/role_is_aws_auto_config.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - role_is_aws_auto
+  - default
+:yaml:
+  :datadir: 'spec/fixtures/hiera'

--- a/spec/fixtures/hiera/role_is_my_role.yaml
+++ b/spec/fixtures/hiera/role_is_my_role.yaml
@@ -1,0 +1,1 @@
+role: my_role

--- a/spec/fixtures/hiera/role_is_my_role_config.yaml
+++ b/spec/fixtures/hiera/role_is_my_role_config.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - role_is_my_role
+  - default
+:yaml:
+  :datadir: 'spec/fixtures/hiera'

--- a/spec/functions/lookup_role_spec.rb
+++ b/spec/functions/lookup_role_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'lookup_role' do
+  context 'when the role is my_role' do
+    let(:hiera_config) { 'spec/fixtures/hiera/role_is_my_role_config.yaml' }
+
+    it { is_expected.to run.and_return('my_role') }
+  end
+
+  context 'when the role is nebula::role::aws::auto' do
+    let(:hiera_config) { 'spec/fixtures/hiera/role_is_aws_auto_config.yaml' }
+
+    it { is_expected.to run.and_return('nebula::role::aws') }
+  end
+end

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -1,0 +1,22 @@
+# Managed by puppet (nebula/profile/prometheus/config.yml.erb)
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+rule_files:
+- rules.yml
+<% unless @alert_managers.empty? -%>
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+<% @alert_managers.each do |alert_manager| -%>
+      - <%= @alert_manager %>
+<% end -%>
+<% end -%>
+scrape_configs:
+- job_name: prometheus
+  static_configs:
+  - targets: [ localhost:9090 ]
+- job_name: node
+  file_sd_configs:
+  - files: [ nodes.yml ]

--- a/templates/profile/prometheus/exporter/node.sh.erb
+++ b/templates/profile/prometheus/exporter/node.sh.erb
@@ -1,0 +1,4 @@
+# Managed by puppet (nebula/profile/prometheus/exporter/node.sh.erb)
+ARGS="-collector.diskstats.ignored-devices=^(ram|loop|fd)\d+$ \
+      -collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/) \
+      -collector.textfile.directory=/var/lib/prometheus/node-exporter"

--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -1,0 +1,10 @@
+# Managed by puppet (nebula/profile/prometheus/rules.yml.erb)
+groups:
+- name: hardware
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 1m
+  - alert: DiskPressure
+    expr: '((node_filesystem_size - node_filesystem_avail) / node_filesystem_size) > .95'
+    for: 1m


### PR DESCRIPTION
This will affect every non-jessie node we have (that's being managed by puppet at least). This will run `apt-get install prometheus-node-exporter` and will open a port to the Prometheus server at its datacenter (if there is one).

Other than that, the purpose here is to set us up with a Prometheus server at each datacenter, with every node giving it basic hardware monitoring data.

Out of scope is setting up the alert manager and figuring out how best to aggregate everything into such as a pretty dashboard. The alert manager and dashboards are pieces of this that I think would fit well in kubernetes (as well as monitoring other details such as Apache)—but the basic hardware monitoring is definitely easiest to set up through puppet.