### PR TITLE
Add heirloom-mailx package

### DIFF
--- a/manifests/profile/hathitrust/ingest_jobs.pp
+++ b/manifests/profile/hathitrust/ingest_jobs.pp
@@ -20,6 +20,8 @@ class nebula::profile::hathitrust::ingest_jobs(
   String $rights_log = '/tmp/populate_rights.log'
 ) {
 
+  package { 'heirloom-mailx': }
+
   $feed_perl = "/usr/bin/perl -I ${feed_home}/lib ${feed_home}/bin"
   $feed_log  = "${feed_home}/var/log"
   $joined_dcu_recipients = $dcu_recipients.join(',')


### PR DESCRIPTION
Some of the cron jobs expect to have the mailx from RHEL, which is known as 'heirloom-mailx' on Debian. It provides some different command line flags and features including being able to attach a file.