### PR TITLE
AEIM-2248 - Scrape WMI exporters as well as node exporters

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -16,6 +16,7 @@
 class nebula::profile::prometheus (
   Array $alert_managers = [],
   Array $static_nodes = [],
+  Array $static_wmi_nodes = [],
   String $version = 'latest',
 ) {
   include nebula::profile::docker

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -112,6 +112,39 @@ describe 'nebula::profile::prometheus' do
           it { is_expected.to contain_concat_fragment(fragment).with_content(content) }
         end
       end
+
+      it do
+        is_expected.to contain_file('/etc/prometheus/prometheus.yml')
+          .without_content(%r{job_name: wmi})
+      end
+
+      context 'with some static wmi nodes set' do
+        let(:params) do
+          {
+            static_wmi_nodes: [
+              {
+                'targets' => ['10.11.12.13:9182'],
+                'labels' => {
+                  'datacenter' => 'windows_center',
+                  'hostname' => 'windows_host',
+                  'role' => 'windows::role',
+                },
+              },
+            ],
+          }
+        end
+
+        [
+          "datacenter: 'windows_center'",
+          "hostname: 'windows_host'",
+          "role: 'windows::role'",
+        ].each do |label|
+          it do
+            is_expected.to contain_file('/etc/prometheus/prometheus.yml')
+              .with_content(%r{job_name: wmi\n.*labels:\n.*#{label}}m)
+          end
+        end
+      end
     end
   end
 end

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -22,3 +22,14 @@ scrape_configs:
 - job_name: node
   file_sd_configs:
   - files: [ nodes.yml ]
+<% unless @static_wmi_nodes.empty? -%>
+- job_name: wmi
+  static_configs:
+<% @static_wmi_nodes.each do |wmi_node| -%>
+  - targets: [ '<%= wmi_node['targets'].join("', '") %>' ]
+    labels:
+<% wmi_node['labels'].each do |key, value| -%>
+      <%= key %>: '<%= value %>'
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Since we don't manage our windows machines with puppet, this just uses a
static node list for each scraper to know what to scrape.