### PR TITLE
Disable ingest restart jobs

### DIFF
--- a/manifests/profile/hathitrust/ingest_service.pp
+++ b/manifests/profile/hathitrust/ingest_service.pp
@@ -26,16 +26,18 @@ class nebula::profile::hathitrust::ingest_service(
   }
 
   cron { 'stop ingest':
-    command => '/bin/systemctl stop feedd.service > /dev/null 2>&1',
-    user    => 'root',
-    minute  => '45',
-    hour    => '2',
+    #    command => '/bin/systemctl stop feedd.service > /dev/null 2>&1',
+    #    user    => 'root',
+    #    minute  => '45',
+    #    hour    => '2',
+    ensure  => 'absent'
   }
 
   cron { 'start ingest':
-    command => '/bin/systemctl start feedd.service > /dev/null 2>&1',
-    user    => 'root',
-    minute  => '30',
-    hour    => '3'
+    #   command => '/bin/systemctl start feedd.service > /dev/null 2>&1',
+    #   user    => 'root',
+    #   minute  => '30',
+    #   hour    => '3'
+    ensure      => 'absent'
   }
 }


### PR DESCRIPTION
In rare cases ingest can get stopped in such a way that material ends up
in the repository even if it is incomplete. In the worst case, a zip
file can be put into place and appear intact, but in fact be incomplete
(see HT-1666)