### PR TITLE
AEIM-2206: Create redirects vhost

### DIFF
--- a/manifests/apache/redirect_vhost_http.pp
+++ b/manifests/apache/redirect_vhost_http.pp
@@ -3,14 +3,15 @@
 # BSD License. See LICENSE.txt for details.
 
 define nebula::apache::redirect_vhost_http (
-  String $servername,
   Array[String] $serveraliases = [],
-  String $target = "http://www.${servername}",
+  String $target = "http://www.${title}/",
+  $priority = false,
 ) {
-  apache::vhost { "${servername}-http":
+  apache::vhost { "${title}-redirect-http":
     port            => '80',
+    priority        => $priority,
     docroot         => false,
-    servername      => $servername,
+    servername      => $title,
     serveraliases   => $serveraliases,
     redirect_source => '/',
     redirect_status => 'permanent',

--- a/manifests/apache/redirect_vhost_https.pp
+++ b/manifests/apache/redirect_vhost_https.pp
@@ -6,8 +6,13 @@ define nebula::apache::redirect_vhost_https (
   Array[String] $serveraliases = [],
   String $target = "https://www.${title}/",
   String $ssl_cn = $title,
+  $priority = false,
 ) {
-  nebula::apache::www_lib_vhost { "${title}-https":
+  nebula::apache::redirect_vhost_http { $title:
+    serveraliases => $serveraliases
+  }
+  nebula::apache::www_lib_vhost { "${title}-redirect-https":
+    priority        => $priority,
     ssl             => true,
     ssl_cn          => $ssl_cn,
     docroot         => false,

--- a/manifests/apache/www_lib_vhost.pp
+++ b/manifests/apache/www_lib_vhost.pp
@@ -27,6 +27,7 @@ define nebula::apache::www_lib_vhost (
   Optional[String] $ssl_proxy_check_peer_expire = undef,
   Optional[Array] $setenv = undef,
   Optional[Array] $setenvifnocase = undef,
+  $priority = false
 ) {
   $ssl_cert = "${nebula::profile::apache::ssl_cert_dir}/${ssl_cn}.crt"
   $ssl_key = "${nebula::profile::apache::ssl_key_dir}/${ssl_cn}.key"
@@ -138,7 +139,7 @@ define nebula::apache::www_lib_vhost (
     manage_docroot              => false,
     directories                 => $default_directories + $directories + $cosign_locations,
     log_level                   => 'warn',
-    priority                    => false, # don't prepend a numeric identifier to the vhost
+    priority                    => $priority,
     ssl                         => $ssl,
     # unused if ssl is false
     ssl_protocol                => '+TLSv1.2',

--- a/manifests/profile/www_lib/apache.pp
+++ b/manifests/profile/www_lib/apache.pp
@@ -87,29 +87,27 @@ class nebula::profile::www_lib::apache (
   # should be moved elsewhere to include as virtual all that might be present on the puppet master
   @nebula::apache::ssl_keypair {
     [
-      'www.lib.umich.edu',
-      'www.mportfolio.umich.edu',
       'datamart.lib.umich.edu',
       'deepblue.lib.umich.edu',
-      'www.theater-historiography.org',
+      'developingwritersbook.com',
+      'fulcrum.org',
       'open.umich.edu',
+      'michiganelt.org',
       'mirlyn.lib.umich.edu',
       'staff.lib.umich.edu',
+      'www.digitalculture.org',
+      'www.lib.umich.edu',
+      'www.mblem.umich.edu',
+      'www.mportfolio.umich.edu',
       'www.press.umich.edu',
+      'www.publishing.umich.edu',
+      'www.textcreationpartnership.org',
+      'www.theater-historiography.org',
     ]:
   }
 
-  nebula::apache::redirect_vhost_https { 'theater-historiography.org':
-    ssl_cn        => 'www.theater-historiography.org',
-    serveraliases => [
-      'www.theater-historiography.com',
-      'theater-historiography.com',
-      'www.theatre-historiography.com',
-      'theatre-historiography.com',
-      'www.theatre-historiography.org',
-      'theatre-historiography.org',
-    ],
-  }
+  # depends on ssl_keypairs above
+  include nebula::profile::www_lib::vhosts::redirects
 
   $vhost_prefix = 'nebula::profile::www_lib::vhosts'
 

--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -1,0 +1,237 @@
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::www_lib::vhosts::redirects(
+) {
+
+  nebula::apache::redirect_vhost_http { 'mediaindustriesjournal.org':
+    serveraliases => [],
+  }
+
+  nebula::apache::redirect_vhost_https { 'michiganelt.org':
+    serveraliases => []
+  }
+
+  nebula::apache::redirect_vhost_http { 'www.michiganelt.org':
+    target => 'http://www.press.umich.edu/elt'
+  }
+
+  nebula::apache::redirect_vhost_https { 'lib.umich.edu':
+    ssl_cn        => 'www.lib.umich.edu',
+    serveraliases => ['lib', 'library.umich.edu', 'www.library.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'mblem.umich.edu':
+    ssl_cn        => 'www.mblem.umich.edu',
+    serveraliases => ['mblem.nslb.umdl.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'mportfolio.umich.edu':
+    ssl_cn        => 'www.mportfolio.umich.edu',
+    serveraliases => ['mportfolio.nslb.umdl.umich.edu'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'publishing.umich.edu':
+    ssl_cn        => 'www.publishing.umich.edu',
+    serveraliases => ['publishing'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'press.umich.edu':
+    ssl_cn        => 'www.press.umich.edu',
+    serveraliases => ['press.lib.umich.edu', 'press.nslb.umdl.umich.edu']
+  }
+
+  nebula::apache::redirect_vhost_https { 'developingwritersbook.org':
+    ssl_cn        => 'developingwritersbook.com',
+    serveraliases => [
+      'developingwritersbook.com',
+      'developingwritersbook.net',
+      'www.developingwritersbook.com',
+      'www.developingwritersbook.net'
+    ],
+  }
+
+  nebula::apache::redirect_vhost_https { 'fulcrum.publishing.umich.edu':
+    ssl_cn   => 'www.publishing.umich.edu',
+    priority => '07',
+    target   => 'https://tools.lib.umich.edu/confluence/display/FPS'
+  }
+
+  nebula::apache::redirect_vhost_https { 'support.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://tools.lib.umich.edu/confluence/display/FPS',
+    serveraliases => ['support.fulcrum.org', 'support.fulcrumservices.org'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'northwestern.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/northwestern',
+    serveraliases => ['northwestern.fulcrum.org', 'northwestern.fulcrumservices.org'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'minnesota.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/minnesota',
+    serveraliases => [ 'minnesota.fulcrum.org', 'minnesota.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'michigan.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/michigan',
+    serveraliases => [ 'michigan.fulcrum.org', 'michigan.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'indiana.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/indiana',
+    serveraliases => [ 'indiana.fulcrum.org', 'indiana.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'pennstate.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/pennstate',
+    serveraliases => [ 'pennstate.fulcrum.org', 'pennstate.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'nyupress.fulcrumscholar.org':
+    ssl_cn        => 'fulcrum.org',
+    priority      => '08',
+    target        => 'https://www.fulcrum.org/nyupress',
+    serveraliases => [ 'nyupress.fulcrum.org', 'nyupress.fulcrumservices.org']
+  }
+
+  nebula::apache::redirect_vhost_https { 'fulcrum.org':
+    priority      => '14',
+    serveraliases => [
+      'fulcrum.pub',
+      'fulcrumscholar.org',
+      'fulcrumscholar.com',
+      'fulcrumscholar.net',
+      'fulcrumservices.org',
+      'fulcrumservices.net',
+      '*.fulcrum.org',
+      '*.fulcrum.pub',
+      '*.fulcrumscholar.org',
+      '*.fulcrumscholar.com',
+      '*.fulcrumscholar.net',
+      '*.fulcrumservices.org',
+      '*.fulcrumservices.net',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_https { 'digitalculture.org':
+    ssl_cn        => 'www.digitalculture.org',
+    serveraliases => [
+      'www.digitalculturebooks.com',
+      'digitalculturebooks.com',
+      'www.digitalculturebooks.org',
+      'digitalculturebooks.org',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_http { 'lgbtheritage.org':
+  }
+
+  nebula::apache::redirect_vhost_https { 'textcreationpartnership.org':
+    ssl_cn        => 'www.textcreationpartnership.org',
+    serveraliases => ['www.textcreationpartnership.com', 'textcreationpartnership.com'],
+  }
+
+  nebula::apache::redirect_vhost_https { 'theater-historiography.org':
+    ssl_cn        => 'www.theater-historiography.org',
+    serveraliases => [
+      'www.theater-historiography.com',
+      'theater-historiography.com',
+      'www.theatre-historiography.com',
+      'theatre-historiography.com',
+      'www.theatre-historiography.org',
+      'theatre-historiography.org',
+    ],
+  }
+
+  nebula::apache::redirect_vhost_http { 'mazebooks.org':
+    serveraliases => ['www.mazebooks.org'],
+  }
+
+  nebula::apache::redirect_vhost_http { 'www.maizebooks.org':
+    target => 'http://www.publishing.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'datainfolit.org':
+    serveraliases => ['www.datainformationliteracy.org', 'datainformationliteracy.org'],
+  }
+
+  nebula::apache::redirect_vhost_http { 'beta.lib.umich.edu':
+    target => 'http://www.lib.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'medsearch.lib.umich.edu':
+    serveraliases => ['medsearch', 'medsearch.lib'],
+    target        => 'http://www.lib.umich.edu/health-sciences-libraries/medsearch/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'm-update.lib.umich.edu':
+    serveraliases => ['m-update.lib'],
+    target        => 'http://m.lib.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'www-update.lib.umich.edu':
+    serveraliases => ['www-update.lib'],
+    target        => 'http://www.lib.umich.edu/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'pk.lib.umich.edu':
+    target => 'http://www.lib.umich.edu/pk/'
+  }
+
+  nebula::apache::redirect_vhost_http { 'sfx.lib.umich.edu':
+    serveraliases => ['sfx.lib'],
+    target        => 'http://mgetit.lib.umich.edu/'
+  }
+
+  apache::vhost { 'lgbtheritage.org-redirect-http-all':
+    priority   => false,
+    port       => '80',
+    docroot    => false,
+    servername => 'www.lgbtheritage.org',
+    rewrites   => [
+      {
+        rewrite_rule => ['^/.*$ http://www.lib.umich.edu/online-exhibits/exhibits/show/lgbtheritage/ [redirect,noescape]']
+      }
+    ]
+  }
+
+  apache::vhost { 'searchtools.lib.umich.edu-redirect-http':
+    priority      => false,
+    port          => '80',
+    docroot       => false,
+    servername    => 'searchtools.lib.umich.edu',
+    serveraliases => ['searchtools.lib'],
+    rewrites      => [
+      {
+        rewrite_cond => ['%{QUERY_STRING} func=native-link'],
+        rewrite_rule => ['^/(V|V/.*)$ http://www.lib.umich.edu/V [redirect=permanent,last,noescape]'],
+      },
+      {
+        rewrite_cond => ['%{QUERY_STRING} func=find-db-1(.*)mode=category'],
+        rewrite_rule => ['^/(V|V/.*)$ http://www.lib.umich.edu/searchtools#databases/search?  [redirect=permanent,last,noescape]'],
+      },
+      {
+        rewrite_cond => ['%{QUERY_STRING} func=find-db-1'],
+        rewrite_rule => ['^/(V|V/.*)$ http://www.lib.umich.edu/searchtools#databases? [redirect=permanent,last,noescape]'],
+      },
+      {
+        rewrite_rule => ['^/.*$ http://www.lib.umich.edu/searchtools? [redirect=permanent,last,noescape]']
+      }
+    ]
+
+  }
+
+}

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -85,7 +85,27 @@ describe 'nebula::role::webhost::www_lib_vm' do
       end
 
       it do
-        is_expected.to contain_apache__vhost('theater-historiography.org-https')
+        is_expected.to contain_apache__vhost('mediaindustriesjournal.org-redirect-http')
+          .with_redirect_dest('http://www.mediaindustriesjournal.org/')
+          .with_serveraliases([])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('michiganelt.org-redirect-https')
+          .with_redirect_dest('https://www.michiganelt.org/')
+          .with_serveraliases([])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('lib.umich.edu-redirect-https')
+          .with_redirect_dest('https://www.lib.umich.edu/')
+          .with_serveraliases(%w[lib
+                                 library.umich.edu
+                                 www.library.umich.edu])
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('theater-historiography.org-redirect-https')
           .with_ssl_cert('/etc/ssl/certs/www.theater-historiography.org.crt')
           .with_redirect_dest('https://www.theater-historiography.org/')
           .with_serveraliases(%w[www.theater-historiography.com


### PR DESCRIPTION
Implements the "redirects vhost" in puppet. Some notes:

* This terminates ssl for those vhosts that were specified as https. This is a change from what was in rdist. See Aaron's comments on #198 
* https redirects automatically have http redirects as well
* The `copyright` redirects have been removed; copyright dept (group?) confirms they're not currently being used anyway, and gave the greenlight to remove them so long as there was no risk of content loss.