### PR TITLE
Add adoptopenjdk repository everywhere

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -95,6 +95,16 @@ class nebula::profile::apt (
       }
     }
 
+    apt::source { 'adoptopenjdk':
+      location => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/',
+      release  => $::lsbdistcodename,
+      repos    => 'main',
+      key      => {
+        'id'     => '8ED17AF5D7E675EB3EE3BCE98AC3B29174885C03',
+        'source' => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public'
+      }
+    }
+
     apt::source { 'puppet':
       location => 'http://apt.puppetlabs.com',
       repos    => $puppet_repo,


### PR DESCRIPTION
The packages don't clash with the Debian openjdk packages, so this should be safe to add everywhere.

At least on jessie, we will probably want to use the adoptopenjdk8 package rather than the (no longer maintained) openjdk8 from backports.