### PR TITLE
Update Gemfile.lock fully

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,39 +11,45 @@ GEM
       url
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    dependency_checker (0.2.0)
+      parallel
+      puppet_forge (~> 2.2)
+      rake (~> 12.3)
+      semantic_puppet (~> 1.0)
     diff-lcs (1.3)
-    docile (1.3.1)
-    domain_name (0.5.20180417)
+    docile (1.3.2)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     facter (2.5.1)
-    facterdb (0.6.0)
+    facterdb (0.8.1)
       facter
       jgrep
     faker (1.8.7)
       i18n (>= 0.7)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     fast_gettext (1.1.2)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
-    gettext-setup (0.30)
+    gettext-setup (0.31)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
       locale
     hiera (3.5.0)
     hirb (0.7.3)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jgrep (1.5.0)
-    json (2.1.0)
+    json (2.2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     locale (2.1.2)
-    mcollective-client (2.12.4)
-      json
-      stomp
-      systemu
     metaclass (0.0.4)
     metadata-json-lint (2.2.0)
       json-schema (~> 2.8)
@@ -51,16 +57,18 @@ GEM
     method_source (0.8.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
+    minitar (0.8)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.13.1)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (5.1.0)
+    multipart-post (2.1.1)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
+    net-ssh (5.2.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    parallel (1.13.0)
+    parallel (1.17.0)
     parallel_tests (2.14.2)
       parallel
     parser (2.5.1.2)
@@ -71,7 +79,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     puppet (5.5.10)
       facter (> 2.0.1, < 4)
       fast_gettext (~> 1.1.2)
@@ -81,9 +89,10 @@ GEM
     puppet-blacksmith (4.1.2)
       rest-client (~> 2.0)
     puppet-lint (2.3.6)
-    puppet-module-posix-default-r2.4 (0.3.12)
-    puppet-module-posix-dev-r2.4 (0.3.14)
+    puppet-module-posix-default-r2.5 (0.4.2)
+    puppet-module-posix-dev-r2.5 (0.3.15)
       codecov (~> 0.1.10)
+      dependency_checker (~> 0.2)
       gettext-setup (~> 0.26)
       metadata-json-lint (>= 2.0.2, < 3.0.0)
       mocha (>= 1.0.0, < 1.2.0)
@@ -105,12 +114,18 @@ GEM
       rubocop-rspec (~> 1.16.0)
       simplecov (>= 0.14.1, < 1.0.0)
       simplecov-console (~> 0.4.2)
-      specinfra (= 2.76.7)
+      specinfra (= 2.77.1)
     puppet-strings (2.1.0)
       rgen
       yard (~> 0.9.5)
     puppet-syntax (2.4.1)
       rake
+    puppet_forge (2.3.0)
+      faraday (>= 0.9.0, < 0.14.0)
+      faraday_middleware (>= 0.9.0, < 0.13.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 1.0)
     puppet_pot_generator (1.0.1)
       puppet
     puppetlabs_spec_helper (2.13.1)
@@ -122,7 +137,8 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.3.2)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -141,11 +157,10 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-puppet (2.7.2)
       rspec
-    rspec-puppet-facts (1.9.2)
+    rspec-puppet-facts (1.9.5)
       facter
       facterdb (>= 0.5.0)
       json
-      mcollective-client
       puppet
     rspec-puppet-utils (3.4.0)
       mocha
@@ -167,10 +182,10 @@ GEM
       rubocop (~> 0.49.0)
     rubocop-rspec (1.16.0)
       rubocop (>= 0.49.0)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     semantic_puppet (1.0.2)
     sfl (2.3)
-    simplecov (0.16.1)
+    simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -181,18 +196,16 @@ GEM
     simplecov-html (0.10.2)
     slop (3.6.0)
     spdx-licenses (1.2.0)
-    specinfra (2.76.7)
+    specinfra (2.77.1)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
       sfl
-    stomp (1.4.8)
-    systemu (2.6.5)
     text (1.3.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
-    unicode-display_width (1.4.1)
+    unf_ext (0.0.7.6)
+    unicode-display_width (1.6.0)
     url (0.3.2)
     yard (0.9.20)
 
@@ -203,8 +216,8 @@ DEPENDENCIES
   faker
   fast_gettext
   puppet (~> 5.5)
-  puppet-module-posix-default-r2.4
-  puppet-module-posix-dev-r2.4
+  puppet-module-posix-default-r2.5
+  puppet-module-posix-dev-r2.5
   puppet-strings
   rspec-puppet-utils
   semantic_puppet


### PR DESCRIPTION
For some reason, running specs was updating the Gemfile.lock, resulting
in frequent, uncommitted changes. This just commits what everybody is
ending up with on each test run, outside of any functional change.