### PR TITLE
HT-379: testing isn't buster any more

### DIFF
--- a/manifests/profile/apt/buster.pp
+++ b/manifests/profile/apt/buster.pp
@@ -2,24 +2,24 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-# Add Debian testing apt repo by code name
+# Add Debian buster apt repo by code name
 #
 # @example
-#   include nebula::profile::apt::testing
-class nebula::profile::apt::testing {
+#   include nebula::profile::apt::buster
+class nebula::profile::apt::buster {
   # pinning first so we don't install things we don't want
-  apt::pin { 'testing':
-    explanation => 'Deprioritize packages from Debian Testing',
-    release     => 'testing',
+  apt::pin { 'buster':
+    explanation => 'Deprioritize packages from Debian buster',
+    release     => 'buster',
     priority    => -10,
     packages    => '*',
-    before      => Apt::Source['testing']
+    before      => Apt::Source['buster']
   }
 
   # add apt repo
-  apt::source { 'testing':
+  apt::source { 'buster':
     location => lookup('nebula::profile::apt::mirror'),
-    release  => 'testing',
+    release  => 'buster',
     repos    => 'main contrib non-free',
   }
 }

--- a/manifests/profile/hathitrust/dependencies.pp
+++ b/manifests/profile/hathitrust/dependencies.pp
@@ -34,8 +34,8 @@ class nebula::profile::hathitrust::dependencies () {
   }
 
   # install jhove, pin it to buster if we're on stretch
-  if $facts['os']['family'] == 'Debian' and $::lsbdistcodename != 'jessie' {
-    include nebula::profile::apt::testing
+  if $facts['os']['family'] == 'Debian' and $::lsbdistcodename == 'stretch' {
+    include nebula::profile::apt::buster
     include apt::backports
 
     $packages = ['jhove','libjaxb-api-java','libactivation-java']
@@ -46,7 +46,7 @@ class nebula::profile::hathitrust::dependencies () {
       codename    => $release,
       priority    => 700,
       packages    => $packages,
-      require     => Class['nebula::profile::apt::testing']
+      require     => Class['nebula::profile::apt::buster']
     }
 
     package {

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -33,8 +33,8 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
           is_expected.to contain_apt__pin('buster-jhove')
             .with(codename: 'buster', packages: ['jhove', 'libjaxb-api-java', 'libactivation-java'])
         end
-        it { is_expected.to contain_apt__source('testing') }
-        it { is_expected.to contain_apt__pin('testing').with(priority: '-10', packages: '*') }
+        it { is_expected.to contain_apt__source('buster') }
+        it { is_expected.to contain_apt__pin('buster').with(priority: '-10', packages: '*') }
 
       end
 


### PR DESCRIPTION
initial installation of jhove/libactivation-java doesn't work on stretch
currently because buster is stable (not testing) now