### PR TITLE
AEIM-2768 - Uninstall unwanted ruby versions

### DIFF
--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018, 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -84,6 +84,22 @@ class nebula::profile::ruby (
             }
           }
         }
+      }
+    }
+  }
+
+  $::ruby_versions.each |$version| {
+    unless $version in $supported_versions {
+      unless $version == $global_version {
+        exec { "rbenv uninstall ${version}":
+          command     => "rbenv uninstall -f ${version}",
+          environment => "RBENV_ROOT=${install_dir}",
+          path        => "${install_dir}/shims:${install_dir}/bin:/usr/bin:/bin",
+        }
+
+        # This uninstall exec requires every rbenv::build. Don't
+        # uninstall anything until everything is installed.
+        Rbenv::Build <| |> -> Exec <| title == "rbenv uninstall ${version}" |>
       }
     }
   }

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018, 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -40,6 +40,16 @@ describe 'nebula::profile::ruby' do
           end
         end
       end
+
+      it do
+        is_expected.to contain_exec('rbenv uninstall 2.4.2')
+          .with_command('rbenv uninstall -f 2.4.2')
+          .with_environment(['RBENV_ROOT=/opt/rbenv'])
+          .with_path('/opt/rbenv/shims:/opt/rbenv/bin:/usr/bin:/bin')
+          .that_requires('Rbenv::Build[2.4.3]')
+      end
+
+      it { is_expected.not_to contain_exec('rbenv uninstall 2.5.0') }
 
       case os
       when 'debian-8-x86_64'

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -27,3 +27,10 @@ apt_update_last_success: '1523250000'
 ec2_tag_role: nebula::role::aws
 
 vm_guests: ['invalid_existing_guest']
+
+# The ruby tests by default are set to install 2.4.3 and 2.5.0, so 2.4.2
+# represents an installed but not desired version of ruby, while 2.5.0
+# represents an already-installed and still desired version of ruby.
+ruby_versions:
+- 2.4.2
+- 2.5.0


### PR DESCRIPTION
This will check every already-installed version of ruby and compare it
against the list of supported versions. If a version of ruby is
installed but not supported, it will be uninstalled.