### PR TITLE
HT-2231: remove get_brittle_books_data

### DIFF
--- a/manifests/profile/hathitrust/ingest_jobs.pp
+++ b/manifests/profile/hathitrust/ingest_jobs.pp
@@ -12,7 +12,6 @@ class nebula::profile::hathitrust::ingest_jobs(
   String $config,
   String $feed_home,
   String $stats_home,
-  Array[String] $dcu_recipients,
   String $crms_renewals_source,
   String $crms_renewals_dest,
   String $recipient,
@@ -26,7 +25,6 @@ class nebula::profile::hathitrust::ingest_jobs(
   $feed_jobs = "${feed_home}/bin/jobs"
   $feed_daily = "${feed_jobs}/feed.daily"
   $feed_log  = "${feed_home}/var/log"
-  $joined_dcu_recipients = $dcu_recipients.join(',')
   $base_env = [
     "MAILTO=${recipient}",
     "FEED_HOME=${feed_home}"
@@ -80,10 +78,7 @@ class nebula::profile::hathitrust::ingest_jobs(
       minute  => 5;
 
     'copy google rejects list':
-      command     => "${feed_daily}/copy_rejects.sh",
-      environment => "MAILTO=${joined_dcu_recipients}",
-      hour        => 3,
-      minute      => 5;
+      ensure      => 'absent';
 
     ## WEEKLY JOBS
 

--- a/manifests/profile/hathitrust/ingest_jobs.pp
+++ b/manifests/profile/hathitrust/ingest_jobs.pp
@@ -88,10 +88,7 @@ class nebula::profile::hathitrust::ingest_jobs(
     ## WEEKLY JOBS
 
     'get brittle books data':
-      command => "${feed_perl} ${feed_jobs}/feed.weekly/get_brittle_books_data.pl 2>&1 > /dev/null",
-      weekday => 1,
-      hour    => 8,
-      minute  => 0;
+      ensure => 'absent';
 
     'generate ingest logs':
       command =>  "${feed_perl} ${feed_jobs}/feed.weekly/generate_logs.pl",
@@ -124,12 +121,8 @@ class nebula::profile::hathitrust::ingest_jobs(
     # pdus/gfv, and reset volumes that are pdus/gfv but not VIEW_FULL on GRIN to
     # their bib-determined rights
 
-    # not sure if this is still needed: "disposition 0 volumes"
     'grin reports':
-      command  => "${feed_perl} ${feed_jobs}/feed.monthly/grin_reports.pl",
-      monthday => 8,
-      hour     => 1,
-      minute   => 1;
+      ensure   => 'absent';
 
     'grin gfv':
       command     => "${feed_perl} ${feed_jobs}/feed.monthly/grin_gfv.pl",
@@ -149,12 +142,6 @@ class nebula::profile::hathitrust::ingest_jobs(
       monthday => 1,
       hour     => 2,
       minute   => 35;
-
-    # unneeded?
-    # 30 2 1 * * /bin/bash $FEED_HOME/bin/feed.monthly/grin_pod.sh
-
-    # TO REWRITE
-    # 25 2 1 * * /bin/bash $FEED_HOME/bin/feed.monthly/grin_error_range.sh
 
     'monthly ingest count':
       command  => "${feed_perl} ${feed_jobs}/feed.monthly/monthly_ingest_count.pl",

--- a/spec/classes/role/ht_ingest_primary_spec.rb
+++ b/spec/classes/role/ht_ingest_primary_spec.rb
@@ -28,12 +28,6 @@ describe 'nebula::role::hathitrust::ingest_indexing::primary' do
           ],
         )
       end
-
-      it do
-        is_expected.to contain_cron('copy google rejects list').with_environment(
-          ['MAILTO=aardvark@default.invalid,badger@default.invalid'],
-        )
-      end
     end
   end
 end

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -106,9 +106,6 @@ nebula::profile::hathitrust::ingest_jobs::rights_db_config: '/default/rights_db.
 nebula::profile::hathitrust::ingest_jobs::feed_home: '/htfeed'
 nebula::profile::hathitrust::ingest_jobs::stats_home: '/somewhere/stats'
 nebula::profile::hathitrust::ingest_jobs::recipient: 'nobody@default.invalid'
-nebula::profile::hathitrust::ingest_jobs::dcu_recipients:
-  - aardvark@default.invalid
-  - badger@default.invalid
 
 nebula::profile::hathitrust::ingest_jobs::crms_renewals_source: somebody@somewhere:/wherever/file
 nebula::profile::hathitrust::ingest_jobs::crms_renewals_dest: /somewhere/files/


### PR DESCRIPTION
Tim reports (regarding the file this job processes): "It's definitely
obsolete. We have a umich process that manages the workflow for
locally-digitized volumes (that were "rejected" for scanning by google).
The "allrejects.txt" file was from an earlier iteration of the process,
which was rewritten about 5 years ago. So, Aaron should just remove
references to it. And since it's not a HathiTrust workflow, you
shouldn't have to mess with it either." -
https://github.com/hathitrust/post_zephir_processing/pull/1#issuecomment-573829040

I am wondering though if just removing all references to this job (and then manually purging the cron job on the server it runs on) is a preferred approach, or if we should instead do

```puppet
'get brittle books data':
  ensure => 'absent';
```

and keep it represented in the code in perpetuity.
```