### PR TITLE
HT-1845: redirects for m.hathitrust.org

### DIFF
--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -37,7 +37,6 @@ class nebula::profile::hathitrust::apache::catalog (
   apache::vhost { "${servername} ssl":
     servername        => $servername,
     port              => 443,
-    serveraliases     => ["${prefix}m.${domain}"],
     manage_docroot    => false,
     docroot           => $docroot,
     error_log_file    => 'catalog/error.log',


### PR DESCRIPTION
redirect m.hathitrust.org to www.hathitrust.org (for root) or catalog.hathitrust.org (for everything else)