### PR TITLE
AEIM-2815 - Rename kubernetes legacy::kubernetes

### DIFF
--- a/manifests/profile/legacy/kubernetes.pp
+++ b/manifests/profile/legacy/kubernetes.pp
@@ -40,7 +40,7 @@
 #
 # @param cluster The unique name of the cluster.
 # @param clusters A hash of cluster names to cluster definitions.
-class nebula::profile::kubernetes (
+class nebula::profile::legacy::kubernetes (
   String             $cluster,
   Hash[String, Hash] $clusters,
 ) {

--- a/manifests/profile/legacy/kubernetes/haproxy.pp
+++ b/manifests/profile/legacy/kubernetes/haproxy.pp
@@ -13,20 +13,20 @@
 # @param cluster The name of the cluster to serve as ambassador to. This
 #   defaults to nebula::profile::kubernetes::cluster, and you should
 #   almost certainly set that instead.
-class nebula::profile::kubernetes::haproxy (
+class nebula::profile::legacy::kubernetes::haproxy (
   Boolean $master = false,
   String $cluster = '',
 ) {
   include nebula::profile::networking::sysctl
 
   if $cluster == '' {
-    $cluster_name = lookup('nebula::profile::kubernetes::cluster')
+    $cluster_name = lookup('nebula::profile::legacy::kubernetes::cluster')
   } else {
     $cluster_name = $cluster
   }
 
   $email = lookup('nebula::root_email')
-  $floating_ip = lookup('nebula::profile::kubernetes::clusters')[$cluster_name]['address']
+  $floating_ip = lookup('nebula::profile::legacy::kubernetes::clusters')[$cluster_name]['address']
   $monitoring_user = lookup('nebula::profile::haproxy::monitoring_user')
 
   concat_fragment { 'haproxy defaults':

--- a/manifests/profile/legacy/kubernetes/stacked_controller.pp
+++ b/manifests/profile/legacy/kubernetes/stacked_controller.pp
@@ -15,15 +15,15 @@
 # running. Due to the finicky nature of the bootstrapping process,
 # puppet's responsibility ends when the servers simply have the desired
 # software installed.
-class nebula::profile::kubernetes::stacked_controller {
-  include nebula::profile::kubernetes
+class nebula::profile::legacy::kubernetes::stacked_controller {
+  include nebula::profile::legacy::kubernetes
 
-  $cluster_name = lookup('nebula::profile::kubernetes::cluster')
-  $cluster = lookup('nebula::profile::kubernetes::clusters')[$cluster_name]
+  $cluster_name = lookup('nebula::profile::legacy::kubernetes::cluster')
+  $cluster = lookup('nebula::profile::legacy::kubernetes::clusters')[$cluster_name]
   $control_dns = $cluster['control_dns']
   $kubernetes_version = $cluster['kubernetes_version']
-  $service_cidr = pick($cluster['service_cidr'], lookup('nebula::profile::kubernetes::service_cidr'))
-  $pod_cidr = pick($cluster['pod_cidr'], lookup('nebula::profile::kubernetes::pod_cidr'))
+  $service_cidr = pick($cluster['service_cidr'], lookup('nebula::profile::legacy::kubernetes::service_cidr'))
+  $pod_cidr = pick($cluster['pod_cidr'], lookup('nebula::profile::legacy::kubernetes::pod_cidr'))
 
   concat_file { 'kubeadm config':
     path   => '/etc/kubeadm_config.yaml',

--- a/manifests/profile/legacy/kubernetes/worker.pp
+++ b/manifests/profile/legacy/kubernetes/worker.pp
@@ -7,14 +7,14 @@
 # This opens up the ports we need open on workers. This does not start
 # kubernetes or attempt to connect this node to the cluster. All it does
 # is ensure the possibility of you doing it by hand.
-class nebula::profile::kubernetes::worker (
+class nebula::profile::legacy::kubernetes::worker (
   Hash[String, Hash] $cifs_mounts = {},
 ) {
-  include nebula::profile::kubernetes
+  include nebula::profile::legacy::kubernetes
 
   ensure_packages(['nfs-common'], {'ensure' => 'present'})
 
-  $cluster = lookup('nebula::profile::kubernetes::cluster')
+  $cluster = lookup('nebula::profile::legacy::kubernetes::cluster')
 
   @@concat_fragment { "haproxy nodeports ${::hostname}":
     target  => '/etc/haproxy/haproxy.cfg',

--- a/manifests/role/legacy/kubernetes/controller.pp
+++ b/manifests/role/legacy/kubernetes/controller.pp
@@ -3,10 +3,10 @@
 # BSD License. See LICENSE.txt for details.
 
 # Kubernetes controller plane and etcd server
-class nebula::role::kubernetes::controller {
+class nebula::role::legacy::kubernetes::controller {
   class { 'nebula::role::minimum':
     internal_routing => 'kubernetes_calico',
   }
 
-  include nebula::profile::kubernetes::stacked_controller
+  include nebula::profile::legacy::kubernetes::stacked_controller
 }

--- a/manifests/role/legacy/kubernetes/gateway.pp
+++ b/manifests/role/legacy/kubernetes/gateway.pp
@@ -3,7 +3,7 @@
 # BSD License. See LICENSE.txt for details.
 
 # Kubernetes gateway node
-class nebula::role::kubernetes::gateway {
+class nebula::role::legacy::kubernetes::gateway {
   include nebula::role::minimum
-  include nebula::profile::kubernetes::haproxy
+  include nebula::profile::legacy::kubernetes::haproxy
 }

--- a/manifests/role/legacy/kubernetes/worker.pp
+++ b/manifests/role/legacy/kubernetes/worker.pp
@@ -3,10 +3,10 @@
 # BSD License. See LICENSE.txt for details.
 
 # Kubernetes worker node
-class nebula::role::kubernetes::worker {
+class nebula::role::legacy::kubernetes::worker {
   class { 'nebula::role::minimum':
     internal_routing => 'kubernetes_calico',
   }
 
-  include nebula::profile::kubernetes::worker
+  include nebula::profile::legacy::kubernetes::worker
 }

--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -60,7 +60,7 @@ end
             %w[nebula::role::clearinghouse chipmunk],
             %w[nebula::role::deb_server deb_server],
             %w[nebula::role::deploy_host named_instances],
-            %w[nebula::role::kubernetes kubernetes],
+            %w[nebula::role::legacy::kubernetes kubernetes],
             %w[nebula::role::log_host log_host],
             %w[nebula::role::webhost::www_lib_vm www_lib],
             %w[nebula::role::docker_registry docker_registry],

--- a/spec/classes/profile/legacy/kubernetes/haproxy_spec.rb
+++ b/spec/classes/profile/legacy/kubernetes/haproxy_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
 
-describe 'nebula::profile::kubernetes::haproxy' do
+describe 'nebula::profile::legacy::kubernetes::haproxy' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { 'spec/fixtures/hiera/kubernetes_config.yaml' }

--- a/spec/classes/profile/legacy/kubernetes/stacked_controller_spec.rb
+++ b/spec/classes/profile/legacy/kubernetes/stacked_controller_spec.rb
@@ -5,14 +5,14 @@
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
 
-describe 'nebula::profile::kubernetes::stacked_controller' do
+describe 'nebula::profile::legacy::kubernetes::stacked_controller' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { 'spec/fixtures/hiera/kubernetes_config.yaml' }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('Nebula::Profile::Kubernetes') }
+      it { is_expected.to contain_class('Nebula::Profile::Legacy::Kubernetes') }
 
       it do
         is_expected.to contain_concat_file('kubeadm config').with(

--- a/spec/classes/profile/legacy/kubernetes/worker_spec.rb
+++ b/spec/classes/profile/legacy/kubernetes/worker_spec.rb
@@ -5,14 +5,14 @@
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
 
-describe 'nebula::profile::kubernetes::worker' do
+describe 'nebula::profile::legacy::kubernetes::worker' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { 'spec/fixtures/hiera/kubernetes_config.yaml' }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('Nebula::Profile::Kubernetes') }
+      it { is_expected.to contain_class('Nebula::Profile::Legacy::Kubernetes') }
       it { is_expected.to contain_package('nfs-common') }
 
       context 'when a cifs_mount is defined' do

--- a/spec/classes/profile/legacy/kubernetes_spec.rb
+++ b/spec/classes/profile/legacy/kubernetes_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
 
-describe 'nebula::profile::kubernetes' do
+describe 'nebula::profile::legacy::kubernetes' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { 'spec/fixtures/hiera/kubernetes_config.yaml' }

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -6,7 +6,7 @@
 require 'spec_helper'
 
 %w[controller worker].each do |role|
-  describe "nebula::role::kubernetes::#{role}" do
+  describe "nebula::role::legacy::kubernetes::#{role}" do
     on_supported_os.each do |os, os_facts|
       next if os == 'debian-8-x86_64'
 

--- a/spec/fixtures/hiera/kubernetes.yaml
+++ b/spec/fixtures/hiera/kubernetes.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-nebula::profile::kubernetes::service_cidr: "192.168.0.0/16"
-nebula::profile::kubernetes::pod_cidr: "10.96.0.0/12"
-nebula::profile::kubernetes::cluster: first_cluster
-nebula::profile::kubernetes::clusters:
+nebula::profile::legacy::kubernetes::service_cidr: "192.168.0.0/16"
+nebula::profile::legacy::kubernetes::pod_cidr: "10.96.0.0/12"
+nebula::profile::legacy::kubernetes::cluster: first_cluster
+nebula::profile::legacy::kubernetes::clusters:
   first_cluster:
     address: 10.0.0.1
     docker_version: 5:18.09.6~3-0~debian-stretch


### PR DESCRIPTION
This is to make room for its radically different production replacement,
since we want the prototype to continue running until we're ready to
replace it.

This requires a s/kubernetes/legacy::kubernetes/g in the hieradata that
definitely needs to be tested on hatcher-k8s-* before this is safe to
merge.