### PR TITLE
PFDR-274 - Clean up pam/sshd config to avoid repeated corrections

### DIFF
--- a/files/pam.d/sshd-defaults
+++ b/files/pam.d/sshd-defaults
@@ -1,8 +1,11 @@
+# This file is managed by Puppet (nebula/files/pam.d/sshd-defaults)
+# These defaults are the same for the openssh package on Debian jessie,
+# stretch, and buster. See profile/networking/sshd if variation is needed.
+
 # PAM configuration for the Secure Shell service
 
 # Standard Un*x authentication.
 @include common-auth
-auth required pam_duo.so
 
 # Disallow non-root logins when /etc/nologin exists.
 account    required     pam_nologin.so

--- a/manifests/profile/duo.pp
+++ b/manifests/profile/duo.pp
@@ -28,7 +28,7 @@ class nebula::profile::duo (
     ensure => absent
   }
 
-  ['sshd', 'sudo'].each |$pamfile| {
+  ['sudo'].each |$pamfile| {
     file_line { "/etc/pam.d/${pamfile}: pam_duo":
       path    => "/etc/pam.d/${pamfile}",
       line    => 'auth required pam_duo.so',
@@ -41,6 +41,15 @@ class nebula::profile::duo (
       path   => "/etc/pam.d/${pamfile}",
       line   => 'auth required /lib64/security/pam_duo.so'
     }
+  }
+
+  concat_fragment { '/etc/pam.d/sshd: pam_duo':
+    target  => '/etc/pam.d/sshd',
+    content => @("EOT")
+
+      # Require Duo 2FA for password logins; public-key bypasses PAM
+      auth required pam_duo.so
+      | EOT
   }
 
   file { '/etc/security/pam_duo.conf':

--- a/manifests/profile/networking/sshd.pp
+++ b/manifests/profile/networking/sshd.pp
@@ -34,4 +34,22 @@ class nebula::profile::networking::sshd (
   file { '/etc/ssh/ssh_config':
     content => template('nebula/profile/networking/ssh_config.erb'),
   }
+
+  # The PAM defaults for sshd have been unchanged between jessie and buster...
+  # If we need to update them, we can add some file selection here.
+  file { '/etc/pam.d/sshd-defaults':
+    source => 'puppet:///modules/nebula/pam.d/sshd-defaults',
+  }
+
+  concat_file { '/etc/pam.d/sshd': }
+
+  concat_fragment { '/etc/pam.d/sshd: base':
+    target  => '/etc/pam.d/sshd',
+    order   => '01',
+    content => @("EOT")
+      # Managed by puppet (manifests/profile/networking/sshd)
+
+      @include sshd-defaults
+      | EOT
+  }
 }

--- a/manifests/profile/networking/sshd_group_umask.pp
+++ b/manifests/profile/networking/sshd_group_umask.pp
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::networking::sshd_group_umask
+#
+# Ensure that the umask is set to allow scp/rsync files to carry group
+# permissions (0002). This adjusts the PAM sshd config under /etc/pam.d.
+#
+# @example
+#   include nebula::profile::networking::sshd_group_umask
+class nebula::profile::networking::sshd_group_umask () {
+  # Ensure that group-write umask is set for uploaders.
+  concat_fragment { '/etc/pam.d/sshd: group umask':
+    target  => '/etc/pam.d/sshd',
+    content => @("EOT")
+
+      # Allow rsync transfers to set group write
+      session    optional   pam_umask.so umask=0002
+      | EOT
+  }
+}

--- a/manifests/role/chipmunk.pp
+++ b/manifests/role/chipmunk.pp
@@ -1,31 +1,15 @@
 class nebula::role::chipmunk {
   include nebula::role::app_host::standalone
 
-  # Make it possible for the catalog to apply on jessie while we are upgrading.
-  if $facts['os']['family'] == 'Debian' and $::lsbdistcodename != 'jessie' {
-    include nebula::profile::hathitrust::dependencies
-    include nebula::profile::hathitrust::perl
+  include nebula::profile::hathitrust::dependencies
+  include nebula::profile::hathitrust::perl
 
-    # Ensure that group-write umask is set for uploaders.
-    # This does not take effect when the repository storage is mounted via
-    # CIFS, but does when on local disk or NFS.
-    file { '/etc/pam.d/sshd':
-      require => File["/etc/pam.d/sshd-${::lsbdistcodename}"],
-      notify  => Service['sshd'],
-      content => @("EOT")
-        # Managed by puppet (manifests/role/chipmunk)
-
-        @include sshd-${::lsbdistcodename}
-
-        # Set the umask for uploads
-        session    optional   pam_umask.so umask=0002
-      | EOT
-    }
-
-    file { "/etc/pam.d/sshd-${::lsbdistcodename}":
-      source => "puppet:///modules/nebula/pam.d/sshd-${::lsbdistcodename}",
-    }
-  }
+  # Ensure that users can upload files with group write so the ingest
+  # process can move them afterward.
+  #
+  # This is not required when the repository storage is mounted via
+  # CIFS, but it is when on local disk or NFS.
+  include nebula::profile::networking::sshd_group_umask
 
   # should be conditionally included from named_instances::apache when the
   # vhost config is deployed on the web node

--- a/spec/classes/profile/duo_spec.rb
+++ b/spec/classes/profile/duo_spec.rb
@@ -18,11 +18,9 @@ describe 'nebula::profile::duo' do
       it { is_expected.to contain_package('libpam-duo') }
 
       it do
-        is_expected.to contain_file_line('/etc/pam.d/sshd: pam_duo')
-          .with_path('/etc/pam.d/sshd')
-          .with_line('auth required pam_duo.so')
-          .with_after('^@include common-auth')
-          .that_requires(['Package[sudo]', 'Package[libpam-duo]'])
+        is_expected.to contain_concat_fragment('/etc/pam.d/sshd: pam_duo')
+          .with_target('/etc/pam.d/sshd')
+          .with_content(%r{auth required pam_duo.so})
       end
 
       it do

--- a/spec/classes/profile/networking/sshd_group_mask_spec.rb
+++ b/spec/classes/profile/networking/sshd_group_mask_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::networking::sshd_group_umask' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it do
+        is_expected.to contain_concat_fragment('/etc/pam.d/sshd: group umask')
+          .with_target('/etc/pam.d/sshd')
+          .with_content(%r{session    optional   pam_umask.so umask=0002})
+      end
+    end
+  end
+end

--- a/spec/classes/profile/networking/sshd_spec.rb
+++ b/spec/classes/profile/networking/sshd_spec.rb
@@ -87,6 +87,16 @@ describe 'nebula::profile::networking::sshd' do
         is_expected.to contain_file('/etc/ssh/ssh_config')
           .with_content(%r{^\s*SendEnv LANG LC_\*$})
       end
+
+      it { is_expected.to contain_file('/etc/pam.d/sshd-defaults') }
+
+      it { is_expected.to contain_concat_file('/etc/pam.d/sshd').with_path('/etc/pam.d/sshd') }
+
+      it do
+        is_expected.to contain_concat_fragment('/etc/pam.d/sshd: base')
+          .with_target('/etc/pam.d/sshd')
+          .with_content(%r{@include sshd-defaults})
+      end
     end
   end
 end

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -16,9 +16,7 @@ describe 'nebula::role::chipmunk' do
 
       it { is_expected.to compile }
 
-      if os == 'debian-9-x86_64'
-        it { is_expected.to contain_file('/etc/pam.d/sshd-stretch') }
-      end
+      it { is_expected.to contain_class('nebula::profile::networking::sshd_group_umask') }
     end
   end
 end


### PR DESCRIPTION
The way the Duo PAM module and the umask settings for Dark Blue were
being managed, they were clobbering each other. This is because the
chipmunk role was overwriting the file, and then the file_line for
pam_duo was modifying it each time.

This commit cleans up how /etc/pam.d/sshd is managed so it is a
concat_file that includes the stock config and then concat_fragments can
add to that the minimal custom file.