### PR TITLE
AEIM-2776 - Stop managing jruby-9.0.X as well as 1.7.X

### DIFF
--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -20,6 +20,11 @@ class nebula::profile::ruby (
   String $install_dir,
   Array  $plugins,
   Array  $gems,
+  # AEIM-2776 - We have a temporary blacklist on specific versions that are
+  # installed in some places, but should not be managed at all. If an installed
+  # version matches this regex, it will not appear in the catalogue at all.
+  # These should be removed as soon as practical in coordination with devs.
+  String $manage_blacklist = '^jruby-(1\.7|9\.0)\.',
 ) {
 
   package {[
@@ -69,7 +74,7 @@ class nebula::profile::ruby (
   $supported_versions.each |$version| {
     # Ruby < 2.4 is incompatible with debian stretch
     unless $::os['release']['major'] == '9' and $version =~ /^2\.3\./ {
-      unless $version =~ /^jruby-1\.7\./ { # AEIM-2776
+      unless $version =~ $manage_blacklist {
         unless $version == $global_version {
           rbenv::build { $version:
             bundler_version => $bundler_version,

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -81,11 +81,25 @@ describe 'nebula::profile::ruby' do
         it { is_expected.not_to contain_rbenv__build('2.5.0') }
       end
 
-      # AEIM-2776
+      # AEIM-2776 - Confirm jruby-1.7 is blacklisted by default
       context 'when given supported_versions of [jruby-1.7.anything]' do
         let(:params) { { supported_versions: ['jruby-1.7.anything'] } }
 
         it { is_expected.not_to contain_rbenv__build('jruby-1.7.anything') }
+      end
+
+      # AEIM-2776 - Confirm jruby-9.0 is blacklisted by default
+      context 'when given supported_versions of [jruby-9.0.anything]' do
+        let(:params) { { supported_versions: ['jruby-9.0.anything'] } }
+
+        it { is_expected.not_to contain_rbenv__build('jruby-9.0.anything') }
+      end
+
+      # AEIM-2776 - Confirm we can blacklist by param
+      context 'when supporting and blacklisting ree-0.0' do
+        let(:params) { { supported_versions: ['ree-0.0'], manage_blacklist: '^ree-0' } }
+
+        it { is_expected.not_to contain_rbenv__build('ree-0.0') }
       end
 
       context 'when given global_version of 2.4.1' do


### PR DESCRIPTION
This lets us put off uninstalling 9.0.X on buzz and grog.