### PR TITLE
HTS-135762 - use /ram as the tmpdir for HT ingest service

### DIFF
--- a/templates/profile/hathitrust/ingest_service/feedd.service.erb
+++ b/templates/profile/hathitrust/ingest_service/feedd.service.erb
@@ -7,6 +7,7 @@ Type=simple
 RemainAfterExit=no
 User=libadm
 Environment="HTFEED_CONFIG=<%= @config %>"
+Environment="TMPDIR=/ram"
 ExecStart=/usr/bin/perl /htapps/babel/feed/bin/feedd.pl
 Restart=always
 


### PR DESCRIPTION
The default /tmp is 4G on the ingest machines, which was too small to
process some large images with imagemagick. This uses /ram, which a
corresponding change in lensoftruth has enlarged to 16G.