### PR TITLE
AEIM-2568 - Add https reverse proxy to Prometheus

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -61,6 +61,9 @@ fixtures:
     letsencrypt:
       repo: "puppet/letsencrypt"
       ref: "5.0.0"
+    nginx:
+      repo: "puppet/nginx"
+      ref: "1.0.0"
     php:
       repo: "puppet/php"
       ref: "6.0.2"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -63,7 +63,7 @@ fixtures:
       ref: "5.0.0"
     nginx:
       repo: "puppet/nginx"
-      ref: "1.0.0"
+      ref: "0.15.0"
     php:
       repo: "puppet/php"
       ref: "6.0.2"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -58,6 +58,9 @@ fixtures:
     logrotate:
       repo: "puppet/logrotate"
       ref: "3.4.0"
+    letsencrypt:
+      repo: "puppet/letsencrypt"
+      ref: "5.0.0"
     php:
       repo: "puppet/php"
       ref: "6.0.2"

--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -1,0 +1,34 @@
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+define nebula::cert (
+  Array[String] $additional_domains = [],
+  Variant[Array[String[1]], String[1]] $webroot = [],
+) {
+  require nebula::profile::letsencrypt
+
+  if $webroot == [] {
+
+    letsencrypt::certonly { $title:
+      domains     => [$title] + $additional_domains,
+      manage_cron => true,
+    }
+
+  } else {
+
+    if $webroot =~ Array {
+      $webroot_paths = $webroot
+    } else {
+      $webroot_paths = [$webroot]
+    }
+
+    letsencrypt::certonly { $title:
+      domains       => [$title] + $additional_domains,
+      manage_cron   => true,
+      plugin        => 'webroot',
+      webroot_paths => $webroot_paths,
+    }
+
+  }
+}

