### PR TITLE
AEIM-2328 - Default puma bind address to all interfaces

### DIFF
--- a/manifests/named_instance.pp
+++ b/manifests/named_instance.pp
@@ -50,7 +50,7 @@ define nebula::named_instance(
   String        $data_path = "${path}/data",
   String        $log_path = "${path}/log",
   String        $tmp_path = "${path}/tmp",
-  String        $bind_address = 'localhost',
+  String        $bind_address = '0.0.0.0',
   String        $mysql_host = 'localhost',
   Optional[String] $mysql_user = undef,
   Optional[String] $mysql_password = undef,

--- a/spec/defines/named_instance_spec.rb
+++ b/spec/defines/named_instance_spec.rb
@@ -201,7 +201,7 @@ describe 'nebula::named_instance' do
             'deploy.env'                        => '{"deploy":{"env":{"rack_env":"production","rails_env":"production"}}}',
             'deploy.systemd_services'           => '{"deploy":{"systemd_services":["minimal-instance.target"]}}',
             'deploy.sites.user'                 => '{"deploy":{"sites":{"user":"minimal-instance"}}}',
-            'infrastructure.bind'               => '{"infrastructure":{"bind":"tcp://localhost:3001"}}',
+            'infrastructure.bind'               => '{"infrastructure":{"bind":"tcp://0.0.0.0:3001"}}',
           }.each do |fragment_title, content|
             describe fragment_title do
               it "sets #{content}" do

--- a/templates/named_instance/puma.service.erb
+++ b/templates/named_instance/puma.service.erb
@@ -16,6 +16,7 @@ UMask=0002
 User=<%= @title %>
 Group=<%= @title %>
 Environment="RBENV_ROOT=<%= @rbenv_root %>"
+Environment="RACK_ENV=production"
 Environment="RAILS_ENV=production"
 WorkingDirectory=<%= @path -%>/current
 ExecStart=<%= @puma_wrapper %>


### PR DESCRIPTION
This is a better default than localhost for most of our configurations,
allowing separate web and app server nodes with less messing around
after the fact.