### PR TITLE
Mashup dev app host with private networking

### DIFF
--- a/manifests/role/app_host/dev_private.pp
+++ b/manifests/role/app_host/dev_private.pp
@@ -1,0 +1,16 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::role::app_host::dev_private
+#
+# Application host (development or development-like, with private network configured).
+#
+# Be sure to set the networking::private details for the host in hiera.
+#
+# @example
+#   include nebula::role::app_host::prod_private
+class nebula::role::app_host::dev_private {
+  include nebula::role::app_host::dev
+  include nebula::profile::networking::private
+}


### PR DESCRIPTION
Continues to point to the need for dependency injection based on data
from hiera

trivial PR based on production app host with private networking