### PR TITLE
AEIM-2667 - Add Dark Blue storage monitoring

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -12,11 +12,14 @@
 # @param alert_managers A list of alert managers to push alerts to.
 # @param static_nodes A list of nodes to scrape in addition to those
 #   that don't export themselves via puppet.
+# @param rules_variables A hash of values to make available to the rules
+#   template
 # @param version The version of prometheus to run.
 class nebula::profile::prometheus (
   Array $alert_managers = [],
   Array $static_nodes = [],
   Array $static_wmi_nodes = [],
+  Hash $rules_variables = {},
   String $version = 'latest',
 ) {
   include nebula::profile::docker

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -39,10 +39,21 @@ describe 'nebula::profile::prometheus' do
           .that_requires('File[/etc/prometheus]')
       end
 
-      it do
-        is_expected.to contain_file('/etc/prometheus/rules.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+      context 'with rules_variables set' do
+        let(:params) do
+          {
+            rules_variables: {
+              darkblue_device: '//storage.invalid/volume',
+            },
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/prometheus/rules.yml')
+            .that_notifies('Docker::Run[prometheus]')
+            .that_requires('File[/etc/prometheus]')
+            .with_content(%r{device="//storage.invalid/volume"})
+        end
       end
 
       it do

--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -123,6 +123,24 @@ groups:
       severity: page
     annotations:
       summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} is full.'
+  - alert: DarkBlueFillingUp
+    expr: >
+      node_filesystem_avail_bytes{device="<%= @rules_variables['darkblue_device'] %>"} < (1 * 1024 * 1024 * 1024 * 1024)
+    for: 10m
+    labels:
+      severity: ticket
+    annotations:
+      summary: 'Dark Blue repository storage, {{$labels.device}} is running low on available space.'
+      description: '{{$labels.device}} has had less than 1TB of available space for more than 10 minutes.'
+  - alert: DarkBlueFull
+    expr: >
+      node_filesystem_avail_bytes{device="<%= @rules_variables['darkblue_device'] %>"} < (100 * 1024 * 1024 * 1024)
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: 'Dark Blue repository storage, {{$labels.device}} is out of available space.'
+      description: '{{$labels.device}} has had less than 100GB of available space for more than 5 minutes.'
 
   # These are aggregate rules for federated collection across our full
   # system. By putting them here, we essentially precompile them.


### PR DESCRIPTION
This adds two rules to the general scraper profile, and the storage
device/mount is within hiera.