### PR TITLE
Blacklist acpi_power_meter, fix hpwdt name typo

### DIFF
--- a/manifests/profile/base/hp.pp
+++ b/manifests/profile/base/hp.pp
@@ -10,7 +10,11 @@
 #   include nebula::profile::base::hp
 class nebula::profile::base::hp {
   kmod::blacklist { 'hpwdt':
-    file =>  '/etc/modprobe.d/kpwdt-blacklist.conf',
+    file =>  '/etc/modprobe.d/hpwdt-blacklist.conf',
+  }
+
+  kmod::blacklist { 'acpi_power_meter':
+    file =>  '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
   }
 
   package { 'ssacli': }

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -102,7 +102,13 @@ describe 'nebula::profile::base' do
 
         it do
           is_expected.to contain_kmod__blacklist('hpwdt').with(
-            file: '/etc/modprobe.d/kpwdt-blacklist.conf',
+            file: '/etc/modprobe.d/hpwdt-blacklist.conf',
+          )
+        end
+
+        it do
+          is_expected.to contain_kmod__blacklist('acpi_power_meter').with(
+            file: '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
           )
         end
       end
@@ -114,7 +120,13 @@ describe 'nebula::profile::base' do
 
         it do
           is_expected.to contain_kmod__blacklist('hpwdt').with(
-            file: '/etc/modprobe.d/kpwdt-blacklist.conf',
+            file: '/etc/modprobe.d/hpwdt-blacklist.conf',
+          )
+        end
+
+        it do
+          is_expected.to contain_kmod__blacklist('acpi_power_meter').with(
+            file: '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
           )
         end
 
@@ -127,6 +139,7 @@ describe 'nebula::profile::base' do
         end
 
         it { is_expected.not_to contain_kmod__blacklist('hpwdt') }
+        it { is_expected.not_to contain_kmod__blacklist('acpi_power_meter') }
       end
 
       it { is_expected.not_to contain_package('i40e-dkms') }


### PR DESCRIPTION
Added the blacklist for the acpi_power_meter kernel module that generates the ACPI errors due to a firmware bug (fixable but not something we use so no need). The errors fill logs and clutter console displays.

Also fixed the typo of hpwdt (it was kpwdt).