### PR TITLE
PFDR-274 - Support sshd_config addons for Dark Blue

### DIFF
--- a/manifests/profile/networking/sshd.pp
+++ b/manifests/profile/networking/sshd.pp
@@ -13,6 +13,7 @@
 #   include nebula::profile::networking::sshd
 class nebula::profile::networking::sshd (
   Array[String] $whitelist,
+  String $addon_directives = '',
 ) {
 
   # This will do nothing if the keytab doesn't exist

--- a/manifests/role/chipmunk.pp
+++ b/manifests/role/chipmunk.pp
@@ -6,7 +6,9 @@ class nebula::role::chipmunk {
     include nebula::profile::hathitrust::dependencies
     include nebula::profile::hathitrust::perl
 
-    # Ensure that group-write umask is set for uploaders
+    # Ensure that group-write umask is set for uploaders.
+    # This does not take effect when the repository storage is mounted via
+    # CIFS, but does when on local disk or NFS.
     file { '/etc/pam.d/sshd':
       require => File["/etc/pam.d/sshd-${::lsbdistcodename}"],
       notify  => Service['sshd'],

--- a/templates/profile/networking/sshd_config.erb
+++ b/templates/profile/networking/sshd_config.erb
@@ -117,6 +117,9 @@ AcceptEnv LANG LC_*
 # override default of no subsystems
 Subsystem	sftp	/usr/lib/openssh/sftp-server
 
+# Host-specific, additional directives
+<%= @addon_directives %>
+
 # Example of overriding settings on a per-user basis
 #Match User anoncvs
 #	X11Forwarding no


### PR DESCRIPTION
We do a bit of fancy key and chroot management for Dark Blue, and
sshd_config does not yet support a drop-in directory or include pattern,
so we have to make an extension point. This is a regrettable workaround.

See also: https://bugzilla.mindrot.org/show_bug.cgi?id=2351