### PR TITLE
Don't manage jruby 1.7

### DIFF
--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -69,17 +69,19 @@ class nebula::profile::ruby (
   $supported_versions.each |$version| {
     # Ruby < 2.4 is incompatible with debian stretch
     unless $::os['release']['major'] == '9' and $version =~ /^2\.3\./ {
-      unless $version == $global_version {
-        rbenv::build { $version:
-          bundler_version => $bundler_version,
-        }
+      unless $version =~ /^jruby-1\.7\./ { # AEIM-2776
+        unless $version == $global_version {
+          rbenv::build { $version:
+            bundler_version => $bundler_version,
+          }
 
-        $gems.each |$gem| {
-          rbenv::gem { "${gem[gem]} ${version}":
-            gem          => $gem['gem'],
-            version      => $gem['version'],
-            ruby_version => $version,
-            require      => Rbenv::Build[$version],
+          $gems.each |$gem| {
+            rbenv::gem { "${gem[gem]} ${version}":
+              gem          => $gem['gem'],
+              version      => $gem['version'],
+              ruby_version => $version,
+              require      => Rbenv::Build[$version],
+            }
           }
         }
       }

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -71,6 +71,13 @@ describe 'nebula::profile::ruby' do
         it { is_expected.not_to contain_rbenv__build('2.5.0') }
       end
 
+      # AEIM-2776
+      context 'when given supported_versions of [jruby-1.7.anything]' do
+        let(:params) { { supported_versions: ['jruby-1.7.anything'] } }
+
+        it { is_expected.not_to contain_rbenv__build('jruby-1.7.anything') }
+      end
+
       context 'when given global_version of 2.4.1' do
         let(:params) { { global_version: '2.4.1', bundler_version: '~>1.14' } }
 


### PR DESCRIPTION
Ruby gems isn't working for jruby 1.7, so we want to purge it entirely.
While we work on that, this ensures there are no failing puppet
resources related to it in the meantime. We could silence the alert, but
then we might miss it if something else starts failing.

These changes should be reverted when 1.7 is gone, as is covered by
AEIM-2776.