### PR TITLE
AEIM-2465 - Add explicit rules for IPv6

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -28,6 +28,14 @@ class nebula::profile::networking::firewall (
     resources { 'firewall':
       purge => true,
     }
+
+    firewallchain {
+      ['INPUT:filter:IPv4', 'OUTPUT:filter:IPv4', 'FORWARD:filter:IPv4',
+      'INPUT:filter:IPv6', 'OUTPUT:filter:IPv6', 'FORWARD:filter:IPv6']:
+        ensure => 'present',
+        policy => 'accept',
+      ;
+    }
   } else {
     case $internal_routing {
       'docker': {
@@ -80,6 +88,7 @@ class nebula::profile::networking::firewall (
       default:
         ensure => 'present',
         purge  => true,
+        policy => 'accept',
       ;
 
       'INPUT:filter:IPv4':

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -82,8 +82,6 @@ class nebula::profile::networking::firewall (
         purge  => true,
       ;
 
-      # -- IPv4 ----
-      #
       'INPUT:filter:IPv4':
         ignore => $input_ignore,
       ;
@@ -96,19 +94,13 @@ class nebula::profile::networking::firewall (
         ignore => $forward_ignore,
       ;
 
-      # ---- IPv6 ----
-      # 
-      # Security: disable IPv6, all chains default to DROP.
       'INPUT:filter:IPv6':
-        policy => drop,
       ;
 
       'FORWARD:filter:IPv6':
-        policy => drop,
       ;
 
       'OUTPUT:filter:IPv6':
-        policy => drop,
       ;
     }
 
@@ -122,7 +114,7 @@ class nebula::profile::networking::firewall (
 
   create_resources(firewall,$rules,$firewall_defaults)
 
-  # Default items, sorted by title
+  # Default IPv4 items, sorted by title
   firewall { '001 accept related established rules':
     proto  => 'all',
     state  => ['RELATED', 'ESTABLISHED'],
@@ -139,6 +131,28 @@ class nebula::profile::networking::firewall (
     proto  => 'all',
     action => 'drop',
     before => undef,
+  }
+
+  # Default IPv6 items, sorted by title
+  firewall { '001 accept related established rules (v6)':
+    proto    => 'all',
+    state    => ['RELATED', 'ESTABLISHED'],
+    action   => 'accept',
+    provider => 'ip6tables',
+  }
+
+  firewall { '001 accept all to lo interface (v6)':
+    proto    => 'all',
+    iniface  => 'lo',
+    action   => 'accept',
+    provider => 'ip6tables',
+  }
+
+  firewall { '999 drop all (v6)':
+    proto    => 'all',
+    action   => 'drop',
+    before   => undef,
+    provider => 'ip6tables',
   }
 
 }

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -21,10 +21,28 @@ describe 'nebula::profile::networking::firewall' do
       end
 
       it do
+        is_expected.to contain_firewall('001 accept related established rules (v6)').with(
+          proto: 'all',
+          state: %w[RELATED ESTABLISHED],
+          action: 'accept',
+          provider: 'ip6tables',
+        )
+      end
+
+      it do
         is_expected.to contain_firewall('001 accept all to lo interface').with(
           proto: 'all',
           iniface: 'lo',
           action: 'accept',
+        )
+      end
+
+      it do
+        is_expected.to contain_firewall('001 accept all to lo interface (v6)').with(
+          proto: 'all',
+          iniface: 'lo',
+          action: 'accept',
+          provider: 'ip6tables',
         )
       end
 
@@ -56,7 +74,15 @@ describe 'nebula::profile::networking::firewall' do
         )
       end
 
-      it { is_expected.to have_firewall_resource_count(5) }
+      it do
+        is_expected.to contain_firewall('999 drop all (v6)').with(
+          proto: 'all',
+          action: 'drop',
+          provider: 'ip6tables',
+        )
+      end
+
+      it { is_expected.to have_firewall_resource_count(8) }
 
       it { is_expected.to contain_package('iptables-persistent') }
       it { is_expected.to contain_package('netfilter-persistent') }
@@ -71,6 +97,12 @@ describe 'nebula::profile::networking::firewall' do
         %w[INPUT OUTPUT FORWARD].each do |chain|
           it do
             is_expected.to contain_firewallchain("#{chain}:filter:IPv4")
+              .with_ensure('present')
+              .with_purge(true)
+          end
+
+          it do
+            is_expected.to contain_firewallchain("#{chain}:filter:IPv6")
               .with_ensure('present')
               .with_purge(true)
           end

--- a/spec/classes/role/minimum_spec.rb
+++ b/spec/classes/role/minimum_spec.rb
@@ -18,29 +18,6 @@ describe 'nebula::role::minimum' do
         it { is_expected.to have_firewall_resource_count(0) }
       when 'debian-9-x86_64'
         it { is_expected.to contain_class('nebula::profile::networking::firewall') }
-        it { is_expected.to have_firewall_resource_count(3) }
-        it do
-          is_expected.to contain_firewall('001 accept related established rules').with(
-            proto: 'all',
-            state: %w[RELATED ESTABLISHED],
-            action: 'accept',
-          )
-        end
-
-        it do
-          is_expected.to contain_firewall('001 accept all to lo interface').with(
-            proto: 'all',
-            iniface: 'lo',
-            action: 'accept',
-          )
-        end
-
-        it do
-          is_expected.to contain_firewall('999 drop all').with(
-            proto: 'all',
-            action: 'drop',
-          )
-        end
       end
     end
   end


### PR DESCRIPTION
Dropping everything on IPv6 was causing problems for connections to
localhost by name. By mirroring our IPv4 rules, we get the same effect,
except that loopback connections are accepted.