### PR TITLE
AEIM-2409 - Fix up Open Michigan ServerAlias

### DIFF
--- a/manifests/profile/www_lib/vhosts/openmich.pp
+++ b/manifests/profile/www_lib/vhosts/openmich.pp
@@ -23,7 +23,7 @@ class nebula::profile::www_lib::vhosts::openmich (
 
   nebula::apache::www_lib_vhost { 'openmich-http':
     servername     => $servername,
-    serveraliases  => ["${prefix}openmich.www.lib.${domain}"],
+    serveraliases  => ["${prefix}openmich.www.${domain}"],
     docroot        => $docroot,
     logging_prefix => 'openmich/',
 
@@ -36,7 +36,7 @@ class nebula::profile::www_lib::vhosts::openmich (
 
   nebula::apache::www_lib_vhost { 'openmich-https':
     servername     => $servername,
-    serveraliases  => ["${prefix}openmich.www.lib.${domain}"],
+    serveraliases  => ["${prefix}openmich.www.${domain}"],
     docroot        => $docroot,
     logging_prefix => 'openmich/',
 


### PR DESCRIPTION
We were including `lib` in the role, giving openmich.www.lib.lib as an alias.