### PR TITLE
AEIM-2206: Create redirects vhost

### DIFF
--- a/manifests/apache/redirect_vhost_http.pp
+++ b/manifests/apache/redirect_vhost_http.pp
@@ -3,14 +3,15 @@
 # BSD License. See LICENSE.txt for details.
 
 define nebula::apache::redirect_vhost_http (
-  String $servername,
   Array[String] $serveraliases = [],
-  String $target = "http://www.${servername}",
+  String $target = "http://www.${title}/",
+  $priority = false,
 ) {
-  apache::vhost { "${servername}-http":
+  apache::vhost { "${title}-redirect-http":
     port            => '80',
+    priority        => $priority,
     docroot         => false,
-    servername      => $servername,
+    servername      => $title,
     serveraliases   => $serveraliases,
     redirect_source => '/',
     redirect_status => 'permanent',

--- a/manifests/apache/redirect_vhost_https.pp
+++ b/manifests/apache/redirect_vhost_https.pp
@@ -5,11 +5,14 @@
 define nebula::apache::redirect_vhost_https (
   Array[String] $serveraliases = [],
   String $target = "https://www.${title}/",
-  String $ssl_cn = $title,
+  $priority = false,
 ) {
-  nebula::apache::www_lib_vhost { "${title}-https":
-    ssl             => true,
-    ssl_cn          => $ssl_cn,
+  nebula::apache::redirect_vhost_http { "${title}":
+    serveraliases => $serveraliases
+  }
+  apache::vhost { "${title}-redirect-https":
+    port            => '443',
+    priority        => $priority,
     docroot         => false,
     servername      => $title,
     serveraliases   => $serveraliases,

--- a/manifests/profile/www_lib/apache.pp
+++ b/manifests/profile/www_lib/apache.pp
@@ -38,6 +38,7 @@ class nebula::profile::www_lib::apache (
   }
 
   include nebula::profile::apache::monitoring
+  include nebula::profile::www_lib::vhosts::redirects
 
   class { 'nebula::profile::monitor_pl':
     directory  => $nebula::profile::apache::monitoring::monitor_dir,
@@ -96,18 +97,6 @@ class nebula::profile::www_lib::apache (
       'mirlyn.lib.umich.edu',
       'staff.lib.umich.edu',
     ]:
-  }
-
-  nebula::apache::redirect_vhost_https { 'theater-historiography.org':
-    ssl_cn        => 'www.theater-historiography.org',
-    serveraliases => [
-      'www.theater-historiography.com',
-      'theater-historiography.com',
-      'www.theatre-historiography.com',
-      'theatre-historiography.com',
-      'www.theatre-historiography.org',
-      'theatre-historiography.org',
-    ],
   }
 
   $vhost_prefix = 'nebula::profile::www_lib::vhosts'

--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -1,0 +1,214 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::www_lib::vhosts::redirects(
+) {
+
+  nebula::apache::redirect_vhost_http { 'mediaindustriesjournal.org':
+    serveraliases => [],
+  }
+
+  nebula::apache::redirect_vhost_https { 'michiganelt.org':
+    serveraliases => []
+  }
+
+  nebula::apache::redirect_vhost_https { 'lib.umich.edu':
+    serveraliases => ['lib', 'library.umich.edu', 'www.library.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'mblem.umich.edu':
+    serveraliases => ['mblem.nslb.umdl.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'mportfolio.umich.edu':
+    serveraliases => ['mportfolio.nslb.umdl.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'publishing.umich.edu':
+    serveraliases => ['publishing'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'press.umich.edu':
+    serveraliases => ['press.lib.umich.edu', 'press.nslb.umdl.umich.edu']
+  }
+
+  nebula::apache::redirect_vhost_https { 'developingwritersbook.org':
+    serveraliases => [
+      'developingwritersbook.com',
+      'developingwritersbook.net',
+      'www.developingwritersbook.com',
+      'www.developingwritersbook.net'
+    ],
+  }
+
+  nebula::apache::redirect_vhost_https { 'fulcrum.publishing.umich.edu':
+    priority => '07',
+    target => 'https://tools.lib.umich.edu/confluence/display/FPS'
+  }
+
+  nebula::apache::redirect_vhost_https { 'support.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://tools.lib.umich.edu/confluence/display/FPS',
+    serveraliases => ['support.fulcrum.org', 'support.fulcrumservices.org'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'northwestern.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/northwestern',
+    serveraliases => ['northwestern.fulcrum.org', 'northwestern.fulcrumservices.org'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'minnesota.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/minnesota',
+    serveraliases => [ 'minnesota.fulcrum.org', 'minnesota.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'michigan.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/michigan',
+    serveraliases => [ 'michigan.fulcrum.org', 'michigan.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'indiana.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/indiana',
+    serveraliases => [ 'indiana.fulcrum.org', 'indiana.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'pennstate.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/pennstate',
+    serveraliases => [ 'pennstate.fulcrum.org', 'pennstate.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'nyupress.fulcrumscholar.org':
+    priority => '08',
+    target => 'https://www.fulcrum.org/nyupress',
+    serveraliases => [ 'nyupress.fulcrum.org', 'nyupress.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'fulcrum.org':
+    priority => '14',
+    serveraliases => [
+      'fulcrum.pub',
+      'fulcrumscholar.org',
+      'fulcrumscholar.com',
+      'fulcrumscholar.net',
+      'fulcrumservices.org',
+      'fulcrumservices.net',
+      '*.fulcrum.org',
+      '*.fulcrum.pub',
+      '*.fulcrumscholar.org',
+      '*.fulcrumscholar.com',
+      '*.fulcrumscholar.net',
+      '*.fulcrumservices.org',
+      '*.fulcrumservices.net',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_https { 'digitalculture.org':
+    serveraliases => [
+      'www.digitalculturebooks.com',
+      'digitalculturebooks.com',
+      'www.digitalculturebooks.org',
+      'digitalculturebooks.org',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_http { 'lgbtheritage.org':
+  }
+
+  nebula::apache::redirect_vhost_https { 'textcreationpartnership.org':
+    serveraliases => ['www.textcreationpartnership.com', 'textcreationpartnership.com'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'theater-historiography.org':
+    serveraliases => [
+      'www.theater-historiography.com',
+      'theater-historiography.com',
+      'www.theatre-historiography.com',
+      'theatre-historiography.com',
+      'www.theatre-historiography.org',
+      'theatre-historiography.org',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_https { 'mazebooks.org':
+    serveraliases => ['www.mazebooks.org'],
+  }
+
+  nebula::apache::redirect_vhost_http { 'datainfolit.org':
+    serveraliases => ['www.datainformationliteracy.org', 'datainformationliteracy.org'],
+  }
+
+  nebula::apache::redirect_vhost_http { 'beta.lib.umich.edu':
+    target => 'http://www.lib.umich.edu/'
+  }
+
+
+  nebula::apache::redirect_vhost_http { 'www.maizebooks.org':
+    target => 'http://www.publishing.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'www.michiganelt.org':
+    target => 'http://www.press.umich.edu/elt'
+  }
+
+  nebula::apache::redirect_vhost_http { 'medsearch.lib.umich.edu':
+    serveraliases => ['medsearch', 'medsearch.lib'],
+    target => 'http://www.lib.umich.edu/health-sciences-libraries/medsearch/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'm-update.lib.umich.edu':
+    serveraliases => ['m-update.lib'],
+    target => 'http://m.lib.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'www-update.lib.umich.edu':
+    serveraliases => ['www-update.lib'],
+    target => 'http://www.lib.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'pk.lib.umich.edu':
+    target => 'http://www.lib.umich.edu/pk/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'sfx.lib.umich.edu':
+    serveraliases => ['sfx.lib'],
+    target => 'http://mgetit.lib.umich.edu/'
+  }
+
+  apache::vhost { 'lgbtheritage.org-redirect-http-all':
+    port            => '80',
+    docroot         => false,
+    servername      => 'www.lgbtheritage.org',
+    rewrites => [
+      {
+        comment => "redirect all to target",
+        rewrite_rule => ['^/.*$ http://www.lib.umich.edu/online-exhibits/exhibits/show/lgbtheritage/ [redirect,noescape]']
+      }
+    ]
+  }
+
+  apache::vhost { 'searchtools.lib.umich.edu-redirect-http':
+    port            => '80',
+    docroot         => false,
+    servername      => 'searchtools.lib.umich.edu',
+    serveraliases   => ['searchtools.lib'],
+    rewrites        => [
+     {
+       rewrite_cond => ['%{QUERY_STRING} func=native-link'],
+       rewrite_rule => ['^/(V|V/.*)$ http://www.lib.umich.edu/V [redirect=permanent,last,noescape]'],
+       rewrite_cond => ['%{QUERY_STRING}	func=find-db-1(.*)mode=category'],
+       rewrite_rule	=> ['^/(V|V/.*)$	http://www.lib.umich.edu/searchtools#databases/search?  [redirect=permanent,last,noescape]'],
+       rewrite_cond	=> ['%{QUERY_STRING}	func=find-db-1'],
+       rewrite_rule	=> ['^/(V|V/.*)$	http://www.lib.umich.edu/searchtools#databases?		[redirect=permanent,last,noescape]'],
+       rewrite_rule => ['^/.*$		http://www.lib.umich.edu/searchtools?			[redirect=permanent,last,noescape]']
+     }
+    ]
+
+  }
+
+}

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -85,8 +85,27 @@ describe 'nebula::role::webhost::www_lib_vm' do
       end
 
       it do
-        is_expected.to contain_apache__vhost('theater-historiography.org-https')
-          .with_ssl_cert('/etc/ssl/certs/www.theater-historiography.org.crt')
+        is_expected.to contain_apache__vhost('mediaindustriesjournal.org-redirect-http')
+          .with_redirect_dest('http://www.mediaindustriesjournal.org/')
+          .with_serveraliases([])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('michiganelt.org-redirect-https')
+          .with_redirect_dest('https://www.michiganelt.org/')
+          .with_serveraliases([])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('lib.umich.edu-redirect-https')
+          .with_redirect_dest('https://www.lib.umich.edu/')
+          .with_serveraliases(%w[lib
+                                 library.umich.edu
+                                 www.library.umich.edu])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('theater-historiography.org-redirect-https')
           .with_redirect_dest('https://www.theater-historiography.org/')
           .with_serveraliases(%w[www.theater-historiography.com
                                  theater-historiography.com


### PR DESCRIPTION
This is a 1:1 buildout of the existing functionality in what we refer to
as the redirects vhost as defined in redirects.conf

I'm particularly concerned with the changes to `theater-historiography`, as my changes here _remove_ some of the functionality.