### PR TITLE
Delete prometheus logs but expose error count

### DIFF
--- a/lib/facter/prometheus_errors_total.rb
+++ b/lib/facter/prometheus_errors_total.rb
@@ -15,7 +15,7 @@ Facter.add(:prometheus_errors_total) do
     error_count = %r{(?<=error gathering metrics: )\d*(?= error)}
 
     if File.size? log_path
-      [1, File.read(log_path)[error_count].to_i].max
+      [1, Integer(File.read(log_path)[error_count])].max
     else
       0
     end

--- a/lib/facter/prometheus_errors_total.rb
+++ b/lib/facter/prometheus_errors_total.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+# This will read the Prometheus node exporter's log and look for errors.
+# The result seen by puppet is nothing more than an integer which it can
+# pass to a file that Prometheus will scrape.
+#
+# We're not interested in details in this case, since it's just a
+# metric. If you want more info than error count, then that's what logs
+# are for.
+Facter.add(:prometheus_errors_total) do
+  setcode do
+    log_path = '/var/log/prometheus-node-exporter.log'
+    error_count = %r{(?<=error gathering metrics: )\d*(?= error)}
+
+    if File.size? log_path
+      [1, File.read(log_path)[error_count].to_i].max
+    else
+      0
+    end
+  end
+end

--- a/manifests/profile/named_instances.pp
+++ b/manifests/profile/named_instances.pp
@@ -40,7 +40,7 @@ class nebula::profile::named_instances (
   }
 
   ensure_packages(['rsync'], { 'ensure' => 'present' })
-  include nebula::profile::rsyslog
+  include nebula::subscriber::rsyslog
 
   file { '/etc/rsyslog.d/drop-rbenv.conf':
     content => ':programname, isequal, "rbenv" ~',

--- a/manifests/profile/named_instances.pp
+++ b/manifests/profile/named_instances.pp
@@ -40,9 +40,7 @@ class nebula::profile::named_instances (
   }
 
   ensure_packages(['rsync'], { 'ensure' => 'present' })
-  # we don't create or manage this, but puppet needs to know about it in order
-  # to notify it
-  ensure_resource('service', 'rsyslog', { 'hasrestart' => true })
+  include nebula::profile::rsyslog
 
   file { '/etc/rsyslog.d/drop-rbenv.conf':
     content => ':programname, isequal, "rbenv" ~',

--- a/manifests/profile/rsyslog.pp
+++ b/manifests/profile/rsyslog.pp
@@ -1,0 +1,9 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# we don't create or manage this, but puppet needs to know about it in
+# order to notify it
+class nebula::profile::rsyslog {
+  ensure_resource('service', 'rsyslog', { 'hasrestart' => true })
+}

--- a/manifests/subscriber/rsyslog.pp
+++ b/manifests/subscriber/rsyslog.pp
@@ -2,8 +2,6 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-# we don't create or manage this, but puppet needs to know about it in
-# order to notify it
-class nebula::profile::rsyslog {
+class nebula::subscriber::rsyslog {
   ensure_resource('service', 'rsyslog', { 'hasrestart' => true })
 }

--- a/manifests/subscriber/systemctl_daemon_reload.pp
+++ b/manifests/subscriber/systemctl_daemon_reload.pp
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::subscriber::systemctl_daemon_reload {
+  exec { 'systemctl daemon-reload':
+    command     => '/bin/systemctl daemon-reload',
+    refreshonly => true,
+  }
+}

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -22,6 +22,20 @@ describe 'nebula::profile::prometheus::exporter::node' do
           .that_requires('Package[prometheus-node-exporter]')
       end
 
+      it do
+        is_expected.to contain_file('/etc/rsyslog.d/prometheus-node-exporter.conf')
+          .that_notifies('Service[prometheus-node-exporter]')
+          .that_notifies('Service[rsyslog]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/log/prometheus-node-exporter.log')
+          .with_owner('root')
+          .with_group('adm')
+          .with_mode('0640')
+          .with_content('')
+      end
+
       it { is_expected.to contain_service('prometheus-node-exporter') }
 
       it do

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -9,6 +9,7 @@ macaddress: "AA:AA:AA:AA:AA:AA"
 dmi: {}
 installed_backports: []
 datacenter: "mydatacenter"
+prometheus_errors_total: 0
 mountpoints: {}
 disks: {}
 root_home: "/root"

--- a/templates/profile/prometheus/exporter/node/node_exporter_errors.prom.erb
+++ b/templates/profile/prometheus/exporter/node/node_exporter_errors.prom.erb
@@ -1,0 +1,3 @@
+# HELP node_exporter_errors The number of errors that occur every time Prometheus scrapes the node exporter.
+# TYPE node_exporter_errors gauge
+node_exporter_errors <%= @prometheus_errors_total %>

--- a/templates/profile/prometheus/exporter/node/rsyslog.conf.erb
+++ b/templates/profile/prometheus/exporter/node/rsyslog.conf.erb
@@ -1,0 +1,2 @@
+if $programname == 'prometheus-node-exporter' then <%= @log_file %>
+& stop

--- a/templates/profile/prometheus/exporter/node/systemd.ini.erb
+++ b/templates/profile/prometheus/exporter/node/systemd.ini.erb
@@ -11,6 +11,9 @@ ExecStart=/usr/bin/prometheus-node-exporter $ARGS
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=prometheus-node-exporter
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes the prometheus node exporter has errors, and those errors fill
up /var/log. This way, they'll be cleared out every 30 minutes, but also
their presence won't be lost.