### PR TITLE
AEIM-2345: correct "location" to "path"

### DIFF
--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -49,7 +49,7 @@ class nebula::profile::hathitrust::apache::catalog (
     directories       => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        path     =>  '~$',
         require  => 'all denied'
       },
       {


### PR DESCRIPTION
puppet doesn't complain, just silently omits the `<FilesMatch>` if the parameter name is wrong :(