### PR TITLE
AEIM-2642 - Add pushgateways to prometheus node scrapers

### DIFF
--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -118,10 +118,37 @@ class nebula::profile::prometheus::exporter::node (
     $monitoring_datacenter = $default_datacenter
   }
 
+  ensure_packages(['curl'])
+
+  concat_file { '/usr/local/bin/pushgateway':
+    mode => '0755',
+  }
+
+  concat_fragment { '01 pushgateway shebang':
+    target  => '/usr/local/bin/pushgateway',
+    content => "#!/usr/bin/env bash\n",
+  }
+
+  Concat_fragment <<| title == "02 pushgateway url ${monitoring_datacenter}" |>>
+
+  concat_fragment { '03 main pushgateway content':
+    target  => '/usr/local/bin/pushgateway',
+    content => template('nebula/profile/prometheus/exporter/node/pushgateway.sh.erb'),
+  }
+
   @@concat_fragment { "prometheus node service ${hostname}":
     tag     => "${monitoring_datacenter}_prometheus_node_service_list",
     target  => '/etc/prometheus/nodes.yml',
     content => template('nebula/profile/prometheus/exporter/node/target.yaml.erb'),
+  }
+
+  @@firewall { "300 pushgateway ${::hostname}":
+    tag    => "${monitoring_datacenter}_pushgateway_node",
+    proto  => 'tcp',
+    dport  => 9091,
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
   }
 
   if $::lsbdistcodename != 'jessie' {

--- a/manifests/profile/puppet/query.pp
+++ b/manifests/profile/puppet/query.pp
@@ -11,7 +11,7 @@ class nebula::profile::puppet::query (
 ) {
   $puppetdb_server = lookup('nebula::puppetdb')
 
-  package { 'curl': }
+  ensure_packages(['curl'])
 
   file { '/usr/local/sbin/puppet-query':
     mode    => '0755',

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -26,6 +26,10 @@ scrape_configs:
   - targets: [ localhost:9090 ]
     labels:
       hostname: '<%= @hostname %>'
+- job_name: pushgateway
+  honor_labels: true
+  static_configs:
+  - targets: [ localhost:9091 ]
 - job_name: node
   file_sd_configs:
   - files: [ nodes.yml ]

--- a/templates/profile/prometheus/exporter/node/pushgateway.sh.erb
+++ b/templates/profile/prometheus/exporter/node/pushgateway.sh.erb
@@ -1,0 +1,233 @@
+<%# Shebang and $PUSHGATEWAY are defined by concat fragments -%>
+RUN_COMMAND=true
+PROG="$0"
+USAGE1='[-nf] -j JOB -b START_TIMESTAMP'
+USAGE2='[-nf] -j JOB -s STEP [-s STEP ...]'
+MY_INSTANCE='<%= @ipaddress %>:9100'
+MY_HOSTNAME='<%= @hostname %>'
+MY_DATACENTER='<%= @datacenter %>'
+MY_ROLE='<%= @role %>'
+JOB=''
+END_TIMESTAMP="`date '+%s'`"
+SUCCESS='true'
+START_TIMESTAMP=''
+STEPS=''
+
+errorout() {
+  echo "usage: ${PROG} -h" >&2
+  echo "  or   ${PROG} ${USAGE1}" >&2
+  echo "  or   ${PROG} ${USAGE2}" >&2
+  [ -n "$1" ] && echo "${PROG}: error: $@" >&2
+  exit 1
+}
+
+printhelp() {
+  cat <<EOF
+usage: ${PROG} $USAGE1
+  or   ${PROG} $USAGE2
+
+Push metrics to a prometheus pushgateway.
+
+The easiest way to use this is to add this line at the start of the job:
+
+    START_TIMESTAMP=\`date '+%s'\`
+
+Then, at the end, on success, run this (replace JOB_NAME):
+
+    ${PROG} -j JOB_NAME -b "\$START_TIMESTAMP"
+
+On failure, don't do anything.
+
+If you want to measure the times taken by multiple steps, it will take
+more work on your part, as you'll have to keep track of how long each
+step takes. If for example, your setup phase takes 0:03, your main phase
+takes 10:00, and your cleanup phase takes 0:20, you might finish with:
+
+    ${PROG} -j JOB_NAME \\
+        -s setup=3 \\
+        -s main=600 \\
+        -s cleanup=20
+
+The easiest way to handle failed jobs is to simply do nothing; the
+alertmanager will notice when the last_success metric hasn't been
+updated in a while. However, if you have good reason to want duration
+metrics on failed jobs, you can pass -f to mark it as a failure.
+
+required arguments:
+ -j JOB                 Name of the cronjob; will set the {job="JOB"} label
+
+optional arguments:
+ -h                     Display this help message and exit
+ -n                     Print what would be run; do not execute
+ -f                     Job failed (don't update last_success timestamp)
+ -b START_TIMESTAMP     Time the cronjob started
+ -s STEP_NAME=SECONDS   Number of seconds a step took
+EOF
+}
+
+while getopts ':hfnj:b:s:' opt; do
+  case "$opt" in
+    h)
+      printhelp
+      exit 0
+      ;;
+
+    f)
+      SUCCESS=false
+      ;;
+
+    n)
+      RUN_COMMAND=false
+      ;;
+
+    j)
+      JOB="$OPTARG"
+      ;;
+
+    b)
+      START_TIMESTAMP="$OPTARG"
+      ;;
+
+    s)
+      if [ -z "$OPTARG" ]; then
+        errorout "invalid step: \`'"
+      fi
+
+      if [ -z "$STEPS" ]; then
+        STEPS=()
+      fi
+
+      STEPS=("${STEPS[@]}" "$OPTARG")
+      ;;
+
+    ?)
+      errorout "unrecognized argument: \`-$opt'"
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+main() {
+  validate_arguments
+  set_metrics
+  set_push_url
+  push_metrics
+}
+
+validate_arguments() {
+  assert_job_is_defined
+
+  if start_timestamp_is_set; then
+    assert_no_steps_are_set
+
+  elif any_steps_are_set; then
+    validate_steps
+
+  else
+    errorout "expected -b or at least one -s"
+  fi
+}
+
+assert_job_is_defined() {
+  if [ -z "$JOB" ]; then
+    errorout "expected -j"
+  fi
+}
+
+start_timestamp_is_set() {
+  [ -n "$START_TIMESTAMP" ]
+}
+
+assert_no_steps_are_set() {
+  if any_steps_are_set; then
+    errorout "use -s XOR -b, not both"
+  fi
+}
+
+any_steps_are_set() {
+  [ -n "$STEPS" ]
+}
+
+validate_steps() {
+  for step in "${STEPS[@]}"; do
+    validate_step "$step"
+  done
+}
+
+validate_step() {
+  # Steps should be abcdefg=1234 or abcdefg=1234.5678
+  local empty="`echo "$1" | sed -e 's/^[^=]\+=\([0-9]\+\.\)\?[0-9]\+$//'`"
+  if [ -n "$empty" ]; then
+    errorout "invalid step: \`$1'"
+  fi
+}
+
+set_metrics() {
+  set_duration
+  METRICS="`print_all_metrics`"
+}
+
+set_duration() {
+  if [ -n "$START_TIMESTAMP" ]; then
+    DURATION="${JOB}_duration_seconds $((END_TIMESTAMP - START_TIMESTAMP))"
+  else
+    DURATION="`print_all_steps`"
+  fi
+}
+
+print_all_steps() {
+  for step in "${STEPS[@]}"; do
+    local step_name="`echo "$step" | sed -e 's/=.*$//'`"
+    local step_time="`echo "$step" | sed -e 's/^.*=//'`"
+    echo "${JOB}_duration_seconds{step=\"${step_name}\"} $step_time"
+  done
+}
+
+print_all_metrics() {
+  echo "# HELP ${JOB}_duration_seconds Time spent running $JOB"
+  echo "# TYPE ${JOB}_duration_seconds gauge"
+  echo "$DURATION"
+
+  if $SUCCESS; then
+    print_success_metric
+  fi
+}
+
+print_success_metric() {
+  echo "# HELP ${JOB}_last_success Last successful run of $JOB"
+  echo "# TYPE ${JOB}_last_success gauge"
+  echo "${JOB}_last_success $END_TIMESTAMP"
+}
+
+set_push_url() {
+  PUSH_URL="${PUSHGATEWAY}/metrics/job@base64/`urlsafe_base64 "$JOB"`"
+  PUSH_URL="${PUSH_URL}/instance@base64/`urlsafe_base64 "$MY_INSTANCE"`"
+  PUSH_URL="${PUSH_URL}/hostname@base64/`urlsafe_base64 "$MY_HOSTNAME"`"
+  PUSH_URL="${PUSH_URL}/datacenter@base64/`urlsafe_base64 "$MY_DATACENTER"`"
+  PUSH_URL="${PUSH_URL}/role@base64/`urlsafe_base64 "$MY_ROLE"`"
+}
+
+urlsafe_base64() {
+  # https://tools.ietf.org/html/rfc4648#section-5
+  echo -n "$1" | base64 -w 0 | tr '/+' '_-'
+}
+
+push_metrics() {
+  if $RUN_COMMAND; then
+    echo "$METRICS" | curl --data-binary @- "$PUSH_URL"
+
+  else
+    show_how_to_push_metrics
+  fi
+}
+
+show_how_to_push_metrics() {
+  echo "# If you're curious about any of these base64 values,"
+  echo "# echo SGVsbG8sIHdvcmxkIQo= | tr '_-' '/+' | base64 -d"
+  echo "cat <<EOF | curl --data-binary @- '$PUSH_URL'"
+  echo "$METRICS"
+  echo 'EOF'
+}
+
+main


### PR DESCRIPTION
The pushgateway is two things:

1.  To a cronjob, it's a place to push metrics from the most recent run.
2.  To a scraper, it's an exporter like any other.

In other words, the pushgateway maintains no history -- that's the
scraper's job.

This commit also opens the port on the scrapers that the pushgateway
uses to all nodes it is currently scraping.

There are 2 things to consider:

1.  By default, the pushgateway's data does not persist (this is default
    even when not run in a container). I did not change this default. So
    whenever the pushgateway restarts, the scraper will start seeing
    null for all cronjob metrics until next time the job runs.

2.  Pushing metrics to the pushgateway is a one-line curl, but we ought
    to have puppet distribute that one line in /usr/local/bin on all
    nodes. That way, puppet can manage metadata such as hostname and
    role, so that we don't have to.

I'm not sure whether this should be blocked by either or both of these.
The second one, at least, should not be very difficult.