### PR TITLE
AEIM-2313 - Restore settings for mod_php

### DIFF
--- a/manifests/profile/www_lib/php.pp
+++ b/manifests/profile/www_lib/php.pp
@@ -75,4 +75,17 @@ class nebula::profile::www_lib::php () {
       # XML_Util
     },
   }
+
+  class { 'php::apache_config':
+    settings => {
+      'PHP/short_open_tag'          => 'On',
+      'PHP/max_input_vars'          => '2000',
+      'PHP/memory_limit'            => '256M',
+      'PHP/error_reporting'         => 'E_ALL & ~E_DEPRECATED',
+      'PHP/upload_max_filesize'     => '32M',
+      'Date/date.timezone'          => 'America/Detroit',
+      'mail function/sendmail_path' => '/usr/sbin/sendmail -t -i'
+    },
+  }
+
 }


### PR DESCRIPTION
The PHP settings are duplicated across 5 and 7 for now; we can find a
better way to normalize them later.