### PR TITLE
AEIM-2384 - Pin docker and kubernetes to a version

### DIFF
--- a/manifests/profile/docker.pp
+++ b/manifests/profile/docker.pp
@@ -69,5 +69,11 @@ class nebula::profile::docker (
       version          => $version,
       extra_parameters => ['--insecure-registry=hatcher-kubernetes.umdl.umich.edu:32030'],
     }
+
+    apt::pin { 'docker-ce':
+      packages => ['docker-ce', 'docker-ce-cli'],
+      version  => $version,
+      priority => 999,
+    }
   }
 }

--- a/manifests/profile/kubernetes.pp
+++ b/manifests/profile/kubernetes.pp
@@ -64,6 +64,12 @@ class nebula::profile::kubernetes (
     require => [Apt::Source['kubernetes'], Class['docker']],
   }
 
+  apt::pin { 'kubernetes':
+    packages => ['kubeadm', 'kubelet'],
+    version  => "${kubernetes_version}-00",
+    priority => 999,
+  }
+
   apt::source { 'kubernetes':
     location => 'https://apt.kubernetes.io/',
     release  => 'kubernetes-xenial',

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -52,12 +52,20 @@ describe 'nebula::profile::docker' do
 
       context 'without version set' do
         it { is_expected.to contain_class('docker').without_version }
+        it { is_expected.not_to contain_apt__pin('docker-ce') }
       end
 
       context 'with version set to 5' do
         let(:params) { { version: '5' } }
 
         it { is_expected.to contain_class('docker').with_version('5') }
+
+        it do
+          is_expected.to contain_apt__pin('docker-ce').with(
+            packages: %w[docker-ce docker-ce-cli],
+            version: '5',
+          )
+        end
       end
     end
   end

--- a/spec/classes/profile/kubernetes_spec.rb
+++ b/spec/classes/profile/kubernetes_spec.rb
@@ -44,6 +44,13 @@ describe 'nebula::profile::kubernetes' do
         end
 
         it do
+          is_expected.to contain_apt__pin('kubernetes').with(
+            packages: %w[kubeadm kubelet],
+            version: '1.14.2-00',
+          )
+        end
+
+        it do
           is_expected.to contain_file('/etc/systemd/system/docker.service.d')
             .with_ensure('directory')
         end
@@ -105,6 +112,7 @@ describe 'nebula::profile::kubernetes' do
         it { is_expected.to contain_package('kubeadm').with_ensure('1.11.9-00') }
         it { is_expected.to contain_package('kubelet').with_ensure('1.11.9-00') }
         it { is_expected.to contain_class('nebula::profile::docker').with_version('18.06.2~ce~3-0~debian') }
+        it { is_expected.to contain_apt__pin('kubernetes').with_version('1.11.9-00') }
 
         describe 'exported resources' do
           subject { exported_resources }


### PR DESCRIPTION
This way, we'll be able to safely run apt-get dist-upgrade.