### PR TITLE
change release to codename

### DIFF
--- a/manifests/profile/apt/buster.pp
+++ b/manifests/profile/apt/buster.pp
@@ -10,7 +10,7 @@ class nebula::profile::apt::buster {
   # pinning first so we don't install things we don't want
   apt::pin { 'buster':
     explanation => 'Deprioritize packages from Debian buster',
-    release     => 'buster',
+    codename    => 'buster',
     priority    => -10,
     packages    => '*',
     before      => Apt::Source['buster']


### PR DESCRIPTION
Wasn't working with release; verified this should work with the actual apt pin file and the generated template here https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/pin.pref.epp