### PR TITLE
AEIM-2242 - Fix up tools_lib to succeed on first run

### DIFF
--- a/manifests/profile/tools_lib/postgres.pp
+++ b/manifests/profile/tools_lib/postgres.pp
@@ -40,24 +40,27 @@ class nebula::profile::tools_lib::postgres (
   }
 
   file { $pg_backup_dir:
-    ensure => 'directory',
-    mode   => '2775',
-    owner  => 'root',
-    group  => 'postgres'
+    ensure  => 'directory',
+    mode    => '2775',
+    owner   => 'root',
+    group   => 'postgres',
+    require => Class['postgresql::server']
   }
 
   file { "${pg_backup_dir}/backup":
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-    source => 'puppet:///modules/nebula/pg_backup'
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    source  => 'puppet:///modules/nebula/pg_backup',
+    require => File[$pg_backup_dir]
   }
 
   cron { 'backup postgres databases':
     command => "cd ${pg_backup_dir} && ( ./backup confluence; ./backup jira ) > pgbackup.log 2>&1",
     user    => 'postgres',
     hour    => 0,
-    minute  => 7
+    minute  => 7,
+    require => Class['postgresql::server']
   }
 
   if($s3_backup_dest) {

--- a/manifests/role/tools_lib.pp
+++ b/manifests/role/tools_lib.pp
@@ -11,7 +11,7 @@
 #   include nebula::role::tools_lib
 class nebula::role::tools_lib (
   String $domain,
-  String $mail_recipient
+  String $mail_recipient = lookup('nebula::automation_email')
 ) {
 
   include nebula::role::aws

--- a/spec/classes/role/tools_lib_spec.rb
+++ b/spec/classes/role/tools_lib_spec.rb
@@ -17,6 +17,8 @@ describe 'nebula::role::tools_lib' do
       it { is_expected.to contain_package('fontconfig') }
       it { is_expected.to contain_class('jira').with(version: '7.13.1') }
       it { is_expected.to contain_class('confluence').with(version: '6.14.1') }
+      it { is_expected.to contain_class('nebula::profile::tools_lib::jira').with(mail_recipient: 'nobody@default.invalid') }
+      it { is_expected.to contain_class('nebula::profile::tools_lib::confluence').with(mail_recipient: 'nobody@default.invalid') }
     end
   end
 end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -5,6 +5,7 @@
 role: invalid_role
 
 nebula::root_email: root@default.invalid
+nebula::automation_email: automation@default.invalid
 nebula::puppetmaster: puppetmaster.default.invalid
 nebula::puppetdb: puppetdb.default.invalid
 


### PR DESCRIPTION
There were two small problems popping up when running on a new AWS VM
provisioned with this role tag:

 1. The mail_recipient had no default value, so we needed a node file
 2. The postgres profile didn't have sufficient dependency information
    on the backup directories

This change introduces a nebula::automation_email to parallel root_email
and a few requires to ensure that postgres is installed before the
backup directories and cron entry are managed.

With a mail_recipient value in common.yml, these hosts can be
provisioned with only an AWS tag.