--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -2,6 +2,32 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
+# Let's Encrypt Certificate
+#
+# This manages a single letsencrypt key/chain. It mostly just uses a
+# letsencrypt::certonly resource, but it also ensures the letsencrypt
+# profile is loaded.
+#
+# Set the title to the domain the cert is for.
+#
+# @param additional_domains An optional array of additional domains the
+#   cert covers
+# @param webroot Without this, every time we renew the cert, it'll use a
+#   standalone http server. If we already have something else set up, we
+#   should pass a path to the `/` directory (e.g. `/var/www`). This can
+#   also be an array in the case were there are multiple domains covered
+#   by the cert.
+#
+# @example Single domain with webroot
+#   nebula::cert { 'mydomain.com':
+#     webroot => '/var/www',
+#   }
+#
+# @example Five domains with differing webroot paths
+#   nebula::cert { 'primary.com':
+#     additional_domains => ['secondary.com', 'third.com', 'third.net', 'third.org'],
+#     webroot            => ['/www/primary', '/www/secondary', '/www/third'],
+#   }
 define nebula::cert (
   Array[String] $additional_domains = [],
   Variant[Array[String[1]], String[1]] $webroot = [],

--- a/manifests/profile/https_to_port.pp
+++ b/manifests/profile/https_to_port.pp
@@ -2,6 +2,17 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
+# Forward HTTPS to a local port
+#
+# This allows us to expose what would be an HTTP port as HTTPS instead.
+# It also creates a simple webroot to use with actual HTTP connections
+# so that cert verification can be automatic.
+#
+# @param port The local HTTP port to forward HTTPS connections to
+# @param server_name The domain we expect connections to (defaults to
+#   the fqdn fact)
+# @param webroot The path to where we want HTTP connections over port 80
+#   to land (defaults to `/var/www`)
 class nebula::profile::https_to_port (
   Integer $port,
   String $server_name = $::fqdn,

--- a/manifests/profile/https_to_port.pp
+++ b/manifests/profile/https_to_port.pp
@@ -11,10 +11,16 @@ class nebula::profile::https_to_port (
 
   $letsencrypt_directory = $::letsencrypt_directory[$server_name]
 
-  nginx::resource::server { 'letsencrypt-webroot':
-    server_name => [$server_name],
-    listen_port => 80,
-    www_root    => $webroot,
+  if $letsencrypt_directory {
+    nginx::resource::server { 'https-forwarder':
+      server_name => [$server_name],
+      listen_port => 443,
+      proxy       => "http://localhost:${port}",
+      ssl         => true,
+      ssl_cert    => "${letsencrypt_directory}/fullchain.pem",
+      ssl_key     => "${letsencrypt_directory}/privkey.pem",
+      require     => Nebula::Cert[$server_name],
+    }
   }
 
   nebula::cert { $server_name:
@@ -22,13 +28,14 @@ class nebula::profile::https_to_port (
     require => Nginx::Resource::Server['letsencrypt-webroot'],
   }
 
-  nginx::resource::server { 'https-forwarder':
+  nginx::resource::server { 'letsencrypt-webroot':
     server_name => [$server_name],
-    listen_port => 443,
-    proxy       => "http://localhost:${port}",
-    ssl         => true,
-    ssl_cert    => "${letsencrypt_directory}/fullchain.pem",
-    ssl_key     => "${letsencrypt_directory}/privkey.pem",
-    require     => Nebula::Cert[$server_name],
+    listen_port => 80,
+    www_root    => $webroot,
+    require     => File[$webroot],
+  }
+
+  file { $webroot:
+    ensure => 'directory',
   }
 }

--- a/manifests/profile/https_to_port.pp
+++ b/manifests/profile/https_to_port.pp
@@ -1,0 +1,34 @@
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::https_to_port (
+  Integer $port,
+  String $server_name = $::fqdn,
+  String $webroot = '/var/www',
+) {
+  include nginx
+
+  $letsencrypt_directory = $::letsencrypt_directory[$server_name]
+
+  nginx::resource::server { 'letsencrypt-webroot':
+    server_name => [$server_name],
+    listen_port => 80,
+    www_root    => $webroot,
+  }
+
+  nebula::cert { $server_name:
+    webroot => $webroot,
+    require => Nginx::Resource::Server['letsencrypt-webroot'],
+  }
+
+  nginx::resource::server { 'https-forwarder':
+    server_name => [$server_name],
+    listen_port => 443,
+    proxy       => "http://localhost:${port}",
+    ssl         => true,
+    ssl_cert    => "${letsencrypt_directory}/fullchain.pem",
+    ssl_key     => "${letsencrypt_directory}/privkey.pem",
+    require     => Nebula::Cert[$server_name],
+  }
+}

--- a/manifests/profile/letsencrypt.pp
+++ b/manifests/profile/letsencrypt.pp
@@ -8,4 +8,11 @@ class nebula::profile::letsencrypt (
   class { 'letsencrypt':
     email => $email,
   }
+
+  firewall { '200 HTTP':
+    proto  => 'tcp',
+    dport  => 80,
+    state  => 'NEW',
+    action => 'accept',
+  }
 }

--- a/manifests/profile/letsencrypt.pp
+++ b/manifests/profile/letsencrypt.pp
@@ -2,6 +2,10 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
+# Let's Encrypt System Requirements
+#
+# This installs certbot and sets it up with our contact email. It also
+# opens port 80 to the world, which is required for verifying ownership.
 class nebula::profile::letsencrypt (
   String $email = lookup('nebula::profile::base::contact_email'),
 ) {

--- a/manifests/profile/letsencrypt.pp
+++ b/manifests/profile/letsencrypt.pp
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::letsencrypt (
+  String $email = lookup('nebula::profile::base::contact_email'),
+) {
+  class { 'letsencrypt':
+    email => $email,
+  }
+}

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -69,8 +69,17 @@ class nebula::profile::prometheus (
     group  => 65534,
   }
 
+  class { 'nebula::profile::https_to_port':
+    port => 9090,
+  }
+
   nebula::exposed_port { '010 Prometheus HTTP':
     port  => 9090,
+    block => 'umich::networks::all_trusted_machines',
+  }
+
+  nebula::exposed_port { '010 Prometheus HTTPS':
+    port  => 443,
     block => 'umich::networks::all_trusted_machines',
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},
     {"name": "puppet/letsencrypt", "version_requirement": ">= 5.0.0 < 6.0.0"},
-    {"name": "puppet/nginx", "version_requirement": ">= 1.0.0 < 2.0.0"},
+    {"name": "puppet/nginx", "version_requirement": ">= 0.15.0 < 0.16.0"},
     {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppet/logrotate", "version_requirement": ">= 3.4.0 < 4.0.0"},
     {"name": "stm/debconf", "version_requirement": ">= 2.1.0 < 3.0.0"},

--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,7 @@
     {"name": "puppetlabs/postgresql", "version_requirement": ">= 5.2.1 < 6.0.0"},
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},
+    {"name": "puppet/letsencrypt", "version_requirement": ">= 5.0.0 < 6.0.0"},
     {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppet/logrotate", "version_requirement": ">= 3.4.0 < 4.0.0"},
     {"name": "stm/debconf", "version_requirement": ">= 2.1.0 < 3.0.0"},

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,7 @@
     {"name": "puppetlabs/puppetdb", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 3.0.0"},
     {"name": "puppet/letsencrypt", "version_requirement": ">= 5.0.0 < 6.0.0"},
+    {"name": "puppet/nginx", "version_requirement": ">= 1.0.0 < 2.0.0"},
     {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 7.0.0"},
     {"name": "puppet/logrotate", "version_requirement": ">= 3.4.0 < 4.0.0"},
     {"name": "stm/debconf", "version_requirement": ">= 2.1.0 < 3.0.0"},

--- a/spec/classes/profile/https_to_port_spec.rb
+++ b/spec/classes/profile/https_to_port_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::https_to_port' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:server_name) { facts[:fqdn] }
+      let(:letsencrypt_directory) { "/etc/letsencrypt/live/#{server_name}" }
+
+      context 'when port is set to 1234' do
+        let(:params) { { port: 1234 } }
+
+        it { is_expected.to compile }
+
+        it { is_expected.to contain_class('nginx') }
+
+        it do
+          is_expected.to contain_nginx__resource__server('letsencrypt-webroot')
+            .with_server_name([server_name])
+            .with_listen_port(80)
+            .with_www_root('/var/www')
+        end
+
+        it do
+          is_expected.to contain_nebula__cert(server_name)
+            .with_webroot('/var/www')
+            .that_requires('Nginx::Resource::Server[letsencrypt-webroot]')
+        end
+
+        it do
+          is_expected.to contain_nginx__resource__server('https-forwarder')
+            .with_server_name([server_name])
+            .with_listen_port(443)
+            .with_proxy('http://localhost:1234')
+            .with_ssl(true)
+            .with_ssl_cert("#{letsencrypt_directory}/fullchain.pem")
+            .with_ssl_key("#{letsencrypt_directory}/privkey.pem")
+            .that_requires("Nebula::Cert[#{server_name}]")
+        end
+
+        context 'and server_name is set to example.invalid' do
+          let(:server_name) { 'example.invalid' }
+          let(:params) do
+            super().merge(server_name: server_name)
+          end
+
+          it do
+            is_expected.to contain_nginx__resource__server('letsencrypt-webroot')
+              .with_server_name([server_name])
+          end
+
+          it do
+            is_expected.to contain_nebula__cert(server_name)
+          end
+
+          it do
+            is_expected.to contain_nginx__resource__server('https-forwarder')
+              .with_server_name([server_name])
+              .with_ssl_cert("#{letsencrypt_directory}/fullchain.pem")
+              .with_ssl_key("#{letsencrypt_directory}/privkey.pem")
+              .that_requires("Nebula::Cert[#{server_name}]")
+          end
+        end
+
+        context 'and webroot is set to /opt/html' do
+          let(:params) do
+            super().merge(webroot: '/opt/html')
+          end
+
+          it do
+            is_expected.to contain_nginx__resource__server('letsencrypt-webroot')
+              .with_www_root('/opt/html')
+          end
+
+          it do
+            is_expected.to contain_nebula__cert(server_name)
+              .with_webroot('/opt/html')
+          end
+        end
+      end
+
+      context 'when port is set to 2468' do
+        let(:params) { { port: 2468 } }
+
+        it do
+          is_expected.to contain_nginx__resource__server('https-forwarder')
+            .with_proxy('http://localhost:2468')
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/https_to_port_spec.rb
+++ b/spec/classes/profile/https_to_port_spec.rb
@@ -67,6 +67,15 @@ describe 'nebula::profile::https_to_port' do
           end
         end
 
+        context "and server_name is set to something that doesn't have keys yet" do
+          let(:server_name) { 'nokeysyet.invalid' }
+          let(:params) do
+            super().merge(server_name: server_name)
+          end
+
+          it { is_expected.not_to contain_nginx__resource__server('https-forwarder') }
+        end
+
         context 'and webroot is set to /opt/html' do
           let(:params) do
             super().merge(webroot: '/opt/html')

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -64,8 +64,19 @@ describe 'nebula::profile::prometheus' do
       end
 
       it do
+        is_expected.to contain_class('nebula::profile::https_to_port')
+          .with_port(9090)
+      end
+
+      it do
         is_expected.to contain_nebula__exposed_port('010 Prometheus HTTP')
           .with_port(9090)
+          .with_block('umich::networks::all_trusted_machines')
+      end
+
+      it do
+        is_expected.to contain_nebula__exposed_port('010 Prometheus HTTPS')
+          .with_port(443)
           .with_block('umich::networks::all_trusted_machines')
       end
 

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -14,6 +14,9 @@ prometheus_errors_total: 0
 mountpoints: {}
 disks: {}
 root_home: "/root"
+letsencrypt_directory:
+  foo.example.com: '/etc/letsencrypt/live/foo.example.com'
+  example.invalid: '/etc/letsencrypt/live/example.invalid'
 
 # required by camptocamp/kmod 2.1.0
 augeasversion: '1.4.0'

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -22,6 +22,14 @@ describe 'nebula::cert' do
             .with_manage_cron(true)
         end
 
+        it do
+          is_expected.to contain_firewall('200 HTTP')
+            .with_proto('tcp')
+            .with_dport(80)
+            .with_state('NEW')
+            .with_action('accept')
+        end
+
         context 'and with additional_domains set to sub.example.invalid' do
           let(:params) { { additional_domains: ['sub.example.invalid'] } }
 

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::cert' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with title set to example.invalid' do
+        let(:title) { 'example.invalid' }
+
+        it { is_expected.to contain_class('letsencrypt').with_email('contact@default.invalid') }
+
+        it do
+          is_expected.to contain_letsencrypt__certonly('example.invalid')
+            .with_domains(['example.invalid'])
+            .with_plugin('standalone')
+            .with_manage_cron(true)
+        end
+
+        context 'and with additional_domains set to sub.example.invalid' do
+          let(:params) { { additional_domains: ['sub.example.invalid'] } }
+
+          it do
+            is_expected.to contain_letsencrypt__certonly('example.invalid')
+              .with_domains(%w[example.invalid sub.example.invalid])
+              .with_plugin('standalone')
+          end
+        end
+
+        context 'and with webroot set to /var/www' do
+          let(:params) { { webroot: '/var/www' } }
+
+          it do
+            is_expected.to contain_letsencrypt__certonly('example.invalid')
+              .with_plugin('webroot')
+              .with_webroot_paths(['/var/www'])
+              .with_manage_cron(true)
+          end
+        end
+
+        context 'and with webroot set to [/var/www]' do
+          let(:params) { { webroot: ['/var/www'] } }
+
+          it do
+            is_expected.to contain_letsencrypt__certonly('example.invalid')
+              .with_plugin('webroot')
+              .with_webroot_paths(['/var/www'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -67,3 +67,25 @@ groups:
       severity: page
     annotations:
       summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} is full.'
+
+  # These are aggregate rules for federated collection across our full
+  # system. By putting them here, we essentially precompile them.
+  - record: datacenter_role:network_transmit_bytes:rate5m
+    expr: >
+      sum without(device, hostname, instance)(
+        rate(node_network_transmit_bytes_total[5m])
+      )
+  - record: datacenter_role:network_receive_bytes:rate5m
+    expr: >
+      sum without(device, hostname, instance)(
+        rate(node_network_receive_bytes_total[5m])
+      )
+  - record: datacenter_role:node_cpu_seconds:max_not_idle_mean30s
+    expr: >
+      max without(hostname, instance)(
+        avg without(cpu)(
+          sum without(mode)(
+            rate(node_cpu_seconds_total{mode!="idle"}[30s])
+          )
+        )
+      )


### PR DESCRIPTION
Adding an apache vhost to point 443 at localhost:9090, which requires keys. Adding letsencrypt keys, which require an apache vhost on port 80 for passing the letsencrypt challenge. Trying to use the simplest settings possible.