### PR TITLE
Wait 30 minutes instead of 10 to alert if machines are off

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -32,14 +32,14 @@ groups:
     annotations:
       summary: 'Linux node {{$labels.hostname}} isn''t responding to Prometheus.'
     expr: 'up{job="node"} == 0'
-    for: 10m
+    for: 30m
     labels:
       severity: page
   - alert: WindowsInstanceDown
     annotations:
       summary: 'Windows node {{$labels.hostname}} isn''t responding to Prometheus.'
     expr: 'up{job="wmi"} == 0'
-    for: 10m
+    for: 30m
     labels:
       severity: page
   - alert: DiskPressure


### PR DESCRIPTION
This because we still have several machines that take longer than 10
minutes to boot. Also, if we want to know sooner than 30 minutes after a
problem happens, we should monitor that particular problem, rather than
the general problem of "a computer is off."