### PR TITLE
PFDR-263 - Add PAM/sshd config

### DIFF
--- a/files/pam.d/sshd-stretch
+++ b/files/pam.d/sshd-stretch
@@ -1,0 +1,56 @@
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+auth required pam_duo.so
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account  required     pam_access.so
+
+# Standard Un*x authorization.
+@include common-account
+
+# SELinux needs to be the first session rule.  This ensures that any
+# lingering context has been cleared.  Without this it is possible that a
+# module could execute code in the wrong domain.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so close
+
+# Set the loginuid process attribute.
+session    required     pam_loginuid.so
+
+# Create a new session keyring.
+session    optional     pam_keyinit.so force revoke
+
+# Standard Un*x session setup and teardown.
+@include common-session
+
+# Print the message of the day upon successful login.
+# This includes a dynamically generated part from /run/motd.dynamic
+# and a static (admin-editable) part from /etc/motd.
+session    optional     pam_motd.so  motd=/run/motd.dynamic
+session    optional     pam_motd.so noupdate
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv # [1]
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+session    required     pam_env.so # [1]
+# In Debian 4.0 (etch), locale-related environment variables were moved to
+# /etc/default/locale, so read that as well.
+session    required     pam_env.so user_readenv=1 envfile=/etc/default/locale
+
+# SELinux needs to intervene at login time to ensure that the process starts
+# in the proper default security context.  Only sessions which are intended
+# to run in the user's context should be run after this.
+session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_selinux.so open
+
+# Standard Un*x password updating.
+@include common-password

--- a/manifests/role/chipmunk.pp
+++ b/manifests/role/chipmunk.pp
@@ -5,6 +5,24 @@ class nebula::role::chipmunk {
   if $facts['os']['family'] == 'Debian' and $::lsbdistcodename != 'jessie' {
     include nebula::profile::hathitrust::dependencies
     include nebula::profile::hathitrust::perl
+
+    # Ensure that group-write umask is set for uploaders
+    file { '/etc/pam.d/sshd':
+      require => File["/etc/pam.d/sshd-${::lsbdistcodename}"],
+      notify  => Service['sshd'],
+      content => @("EOT")
+        # Managed by puppet (manifests/role/chipmunk)
+
+        @include sshd-${::lsbdistcodename}
+
+        # Set the umask for uploads
+        session    optional   pam_umask.so umask=0002
+      | EOT
+    }
+
+    file { "/etc/pam.d/sshd-${::lsbdistcodename}":
+      source => "puppet:///modules/nebula/pam.d/sshd-${::lsbdistcodename}",
+    }
   }
 
   # should be conditionally included from named_instances::apache when the

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -15,6 +15,10 @@ describe 'nebula::role::chipmunk' do
       let(:hiera_config) { 'spec/fixtures/hiera/chipmunk_config.yaml' }
 
       it { is_expected.to compile }
+
+      if os == 'debian-9-x86_64'
+        it { is_expected.to contain_file('/etc/pam.d/sshd-stretch') }
+      end
     end
   end
 end


### PR DESCRIPTION
This brings in a stock stretch /etc/pam.d/sshd config and introduces an
inline template to include that and then add the umask settings.
Specifically, the umask is set to 0002 on ssh logins, so rsync uploads
can preserve setgid and group write permissions readily with:

rsync -rzvtP --no-group --no-perms --chmod=ugo=rwX

This formula is mentioned in the rsync man page, in the --perms section.