### PR TITLE
Block IPv6: purge chains and default to drop

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -91,6 +91,20 @@ class nebula::profile::networking::firewall (
       'FORWARD:filter:IPv4':
         ignore => $forward_ignore,
       ;
+
+      # Purge and then block all IPv6 traffic
+
+      'INPUT:filter:IPv6':
+        policy => drop,
+      ;
+
+      'FORWARD:filter:IPv6':
+        policy => drop,
+      ;
+
+      'OUTPUT:filter:IPv6':
+        policy => drop,
+      ;
     }
   }
 

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -101,7 +101,7 @@ class nebula::profile::networking::firewall (
       purge => true,  
       ensure => present,
       policy => drop,
-      before => undef,
+      # before => undef,
     ;
 
     ['INPUT:filter:IPv6', 'OUTPUT:filter:IPv6', 'FORWARD:filter:IPv6']:

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -114,7 +114,6 @@ class nebula::profile::networking::firewall (
     ;
   }
 
-
   $firewall_defaults = {
     proto  => 'tcp',
     state  => 'NEW',

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -97,6 +97,7 @@ class nebula::profile::networking::firewall (
 
   # Disable IPv6  
   firewallchain { 'INPUT:filter:IPv6':
+    purge => true,  
     ensure => present,
     policy => drop,
     before => undef,

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -92,21 +92,28 @@ class nebula::profile::networking::firewall (
         ignore => $forward_ignore,
       ;
 
-      # Purge and then block all IPv6 traffic
-
-      'INPUT:filter:IPv6':
-        policy => drop,
-      ;
-
-      'FORWARD:filter:IPv6':
-        policy => drop,
-      ;
-
-      'OUTPUT:filter:IPv6':
-        policy => drop,
-      ;
     }
   }
+
+  firewallchain {
+    default:
+      ensure => 'present',
+      purge  => true,
+    ;
+
+    'INPUT:filter:IPv6':
+      policy => 'drop',
+    ;
+
+    'OUTPUT:filter:IPv6':
+      policy => 'drop',
+    ;
+
+    'FORWARD:filter:IPv6':
+      policy => 'drop',
+    ;
+  }
+
 
   $firewall_defaults = {
     proto  => 'tcp',

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -98,8 +98,8 @@ class nebula::profile::networking::firewall (
   # Disable IPv6 by making chains DROP everything 
   firewallchain {
     default:
-      purge => true,  
       ensure => present,
+      purge  => true,
       policy => drop,
       # before => undef,
     ;

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -100,11 +100,18 @@ class nebula::profile::networking::firewall (
     default:
       ensure => present,
       purge  => true,
-      policy => drop,
-      # before => undef,
     ;
 
-    ['INPUT:filter:IPv6', 'OUTPUT:filter:IPv6', 'FORWARD:filter:IPv6']:
+    'INPUT:filter:IPv6':
+      policy => drop,
+    ;
+
+    'FORWARD:filter:IPv6':
+      policy => drop,
+    ;
+
+    'OUTPUT:filter:IPv6':
+      policy => drop,
     ;
   }
 

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -95,23 +95,12 @@ class nebula::profile::networking::firewall (
     }
   }
 
-  firewallchain {
-    default:
-      ensure => 'present',
-      purge  => true,
-    ;
-
-    'INPUT:filter:IPv6':
-      policy => 'drop',
-    ;
-
-    'OUTPUT:filter:IPv6':
-      policy => 'drop',
-    ;
-
-    'FORWARD:filter:IPv6':
-      policy => 'drop',
-    ;
+  # Disable IPv6  
+  firewallchain { 'INPUT:filter:IPv6':
+    purge => true,
+    ensure => present,
+    policy => drop,
+    before => undef,
   }
 
   $firewall_defaults = {
@@ -140,4 +129,5 @@ class nebula::profile::networking::firewall (
     action => 'drop',
     before => undef,
   }
+
 }

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -95,12 +95,17 @@ class nebula::profile::networking::firewall (
     }
   }
 
-  # Disable IPv6  
-  firewallchain { 'INPUT:filter:IPv6':
-    purge => true,  
-    ensure => present,
-    policy => drop,
-    before => undef,
+  # Disable IPv6 by making chains DROP everything 
+  firewallchain {
+    default:
+      purge => true,  
+      ensure => present,
+      policy => drop,
+      before => undef,
+    ;
+
+    ['INPUT:filter:IPv6', 'OUTPUT:filter:IPv6', 'FORWARD:filter:IPv6']:
+    ;
   }
 
   $firewall_defaults = {

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -97,7 +97,6 @@ class nebula::profile::networking::firewall (
 
   # Disable IPv6  
   firewallchain { 'INPUT:filter:IPv6':
-    purge => true,
     ensure => present,
     policy => drop,
     before => undef,


### PR DESCRIPTION
This should make the rules.v6 file block all ipv6 traffic by making chains empty and default to drop.