### PR TITLE
AEIM-2205 - Add vhost for www.press.umich.edu

### DIFF
--- a/manifests/apache/www_lib_vhost.pp
+++ b/manifests/apache/www_lib_vhost.pp
@@ -25,7 +25,8 @@ define nebula::apache::www_lib_vhost (
   Boolean $ssl_proxyengine = false,
   Optional[String] $ssl_proxy_check_peer_name = undef,
   Optional[String] $ssl_proxy_check_peer_expire = undef,
-  Optional[Array] $setenvifnocase = undef
+  Optional[Array] $setenv = undef,
+  Optional[Array] $setenvifnocase = undef,
 ) {
   $ssl_cert = "${nebula::profile::apache::ssl_cert_dir}/${ssl_cn}.crt"
   $ssl_key = "${nebula::profile::apache::ssl_key_dir}/${ssl_cn}.key"
@@ -165,5 +166,6 @@ define nebula::apache::www_lib_vhost (
     ssl_proxy_check_peer_name   => $ssl_proxy_check_peer_name,
     ssl_proxy_check_peer_expire => $ssl_proxy_check_peer_expire,
     setenvifnocase              => $setenvifnocase,
+    setenv                      => $setenv,
   }
 }

--- a/manifests/profile/www_lib/apache.pp
+++ b/manifests/profile/www_lib/apache.pp
@@ -95,6 +95,7 @@ class nebula::profile::www_lib::apache (
       'open.umich.edu',
       'mirlyn.lib.umich.edu',
       'staff.lib.umich.edu',
+      'www.press.umich.edu',
     ]:
   }
 
@@ -112,7 +113,7 @@ class nebula::profile::www_lib::apache (
 
   $vhost_prefix = 'nebula::profile::www_lib::vhosts'
 
-  ['default','www_lib','staff_lib','datamart','deepblue', 'openmich', 'mportfolio'].each |$vhost| {
+  ['default','www_lib','staff_lib','datamart','deepblue', 'openmich', 'mportfolio', 'press'].each |$vhost| {
     class { "nebula::profile::www_lib::vhosts::${vhost}":
       prefix => $prefix,
       domain => $domain,

--- a/manifests/profile/www_lib/vhosts/press.pp
+++ b/manifests/profile/www_lib/vhosts/press.pp
@@ -1,0 +1,99 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::www_lib::vhosts::press
+#
+# press virtual host
+#
+# @example
+#   include nebula::profile::www_lib::vhosts::press
+class nebula::profile::www_lib::vhosts::press (
+  String $prefix,
+  String $domain,
+  String $ssl_cn = 'www.press.umich.edu',
+  String $docroot = '/www/www.press/public',
+  String $bind = '127.0.0.1:31028',
+  Integer $num_proc = 10,
+  String $script = '/www/www.press/script/puppet-press',
+) {
+  $servername = "${prefix}www.press.umich.edu"
+
+  file { "${apache::params::logroot}/press":
+    ensure => 'directory'
+  }
+
+  file { '/usr/local/bin/startup_press':
+    ensure  => 'present',
+    content => template('nebula/profile/www_lib/vhosts/press/startup_press.erb'),
+    notify  => Service['press'],
+    mode    => '0755',
+  }
+
+  file { '/etc/systemd/system/press.service':
+    ensure  => 'present',
+    content => template('nebula/profile/www_lib/vhosts/press/press.service.erb'),
+    notify  => Service['press'],
+  }
+
+  service { 'press':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+  }
+
+  nebula::apache::www_lib_vhost { 'press-http':
+    servername     => $servername,
+    docroot        => $docroot,
+    logging_prefix => 'press/',
+
+    rewrites       => [
+      {
+        rewrite_rule => '^(.*)$ https://%{HTTP_HOST}$1 [L,R]'
+      },
+    ],
+
+    directories    => [
+      {
+        provider      => 'directory',
+        path          => $docroot,
+        options       => 'FollowSymLinks',
+        allowoverride => 'None',
+        require       => $nebula::profile::www_lib::apache::default_access,
+      },
+    ],
+  }
+
+  nebula::apache::www_lib_vhost { 'press-https':
+    servername      => $servername,
+    docroot         => $docroot,
+    logging_prefix  => 'press/',
+    ssl             => true,
+    ssl_cn          => $ssl_cn,
+    setenv          => ['HTTPS on'],
+
+    rewrites        => [
+      {
+        rewrite_cond => [
+          '%{DOCUMENT_ROOT}/%{REQUEST_URI} !-f',
+          '%{REQUEST_URI} !^/cosign',
+        ],
+        rewrite_rule => "^(.*) http://${bind}\$1 [P]"
+      }
+    ],
+
+    directories     => [
+      {
+        provider      => 'directory',
+        path          => $docroot,
+        options       => 'FollowSymLinks',
+        allowoverride => 'None',
+        require       => $nebula::profile::www_lib::apache::default_access,
+      },
+    ],
+
+    custom_fragment => @("EOT")
+      ProxyPassReverse / http://${bind}
+    | EOT
+  }
+}

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -202,6 +202,18 @@ describe 'nebula::role::webhost::www_lib_vm' do
                                 'www.digitalrhetoriccollaborative.org',
                               ])
       end
+
+      it do
+        is_expected.to contain_apache__vhost('press-http')
+          .with_servername('www.press.umich.edu')
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('press-https')
+          .with_servername('www.press.umich.edu')
+          .with_ssl_cert('/etc/ssl/certs/www.press.umich.edu.crt')
+          .with_setenv(['HTTPS on'])
+      end
     end
   end
 end

--- a/templates/profile/www_lib/vhosts/press/press.service.erb
+++ b/templates/profile/www_lib/vhosts/press/press.service.erb
@@ -1,0 +1,13 @@
+[Unit]
+Description=press fcgi
+After=network.target
+
+[Service]
+Type=simple
+RemainAfterExit=no
+User=nobody
+ExecStart=/usr/local/bin/startup_press
+Restart=always
+
+[Install]
+

--- a/templates/profile/www_lib/vhosts/press/startup_press.erb
+++ b/templates/profile/www_lib/vhosts/press/startup_press.erb
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Usage: startup_press
+
+exec >> /tmp/press.out 2>> /tmp/press.err
+
+NPROC=<%= @num_proc %>
+BIND=<%= @bind %>
+SCRIPT=<%= @script %>
+
+MOJO_REVERSE_PROXY=1 /usr/bin/plackup \
+  -R '<%= @script %>' \
+  --nproc <%= @num_proc %> \
+  --listen '<%= @bind %>' \
+  '<%= @script %>' &
+
+trap "echo 'REMOVING press'; kill -TERM -$$; rm -fv /tmp/fastcgi/press.sock; exit" SIGINT SIGTERM SIGQUIT
+
+wait
+


### PR DESCRIPTION
Other than adding a `setenv` parameter to `nebula::apache::www_lib_vhost`, this doesn't much modify anything that already exists.