### PR TITLE
AEIM-2008 add clearinghouse role

### DIFF
--- a/manifests/profile/clearinghouse/apache.pp
+++ b/manifests/profile/clearinghouse/apache.pp
@@ -45,7 +45,7 @@ class nebula::profile::clearinghouse::apache (
   $ssl_params     = {
     ssl            => true,
     ssl_protocol   => 'all -SSLv2 -SSLv3',
-    ssl_cipher     => 'EECDH EDH+aRSA !RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS',
+    ssl_cipher     => 'EECDH:EDH+aRSA:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS',
     ssl_cert       => "/etc/ssl/certs/${ssl_cn}.crt",
     ssl_key        => "/etc/ssl/private/${ssl_cn}.key",
     ssl_certs_dir  => '/etc/ssl/chain'
@@ -58,15 +58,15 @@ class nebula::profile::clearinghouse::apache (
         rewrite_rule => ['^(.*)$ https://%{HTTP_HOST}$1 [L,NE,R]']
       }];
 
-    'public non-ssl':
+    'public-http':
       * => $public_common;
 
-    'admin non-ssl':
+    'admin-http':
       * => $admin_common;
   }
 
   apache::vhost {
-    'public ssl':
+    'public-https':
       port     => '443',
       aliases  => [
         {
@@ -88,7 +88,7 @@ class nebula::profile::clearinghouse::apache (
   }
 
   apache::vhost {
-    'admin ssl':
+    'admin-https':
       port     => '443',
       rewrites => [$nocache_pdf],
 

--- a/manifests/profile/clearinghouse/apache.pp
+++ b/manifests/profile/clearinghouse/apache.pp
@@ -104,12 +104,4 @@ class nebula::profile::clearinghouse::apache (
       *              => $admin_common.merge($ssl_params)
   }
 
-  php::config { 'fpm php.ini':
-    file   => '/etc/php/7.3/fpm/php.ini',
-    config => {
-      'PHP/post_max_size'           => '64M',
-      'PHP/upload_max_filesize'     => '64M',
-    },
-  }
-
 }

--- a/manifests/profile/clearinghouse/apache.pp
+++ b/manifests/profile/clearinghouse/apache.pp
@@ -1,0 +1,98 @@
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::apache::clearinghouse
+#
+# Configure apache & virtual hosts for clearinghouse
+#
+# AWS host with apache, mysql, php
+#
+# @example
+#   include nebula::role::app_host::standalone
+class nebula::profile::clearinghouse::apache (
+  String $base_domain = 'clearinghouse.net',
+  String $ch_root = '/l/web'
+) {
+  include nebula::profile::named_instances::apache
+
+  $ssl_cn = Class['nebula::profile::named_instances::apache']['ssl_cn']
+
+  include nebula::profile::php73
+  include apache::mod::alias
+
+  class { 'apache::mod::dir':
+    indexes => ['index.html','index.php']
+  }
+  class { 'apache::mod::proxy_fcgi': }
+
+  $public_common = {
+    servername    => "www.${base_domain}",
+    docroot       => "${ch_root}/chPublic/public_html",
+    serveraliases => [$base_domain]
+  }
+
+  $admin_common = {
+    servername => "chadmin.${base_domain}",
+    docroot    => "${ch_root}/chAdmin/public_html"
+  }
+
+  $nocache_pdf = {
+    rewrite_rule => '^/chDocs/(.*[.]pdf)$	/chDocs/no_cache.php?file_path=$1	[passthrough]'
+  }
+
+  $ssl_params     = {
+    ssl            => true,
+    ssl_protocol   => 'all -SSLv2 -SSLv3',
+    ssl_cipher     => 'EECDH EDH+aRSA !RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS',
+    ssl_cert       => "/etc/ssl/certs/${ssl_cn}.crt",
+    ssl_key        => "/etc/ssl/private/${ssl_cn}.key",
+    ssl_certs_dir  => '/etc/ssl/chain'
+  }
+
+  apache::vhost {
+    default:
+      port     => '80',
+      rewrites => [{
+        rewrite_rule => ['^(.*)$ https://%{HTTP_HOST}$1 [L,NE,R]']
+      }];
+
+    'public non-ssl':
+      * => $public_common;
+
+    'admin non-ssl':
+      * => $admin_common;
+  }
+
+  apache::vhost {
+    'public ssl':
+      port     => '443',
+      aliases  => [
+        {
+          alias => '/chDocs/',
+          path  => "${ch_root}/chDocs"
+        }
+      ],
+
+      rewrites => [
+        $nocache_pdf,
+        {
+          # block SQL injection attempts
+          rewrite_cond => '%{QUERY_STRING}   (select|insert|update|delete)   [nocase]',
+          rewrite_rule => '(.*)      -         [forbidden,last]'
+        },
+      ],
+
+      *        => $public_common.merge($ssl_params)
+  }
+
+  apache::vhost {
+    'admin ssl':
+      port     => '443',
+      rewrites => [$nocache_pdf],
+
+      *        => $admin_common.merge($ssl_params)
+  }
+
+}

--- a/manifests/profile/php73.pp
+++ b/manifests/profile/php73.pp
@@ -50,7 +50,7 @@ class nebula::profile::php73 (
       'PHP/max_input_vars'          => '2000',
       'PHP/memory_limit'            => '256M',
       'PHP/error_reporting'         => 'E_ALL & ~E_DEPRECATED',
-      'PHP/upload_max_filesize'     => '32M',
+      'PHP/upload_max_filesize'     => '64M',
       'Date/date.timezone'          => 'America/Detroit',
       'mail function/sendmail_path' => '/usr/sbin/sendmail -t -i',
     }

--- a/manifests/role/clearinghouse.pp
+++ b/manifests/role/clearinghouse.pp
@@ -11,10 +11,8 @@
 class nebula::role::clearinghouse {
   include nebula::role::aws
 
-  include nebula::profile::named_instances::apache
-
-  include apache::mod::alias
-
   include nebula::profile::mysql
-  include nebula::profile::php73
+  include nebula::profile::clearinghouse::apache
+
+
 }

--- a/manifests/role/clearinghouse.pp
+++ b/manifests/role/clearinghouse.pp
@@ -13,6 +13,9 @@ class nebula::role::clearinghouse {
 
   include nebula::profile::mysql
   include nebula::profile::clearinghouse::apache
-
+  package { ['git',
+  'libimage-exiftool-perl',
+  'poppler-utils',
+  'php7.3-tidy' ]: }
 
 }

--- a/manifests/role/clearinghouse.pp
+++ b/manifests/role/clearinghouse.pp
@@ -13,6 +13,8 @@ class nebula::role::clearinghouse {
 
   include nebula::profile::named_instances::apache
 
+  include apache::mod::alias
+
   include nebula::profile::mysql
   include nebula::profile::php73
 }

--- a/spec/classes/role/clearinghouse_spec.rb
+++ b/spec/classes/role/clearinghouse_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require_relative '../../support/contexts/with_mocked_nodes'
+
+describe 'nebula::role::clearinghouse' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      include_context 'with mocked query for nodes in other datacenters'
+      let(:facts) { os_facts }
+
+      let(:hiera_config) { 'spec/fixtures/hiera/clearinghouse_config.yaml' }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -7,6 +7,7 @@ ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
 dmi: {}
+disks: {}
 installed_backports: []
 datacenter: "mydatacenter"
 prometheus_errors_total: 0

--- a/spec/fixtures/hiera/clearinghouse.yaml
+++ b/spec/fixtures/hiera/clearinghouse.yaml
@@ -1,0 +1,1 @@
+nebula::profile::mysql::password: changeme

--- a/spec/fixtures/hiera/clearinghouse_config.yaml
+++ b/spec/fixtures/hiera/clearinghouse_config.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - chipmunk
+  - default
+:yaml:
+  :datadir: 'spec/fixtures/hiera'
+


### PR DESCRIPTION
This is mostly Aaron's work from the summer to add a puppet-managed apache config for clearinghouse, plus some updates to finalize the apache and php config. We will add puppet-manage mysql when that work is completed. Conor and the stakeholder want to move to the new AWS hosting now though.

The only change with a broader impact is an increase in our default PHP upload_max_filesize from 32M to 64M. It seemed simplest to increase the default rather than duplicate our full PHP 7.3 config for clearinghouse.