### PR TITLE
Removed support.fulcrumscholar.org config from redirects.pp

### DIFF
--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -58,13 +58,6 @@ class nebula::profile::www_lib::vhosts::redirects(
     target   => 'https://tools.lib.umich.edu/confluence/display/FPS'
   }
 
-  nebula::apache::redirect_vhost_https { 'support.fulcrumscholar.org':
-    ssl_cn        => 'fulcrum.org',
-    priority      => '08',
-    target        => 'https://tools.lib.umich.edu/confluence/display/FPS',
-    serveraliases => ['support.fulcrum.org', 'support.fulcrumservices.org'],
-  }
-
   nebula::apache::redirect_vhost_https { 'northwestern.fulcrumscholar.org':
     ssl_cn        => 'fulcrum.org',
     priority      => '08',


### PR DESCRIPTION
I believe removing the config from redirects.pp is all that is needed to suffice AEIM-2785. 