### PR TITLE
AEIM-2429 Introduce an ordering dependency for unison on mounts.

### DIFF
--- a/templates/unison/client/service.erb
+++ b/templates/unison/client/service.erb
@@ -2,6 +2,7 @@
 Description=<%= @title %> <%= @server %> sync (unison)
 After=network.target
 <%- @filesystems.each do |filesystem| -%>
+After=<%= filesystem %>.mount
 Requires=<%= filesystem %>.mount
 <%- end -%>
 

--- a/templates/unison/server/service.erb
+++ b/templates/unison/server/service.erb
@@ -2,6 +2,7 @@
 Description=<%= @title %> Unison
 After=network.target
 <%- @filesystems.each do |filesystem| -%>
+After=<%= filesystem %>.mount
 Requires=<%= filesystem %>.mount
 <%- end -%>
 


### PR DESCRIPTION
Use an After directive to ensure unison clients and servers start after their data mount dependencies. The Require directive only ensures the mount is present but does not ensure ordering. It is acceptable for systemd units to have multiple After directives, similar to Require.