### PR TITLE
AEIM-1663: Configure TSM via puppet

### DIFF
--- a/files/tsm/tsm.service
+++ b/files/tsm/tsm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Tivoli Storage Manager Client
+After=network.target
+
+[Service]
+Type=simple
+Environment="LANG=en_US.UTF-8"
+Environment="LC_CTYPE=en_US.UTF-8"
+Environment="LC_ALL=en_US.UTF-8"
+ExecStart=/usr/bin/dsmc sched
+RemainAfterExit=no
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/manifests/profile/tsm.pp
+++ b/manifests/profile/tsm.pp
@@ -36,7 +36,7 @@ class nebula::profile::tsm (
   String $serveraddress,
   Boolean $encryption = false,
   Integer $port = 1510,
-  Array[String] $inclexcl = [],
+  Array[String] $inclexcl = ['exclude /.../.nfs*', 'exclude.dir /.../.snapshot'],
   Array[String] $domains = ['/etc','/opt','/var'],
   Array[String] $virtualmountpoints = ['/etc','/opt','/var'],
   Array[String] $exclude_dirs = ['/afs/','/net/','/nfs/','/usr/vice/cache/']

--- a/manifests/profile/tsm.pp
+++ b/manifests/profile/tsm.pp
@@ -37,40 +37,40 @@ class nebula::profile::tsm (
   Boolean $encryption = false,
   Integer $port = 1510,
   Array[String] $inclexcl = [],
-  Array[String] $domains = ["/etc","/opt","/var"],
-  Array[String] $virtualmountpoints = ["/etc","/opt","/var"],
-  Array[String] $exclude_dirs = ["/afs/","/net/","/nfs/","/usr/vice/cache/"]
+  Array[String] $domains = ['/etc','/opt','/var'],
+  Array[String] $virtualmountpoints = ['/etc','/opt','/var'],
+  Array[String] $exclude_dirs = ['/afs/','/net/','/nfs/','/usr/vice/cache/']
 ) {
   package { 'tivsm-ba': }
-  $tsm_home = "/opt/tivoli/tsm/client/ba/bin"
+  $tsm_home = '/opt/tivoli/tsm/client/ba/bin'
 
   file { '/etc/init.d/tsm.service':
-    source => 'puppet:///modules/nebula/tsm/tsm.service'
+    source => 'puppet:///modules/nebula/tsm/tsm.service',
   }
 
   service { 'dsmcad':
     ensure => 'stopped',
-    enable => false
+    enable => false,
   }
 
   service { 'tsm':
-    enable => true
+    enable => true,
   }
 
   file { '/etc/adsm':
-    ensure => 'directory'
+    ensure => 'directory',
   }
 
   file { '/etc/adsm/inclexcl':
-    content => $inclexcl.join("\n")
+    content => $inclexcl.join("\n"),
   }
 
   file { "${tsm_home}/dsm.opt":
-    content => template('nebula/profile/tsm/dsm.opt.erb')
+    content => template('nebula/profile/tsm/dsm.opt.erb'),
   }
 
   file { "${tsm_home}/dsm.sys":
-    content => template('nebula/profile/tsm/dsm.sys.erb')
+    content => template('nebula/profile/tsm/dsm.sys.erb'),
   }
 
 }

--- a/manifests/profile/tsm.pp
+++ b/manifests/profile/tsm.pp
@@ -6,12 +6,43 @@
 #
 # Install TSM backup agent
 #
+# @param servername The value to use for Servername in dsm.sys, e.g. "mytsm"
+#
+# @param serveraddress The value to use for TCPServeraddress in dsm.sys, e.g.
+# "mytsm.whatever.umich.edu"
+#
+# @param port The value to use for TCPPort in dsm.sys, for example 1510.
+#
+# @param encryption Whether to enable encryption. You must configure the
+# encryption key manually.
+#
+# @param $inclexcl An array of lines to add to /etc/adsm/inclexcl, for example
+#    exclude.dir /some/path
+#    include /some/path/inside/.../*
+#
+# @param $domains An array of paths to back up, for example "/etc", "/var", etc
+#
+# @param $virtualmountpoints An array of paths (listed in $domains) that are
+# not their own filesystem, but should be backed up as if they are (e.g. if
+# "/etc" is not its own filesystem)
+#
+# @param exclude_dirs Directories never to back up
+#
 # This does not automate entry of the node password or encryption key (if
 # used); "dsmc" must still be run manually to configure that.
 
 class nebula::profile::tsm (
+  String $servername,
+  String $serveraddress,
+  Boolean $encryption = false,
+  Integer $port = 1510,
+  Array[String] $inclexcl = [],
+  Array[String] $domains = ["/etc","/opt","/var"],
+  Array[String] $virtualmountpoints = ["/etc","/opt","/var"],
+  Array[String] $exclude_dirs = ["/afs/","/net/","/nfs/","/usr/vice/cache/"]
 ) {
   package { 'tivsm-ba': }
+  $tsm_home = "/opt/tivoli/tsm/client/ba/bin"
 
   file { '/etc/init.d/tsm.service':
     source => 'puppet:///modules/nebula/tsm/tsm.service'
@@ -24,6 +55,22 @@ class nebula::profile::tsm (
 
   service { 'tsm':
     enable => true
+  }
+
+  file { '/etc/adsm':
+    ensure => 'directory'
+  }
+
+  file { '/etc/adsm/inclexcl':
+    content => $inclexcl.join("\n")
+  }
+
+  file { "${tsm_home}/dsm.opt":
+    content => template('nebula/profile/tsm/dsm.opt.erb')
+  }
+
+  file { "${tsm_home}/dsm.sys":
+    content => template('nebula/profile/tsm/dsm.sys.erb')
   }
 
 }

--- a/manifests/profile/tsm.pp
+++ b/manifests/profile/tsm.pp
@@ -1,0 +1,29 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::tsm
+#
+# Install TSM backup agent
+#
+# This does not automate entry of the node password or encryption key (if
+# used); "dsmc" must still be run manually to configure that.
+
+class nebula::profile::tsm (
+) {
+  package { 'tivsm-ba': }
+
+  file { '/etc/init.d/tsm.service':
+    source => 'puppet:///modules/nebula/tsm/tsm.service'
+  }
+
+  service { 'dsmcad':
+    ensure => 'stopped',
+    enable => false
+  }
+
+  service { 'tsm':
+    enable => true
+  }
+
+}

--- a/manifests/role/hathitrust/backup.pp
+++ b/manifests/role/hathitrust/backup.pp
@@ -18,4 +18,6 @@ class nebula::role::hathitrust::backup (String $private_address_template = '192.
     readonly            => true
   }
 
+  class { 'nebula::profile::tsm': }
+
 }

--- a/manifests/role/hathitrust/backup.pp
+++ b/manifests/role/hathitrust/backup.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 

--- a/manifests/role/hathitrust/backup.pp
+++ b/manifests/role/hathitrust/backup.pp
@@ -6,24 +6,26 @@
 #
 # @example
 #   include nebula::role::hathitrust::backup
-class nebula::role::hathitrust::backup (String $private_address_template = '192.168.0.%s',
-String $tsm_servername,
-String $tsm_serveraddress) {
+class nebula::role::hathitrust::backup (
+  String $tsm_servername,
+  String $tsm_serveraddress,
+  String $private_address_template = '192.168.0.%s'
+) {
   include nebula::role::hathitrust
 
   class { 'nebula::profile::networking::private':
-    address_template => $private_address_template
+    address_template => $private_address_template,
   }
 
   class { 'nebula::profile::hathitrust::mounts':
     smartconnect_mounts => ['/htapps','/htprep'],
-    readonly            => true
+    readonly            => true,
   }
 
   class { 'nebula::profile::tsm':
     servername    => $tsm_servername,
     serveraddress => $tsm_serveraddress,
-    encryption    => true
+    encryption    => true,
   }
 
 }

--- a/manifests/role/hathitrust/backup.pp
+++ b/manifests/role/hathitrust/backup.pp
@@ -6,7 +6,9 @@
 #
 # @example
 #   include nebula::role::hathitrust::backup
-class nebula::role::hathitrust::backup (String $private_address_template = '192.168.0.%s') {
+class nebula::role::hathitrust::backup (String $private_address_template = '192.168.0.%s',
+String $tsm_servername,
+String $tsm_serveraddress) {
   include nebula::role::hathitrust
 
   class { 'nebula::profile::networking::private':
@@ -18,6 +20,10 @@ class nebula::role::hathitrust::backup (String $private_address_template = '192.
     readonly            => true
   }
 
-  class { 'nebula::profile::tsm': }
+  class { 'nebula::profile::tsm':
+    servername    => $tsm_servername,
+    serveraddress => $tsm_serveraddress,
+    encryption    => true
+  }
 
 }

--- a/manifests/role/hathitrust/backup.pp
+++ b/manifests/role/hathitrust/backup.pp
@@ -1,0 +1,21 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# backup servers for hathitrust.org
+#
+# @example
+#   include nebula::role::hathitrust::backup
+class nebula::role::hathitrust::backup (String $private_address_template = '192.168.0.%s') {
+  include nebula::role::hathitrust
+
+  class { 'nebula::profile::networking::private':
+    address_template => $private_address_template
+  }
+
+  class { 'nebula::profile::hathitrust::mounts':
+    smartconnect_mounts => ['/htapps','/htprep'],
+    readonly            => true
+  }
+
+}

--- a/spec/classes/profile/tsm_spec.rb
+++ b/spec/classes/profile/tsm_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::tsm' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      let(:dsm_sys) { "/opt/tivoli/tsm/client/ba/bin/dsm.sys" }
+      let(:dsm_opt) { "/opt/tivoli/tsm/client/ba/bin/dsm.opt" }
+      let(:inclexcl) { "/etc/adsm/inclexcl" }
+
+      let(:params) do
+        {
+          servername: 'tsmserver1',
+          serveraddress: 'tsmserver1.example.invalid'
+        }
+      end
+
+      it { is_expected.to contain_package('tivsm-ba') }
+
+      it do
+        is_expected.to contain_file(dsm_sys)
+          .with_content(/SErvername\s+tsmserver1$/i)
+          .with_content(%r(VIRTUALMOUNTPOINT /etc))
+          .with_content(%r(EXCLUDE.DIR "/afs/"))
+          .with_content(/TCPServeraddress\s+tsmserver1.example.invalid/i)
+          .with_content(/TCPPort\s+1510/i)
+          .without_content(/encrypt/)
+      end
+
+      it do
+        is_expected.to contain_file(dsm_opt)
+          .with_content(%r(DOMAIN "/etc"))
+      end
+
+      it { is_expected.to contain_service('tsm') }
+
+      it do
+        is_expected.to contain_service('dsmcad')
+          .with_ensure('stopped')
+          .with_enable(false)
+      end
+
+      it { is_expected.to contain_file('/etc/init.d/tsm.service') }
+
+      it { is_expected.to contain_file(inclexcl) }
+
+      context "with custom params" do
+        let(:params) do
+          super().merge(
+            {
+              servername: 'otherserver',
+              serveraddress: 'somethingelse.default.invalid',
+              encryption: true,
+              port: 1234,
+              inclexcl: ["exclude.dir /foo","include /bar otherpolicy"],
+              domains: ["/baz","/quux"],
+              virtualmountpoints: ["/vmount"],
+              exclude_dirs: ["/whatever"]
+            }
+          )
+        end
+
+        it do
+          is_expected.to contain_file(dsm_opt)
+            .with_content(%r(^DOMAIN "/baz"$))
+            .with_content(%r(^DOMAIN "/quux"$))
+        end
+
+        it do
+          is_expected.to contain_file(dsm_sys)
+            .with_content(/^SErvername otherserver/)
+            .with_content(%r(VIRTUALMOUNTPOINT /vmount))
+            .with_content(/encryptiontype/)
+            .with_content(/TCPPort\s*1234/)
+            .with_content(/TCPServeraddress\s*somethingelse.default.invalid/)
+            .with_content(%r(EXCLUDE.DIR "/whatever"))
+        end
+
+        it do
+          is_expected.to contain_file(inclexcl)
+            .with_content(%r(^exclude.dir /foo$))
+            .with_content(%r(^include /bar otherpolicy$))
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/tsm_spec.rb
+++ b/spec/classes/profile/tsm_spec.rb
@@ -10,14 +10,14 @@ describe 'nebula::profile::tsm' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      let(:dsm_sys) { "/opt/tivoli/tsm/client/ba/bin/dsm.sys" }
-      let(:dsm_opt) { "/opt/tivoli/tsm/client/ba/bin/dsm.opt" }
-      let(:inclexcl) { "/etc/adsm/inclexcl" }
+      let(:dsm_sys) { '/opt/tivoli/tsm/client/ba/bin/dsm.sys' }
+      let(:dsm_opt) { '/opt/tivoli/tsm/client/ba/bin/dsm.opt' }
+      let(:inclexcl) { '/etc/adsm/inclexcl' }
 
       let(:params) do
         {
           servername: 'tsmserver1',
-          serveraddress: 'tsmserver1.example.invalid'
+          serveraddress: 'tsmserver1.example.invalid',
         }
       end
 
@@ -25,17 +25,17 @@ describe 'nebula::profile::tsm' do
 
       it do
         is_expected.to contain_file(dsm_sys)
-          .with_content(/SErvername\s+tsmserver1$/i)
-          .with_content(%r(VIRTUALMOUNTPOINT /etc))
-          .with_content(%r(EXCLUDE.DIR "/afs/"))
-          .with_content(/TCPServeraddress\s+tsmserver1.example.invalid/i)
-          .with_content(/TCPPort\s+1510/i)
-          .without_content(/encrypt/)
+          .with_content(%r{SErvername\s+tsmserver1$}i)
+          .with_content(%r{VIRTUALMOUNTPOINT /etc})
+          .with_content(%r{EXCLUDE.DIR "/afs/"})
+          .with_content(%r{TCPServeraddress\s+tsmserver1.example.invalid}i)
+          .with_content(%r{TCPPort\s+1510}i)
+          .without_content(%r{encrypt})
       end
 
       it do
         is_expected.to contain_file(dsm_opt)
-          .with_content(%r(DOMAIN "/etc"))
+          .with_content(%r{DOMAIN "/etc"})
       end
 
       it { is_expected.to contain_service('tsm') }
@@ -50,42 +50,40 @@ describe 'nebula::profile::tsm' do
 
       it { is_expected.to contain_file(inclexcl) }
 
-      context "with custom params" do
+      context 'with custom params' do
         let(:params) do
           super().merge(
-            {
-              servername: 'otherserver',
-              serveraddress: 'somethingelse.default.invalid',
-              encryption: true,
-              port: 1234,
-              inclexcl: ["exclude.dir /foo","include /bar otherpolicy"],
-              domains: ["/baz","/quux"],
-              virtualmountpoints: ["/vmount"],
-              exclude_dirs: ["/whatever"]
-            }
+            servername: 'otherserver',
+            serveraddress: 'somethingelse.default.invalid',
+            encryption: true,
+            port: 1234,
+            inclexcl: ['exclude.dir /foo', 'include /bar otherpolicy'],
+            domains: ['/baz', '/quux'],
+            virtualmountpoints: ['/vmount'],
+            exclude_dirs: ['/whatever'],
           )
         end
 
         it do
           is_expected.to contain_file(dsm_opt)
-            .with_content(%r(^DOMAIN "/baz"$))
-            .with_content(%r(^DOMAIN "/quux"$))
+            .with_content(%r{^DOMAIN "/baz"$})
+            .with_content(%r{^DOMAIN "/quux"$})
         end
 
         it do
           is_expected.to contain_file(dsm_sys)
-            .with_content(/^SErvername otherserver/)
-            .with_content(%r(VIRTUALMOUNTPOINT /vmount))
-            .with_content(/encryptiontype/)
-            .with_content(/TCPPort\s*1234/)
-            .with_content(/TCPServeraddress\s*somethingelse.default.invalid/)
-            .with_content(%r(EXCLUDE.DIR "/whatever"))
+            .with_content(%r{^SErvername otherserver})
+            .with_content(%r{VIRTUALMOUNTPOINT /vmount})
+            .with_content(%r{encryptiontype})
+            .with_content(%r{TCPPort\s*1234})
+            .with_content(%r{TCPServeraddress\s*somethingelse.default.invalid})
+            .with_content(%r{EXCLUDE.DIR "/whatever"})
         end
 
         it do
           is_expected.to contain_file(inclexcl)
-            .with_content(%r(^exclude.dir /foo$))
-            .with_content(%r(^include /bar otherpolicy$))
+            .with_content(%r{^exclude.dir /foo$})
+            .with_content(%r{^include /bar otherpolicy$})
         end
       end
     end

--- a/spec/classes/role/ht_backup_spec.rb
+++ b/spec/classes/role/ht_backup_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::role::hathitrust::backup' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_package('nfs-common') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
+      # causes a warning if concat fragment is included but monitor_pl isn't
+      # (which we don't need on ingest servers)
+      it { is_expected.not_to contain_concat_fragment('monitor nfs /sdr1') }
+      it { is_expected.to contain_mount('/htprep') }
+
+      it { is_expected.to contain_package('tivsm-api') }
+    end
+  end
+end

--- a/spec/classes/role/ht_backup_spec.rb
+++ b/spec/classes/role/ht_backup_spec.rb
@@ -21,15 +21,13 @@ describe 'nebula::role::hathitrust::backup' do
       it { is_expected.not_to contain_concat_fragment('monitor nfs /sdr1') }
       it { is_expected.to contain_mount('/htprep') }
 
-      it { is_expected.to contain_package('tivsm-ba') }
-
-      it { is_expected.to contain_service('tsm') }
       it do
-        is_expected.to contain_service('dsmcad')
-          .with_ensure('stopped')
-          .with_enable(false)
+        is_expected.to contain_class("nebula::profile::tsm")
+          .with_encryption(true)
+          .with_servername("tsmserver")
+          .with_serveraddress("tsm.default.invalid")
       end
-      it { is_expected.to contain_file('/etc/init.d/tsm.service') }
+
     end
   end
 end

--- a/spec/classes/role/ht_backup_spec.rb
+++ b/spec/classes/role/ht_backup_spec.rb
@@ -21,7 +21,15 @@ describe 'nebula::role::hathitrust::backup' do
       it { is_expected.not_to contain_concat_fragment('monitor nfs /sdr1') }
       it { is_expected.to contain_mount('/htprep') }
 
-      it { is_expected.to contain_package('tivsm-api') }
+      it { is_expected.to contain_package('tivsm-ba') }
+
+      it { is_expected.to contain_service('tsm') }
+      it do
+        is_expected.to contain_service('dsmcad')
+          .with_ensure('stopped')
+          .with_enable(false)
+      end
+      it { is_expected.to contain_file('/etc/init.d/tsm.service') }
     end
   end
 end

--- a/spec/classes/role/ht_backup_spec.rb
+++ b/spec/classes/role/ht_backup_spec.rb
@@ -22,12 +22,11 @@ describe 'nebula::role::hathitrust::backup' do
       it { is_expected.to contain_mount('/htprep') }
 
       it do
-        is_expected.to contain_class("nebula::profile::tsm")
+        is_expected.to contain_class('nebula::profile::tsm')
           .with_encryption(true)
-          .with_servername("tsmserver")
-          .with_serveraddress("tsm.default.invalid")
+          .with_servername('tsmserver')
+          .with_serveraddress('tsm.default.invalid')
       end
-
     end
   end
 end

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -124,3 +124,6 @@ nebula::profile::hathitrust::cron::catalog::mail_recipient: nobody@default.inval
 umich::networks::staff: []
 
 nebula::profile::hathitrust::solr_lss::timezone: Somewhere/City
+
+nebula::role::hathitrust::backup::tsm_servername: tsmserver
+nebula::role::hathitrust::backup::tsm_serveraddress: tsm.default.invalid

--- a/templates/profile/tsm/dsm.opt.erb
+++ b/templates/profile/tsm/dsm.opt.erb
@@ -1,0 +1,5 @@
+quiet
+COMPRESSALWAYS NO
+<% @domains.each do |domain| %>
+DOMAIN "<%= domain %>"
+<% end %>

--- a/templates/profile/tsm/dsm.sys.erb
+++ b/templates/profile/tsm/dsm.sys.erb
@@ -1,0 +1,22 @@
+SErvername <%= @servername %>
+<% @virtualmountpoints.each do |mount| %>
+VIRTUALMOUNTPOINT <%= mount %>
+<% end %>
+<% @exclude_dirs.each do |dir| %>
+EXCLUDE.DIR "<%= dir %>"
+<% end %>
+INCLEXCL /etc/adsm/inclexcl
+COMPRESSION YES
+   COMMmethod         TCPip
+   TCPPort            <%= @port %>
+   TCPServeraddress   <%= @serveraddress %>
+passwordaccess generate
+passworddir /etc/adsm
+<% if @encryption %>
+  encryptiontype aes128
+  encryptkey save
+<% end %>
+schedmode polling
+schedlogretention 31
+errorlogname /var/log/dsmerror.log
+schedlogname /var/log/dsmsched.log


### PR DESCRIPTION
Specifically for HT backup servers.

How to include the TSM profile for other nodes running TSM is out of scope for this PR.