### PR TITLE
AEIM-2495 - Add docker profile to deployhost

### DIFF
--- a/manifests/role/deploy_host.pp
+++ b/manifests/role/deploy_host.pp
@@ -10,7 +10,10 @@
 # @example
 #   include nebula::role::deploy_host
 class nebula::role::deploy_host {
-  include nebula::role::umich
+  class { 'nebula::role::umich':
+    internal_routing => 'docker',
+  }
+
   include nebula::profile::ruby
   include nebula::profile::nodejs
   include nebula::profile::moku
@@ -19,4 +22,6 @@ class nebula::role::deploy_host {
     include nebula::profile::afs
     include nebula::profile::users
   }
+
+  include nebula::profile::docker
 }

--- a/manifests/role/umich.pp
+++ b/manifests/role/umich.pp
@@ -10,9 +10,12 @@
 #   include nebula::role::umich
 class nebula::role::umich (
   $bridge_network = false,
+  $internal_routing = '',
 ) {
 
-  include nebula::role::minimum
+  class { 'nebula::role::minimum':
+    internal_routing => $internal_routing,
+  }
 
   if $facts['os']['family'] == 'Debian' and $::lsbdistcodename != 'jessie' {
     include nebula::profile::duo


### PR DESCRIPTION
We have to pass the `internal_routing` parameter along through umich to
get to minimum, but otherwise, this is straightforward. The parameter is
used to preserve the docker-specific routes added when the engine
package is installed -- otherwise our firewall profiles clobber any
rules that are unrecognized.