### PR TITLE
AE-7176: Copy www.lib vhost to apps.lib

### DIFF
--- a/manifests/profile/www_lib/apache.pp
+++ b/manifests/profile/www_lib/apache.pp
@@ -87,6 +87,7 @@ class nebula::profile::www_lib::apache (
   # should be moved elsewhere to include as virtual all that might be present on the puppet master
   @nebula::apache::ssl_keypair {
     [
+      'apps.lib.umich.edu',
       'copyright.umich.edu',
       'datamart.lib.umich.edu',
       'deepblue.lib.umich.edu',
@@ -112,7 +113,7 @@ class nebula::profile::www_lib::apache (
 
   $vhost_prefix = 'nebula::profile::www_lib::vhosts'
 
-  ['default','www_lib','staff_lib','datamart','deepblue', 'openmich', 'mportfolio', 'press'].each |$vhost| {
+  ['default','www_lib','apps_lib','staff_lib','datamart','deepblue', 'openmich', 'mportfolio', 'press'].each |$vhost| {
     class { "nebula::profile::www_lib::vhosts::${vhost}":
       prefix => $prefix,
       domain => $domain,

--- a/manifests/profile/www_lib/vhosts/apps_lib.pp
+++ b/manifests/profile/www_lib/vhosts/apps_lib.pp
@@ -1,0 +1,108 @@
+
+# Copyright (c) 2019 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::www_lib::vhosts::apps_lib
+#
+# apps.lib.umich.edu virtual host
+#
+# @example
+#   include nebula::profile::www_lib::vhosts::apps_lib
+class nebula::profile::www_lib::vhosts::apps_lib (
+  String $prefix,
+  String $domain,
+  String $ssl_cn = 'apps.lib.umich.edu',
+  String $www_lib_root = '/www/www.lib',
+  String $docroot = "${www_lib_root}/web"
+) {
+
+  $servername = "${prefix}apps.${domain}"
+
+  nebula::apache::www_lib_vhost { 'apps.lib-http':
+    servername => $servername,
+    docroot    => $docroot,
+    usertrack  => true,
+
+    rewrites   => [
+      {
+        rewrite_rule => '^(.*)$ https://%{HTTP_HOST}$1 [L,R]'
+      },
+    ],
+  }
+
+  nebula::apache::www_lib_vhost { 'apps.lib-https':
+    servername                    => $servername,
+    ssl                           => true,
+    usertrack                     => true,
+    cosign                        => true,
+    docroot                       => $docroot,
+    cosign_public_access_off_dirs => [
+      {
+        provider => 'location',
+        path     => '/login'
+      },
+      {
+        provider => 'location',
+        path     => '/vf/vflogin_dbsess.php'
+      },
+      {
+        provider => 'location',
+        path     => '/pk',
+      },
+      {
+        provider => 'directory',
+        path     => "${www_lib_root}/cgi/l/login",
+      },
+      {
+        provider => 'directory',
+        path     => "${www_lib_root}/cgi/m/medsearch"
+      },
+    ],
+
+    directories                   => [
+      {
+        provider       => 'directory',
+        path           => $docroot,
+        options        => ['IncludesNOEXEC','Indexes','FollowSymLinks','MultiViews'],
+        allow_override => ['AuthConfig','FileInfo','Limit','Options'],
+        require        => $nebula::profile::www_lib::apache::default_access
+      },
+      {
+        provider       => 'directory',
+        path           => "${www_lib_root}/cgi",
+        allow_override => ['None'],
+        options        => ['None'],
+        require        => $nebula::profile::www_lib::apache::default_access
+      }
+    ],
+
+    # TODO: hopefully these can all be removed
+    rewrites                      => [
+      {
+        # rewrite for wsfh
+        #
+        # remote after 2008-12-31
+        #
+        # jhovater - 2008-12-04 varnum said to keep
+        # 2008-08-28 csnavely per varnum
+        rewrite_rule =>  '^/wsfh		http://www.wsfh.org/	[redirect,last]'
+      },
+      {
+        # rewrites for aol-like, tinyurl-like "go" function
+        #
+        # 2007-05 csnavely
+        # 2013-01-23 keep for drupal7 - aelkiss per bertrama
+        rewrite_rule => '^/go/pubmed  http://searchtools.lib.umich.edu/V?func=native-link&resource=UMI01157 [redirect,last]'
+      },
+      {
+        # Redirect Islamic Manuscripts to the Lib Guides.
+        #
+        # Check with nancymou and ekropf for potential removal after 2016-09-01
+        #
+        # 2016-08-29 skorner per nancymou
+        rewrite_rule => '^/islamic	http://guides.lib.umich.edu/islamicmss/find 	[redirect=permanent,last]'
+      },
+    ];
+  }
+}

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -252,6 +252,16 @@ describe 'nebula::role::webhost::www_lib_vm' do
           .with_ssl_cert('/etc/ssl/certs/copyright.umich.edu.crt')
           .with_port(443)
       end
+
+      it do
+        is_expected.to contain_apache__vhost('apps.lib-https')
+          .with(servername: 'apps.lib.umich.edu',
+                port: 443,
+                ssl: true,
+                ssl_cert: '/etc/ssl/certs/apps.lib.umich.edu.crt')
+          .with_error_log_file('error.log')
+          .with_custom_fragment(%r{CookieName skynet})
+      end
     end
   end
 end


### PR DESCRIPTION
Copying rather than abstracting seems like the right way to go here --
@skorner reports "In about 5 months we won't serve www.lib from our web
servers anymore and even before then the apps.lib vhost config will
likely start to diverge from what we have locally for www.lib."