### PR TITLE
AEIM-2593 - Include all but hostname in a VM's domain

### DIFF
--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -342,6 +342,28 @@ describe 'nebula::virtual_machine' do
         it { is_expected.to compile }
         it { is_expected.not_to contain_install }
       end
+
+      context 'with title set to "myhost.mysub"' do
+        let(:title) { 'myhost.mysub' }
+
+        it do
+          is_expected.to contain_preseed.with_content(
+            %r{^d-i netcfg/get_hostname string myhost\.mysub\.default\.invalid$},
+          )
+        end
+
+        it do
+          is_expected.to contain_preseed.with_content(
+            %r{^d-i netcfg/get_domain string mysub\.default\.invalid$},
+          )
+        end
+
+        it do
+          is_expected.to contain_preseed.with_content(
+            %r{^d-i netcfg/hostname string myhost\.mysub\.default\.invalid$},
+          )
+        end
+      end
     end
   end
 end

--- a/templates/virtual_machine/stretch.cfg.erb
+++ b/templates/virtual_machine/stretch.cfg.erb
@@ -68,7 +68,7 @@ d-i netcfg/confirm_static boolean true
 # values set here. However, setting the values still prevents the questions
 # from being shown, even if values come from dhcp.
 d-i netcfg/get_hostname string <%= @title %>.<%= @domain %>
-d-i netcfg/get_domain string <%= @domain %>
+d-i netcfg/get_domain string <%= "#{@title}.#{@domain}".split('.').drop(1).join('.') %>
 
 # If you want to force a hostname, regardless of what either the DHCP
 # server returns or what the reverse DNS entry for the IP is, uncomment


### PR DESCRIPTION
This change is not the best:

```diff
-@domain
+(@title.split('.') + @domain.split('.')).drop(1).join('.')
```

If it were normal ruby code, I'd want to extract a method as a first
step to clarifying what's going on with this. But this is a template
file, so extracting a method bears an additional cost.

There are tests that represent this behavior, so I'm letting it stand as
is.