### PR TITLE
add manage exclusivity cronjob for HT ETAS

### DIFF
--- a/manifests/profile/hathitrust/cron/mdp_misc.pp
+++ b/manifests/profile/hathitrust/cron/mdp_misc.pp
@@ -41,6 +41,10 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       minute  => $mdp_sessions_minute,
       command => "${home}/scripts/managembookssessions.pl -m clean -a 120 2>&1 | /usr/bin/mail -s '${::hostname} managembooksessions output' ${mail_recipient}";
 
+    'manage exclusivity expiration':
+      minute  => $mdp_sessions_minute,
+      command => "${sdr_root}/pt/scripts/manage_exclusivity.pl";
+
     'harvest proxy downloads':
       minute  => 01,
       hour    => 00,


### PR DESCRIPTION
Just adding a cron job for managing exclusivity. Runs at the same time (offset via config per datacenter) as the sessions cleaning; these are using different tables so shouldn't impact each other. Running simultaneously at both data centers would likely cause deadlocks/replication issues, though.