### PR TITLE
AEIM-2467 Add redirect vhosts for copyright.umich.edu

### DIFF
--- a/manifests/profile/www_lib/apache.pp
+++ b/manifests/profile/www_lib/apache.pp
@@ -87,6 +87,7 @@ class nebula::profile::www_lib::apache (
   # should be moved elsewhere to include as virtual all that might be present on the puppet master
   @nebula::apache::ssl_keypair {
     [
+      'copyright.umich.edu',
       'datamart.lib.umich.edu',
       'deepblue.lib.umich.edu',
       'developingwritersbook.com',

--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -208,6 +208,25 @@ class nebula::profile::www_lib::vhosts::redirects(
     ]
   }
 
+  nebula::apache::redirect_vhost_http { 'copyright.umich.edu':
+    serveraliases => ['www.copyright.umich.edu'],
+    target        => 'https://copyright.umich.edu/'
+  }
+
+  nebula::apache::www_lib_vhost { 'copyright.umich.edu-redirect-https-all':
+    priority      => false,
+    ssl           => true,
+    ssl_cn        => 'copyright.umich.edu',
+    docroot       => false,
+    servername    => 'copyright.umich.edu',
+    serveraliases => ['www.copyright.umich.edu'],
+    rewrites      => [
+      {
+        rewrite_rule => ['^/.*$ https://www.lib.umich.edu/copyright/?utm_source=copyright.umich.edu&utm_medium=redirect [redirect,noescape]']
+      }
+    ]
+  }
+
   apache::vhost { 'searchtools.lib.umich.edu-redirect-http':
     priority      => false,
     port          => '80',

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -239,6 +239,19 @@ describe 'nebula::role::webhost::www_lib_vm' do
           .with_ssl_cert('/etc/ssl/certs/www.press.umich.edu.crt')
           .with_setenv(['HTTPS on'])
       end
+
+      it do
+        is_expected.to contain_apache__vhost('copyright.umich.edu-redirect-http')
+          .with_servername('copyright.umich.edu')
+          .with_port(80)
+      end
+
+      it do
+        is_expected.to contain_apache__vhost('copyright.umich.edu-redirect-https-all')
+          .with_servername('copyright.umich.edu')
+          .with_ssl_cert('/etc/ssl/certs/copyright.umich.edu.crt')
+          .with_port(443)
+      end
     end
   end
 end


### PR DESCRIPTION
Support is needed for both http and https. I used redirect_vhost_http to redirect http to https and added an https vhost to handle the redirection of all source URLs to the single target under www.lib. Alternatives are welcome.