### PR TITLE
Open SSH differently on publicly inaccessible nodes

### DIFF
--- a/lib/puppet/functions/is_publicly_accessible.rb
+++ b/lib/puppet/functions/is_publicly_accessible.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+require 'ipaddr'
+
+Puppet::Functions.create_function(:is_publicly_accessible) do
+  dispatch :run do
+    return_type 'Boolean'
+  end
+
+  def run
+    ip_addresses.any? { |ip| public? ip }
+  end
+
+  def ip_addresses
+    interfaces.values.map { |v| v['ip'] }.delete_if { |ip| ip.nil? }
+  end
+
+  def interfaces
+    @interfaces ||= closure_scope['facts']['networking']['interfaces']
+    @interfaces ||= {}
+  end
+
+  def public?(address)
+    private_blocks.none? { |block| block.include? address }
+  end
+
+  def private_blocks
+    @private_blocks ||= call_function('lookup',
+                                      'umich::networks::private_blocks')
+                        .map { |cidr| IPAddr.new(cidr) }
+  end
+end

--- a/manifests/profile/networking/firewall/ssh.pp
+++ b/manifests/profile/networking/firewall/ssh.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 The Regents of the University of Michigan.
+# Copyright (c) 2018-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -9,8 +9,15 @@
 # @example
 #   include nebula::profile::networking::firewall::ssh
 class nebula::profile::networking::firewall::ssh {
-  nebula::exposed_port { '100 SSH':
-    port  => 22,
-    block => 'umich::networks::all_trusted_machines',
+  if is_publicly_accessible() {
+    nebula::exposed_port { '100 SSH':
+      port  => 22,
+      block => 'umich::networks::all_trusted_machines',
+    }
+  } else {
+    nebula::exposed_port { '100 SSH':
+      port  => 22,
+      block => 'umich::networks::private_bastion_hosts',
+    }
   }
 }

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018-2019 The Regents of the University of Michigan.
+# Copyright (c) 2018-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -10,13 +10,42 @@ describe 'nebula::profile::networking::firewall::ssh' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
+      context 'when publicly accessible' do
+        let(:facts) do
+          super().merge(
+            'networking' => {
+              'interfaces' => { 'eth0' => { 'ip' => '123.45.67.89' } },
+            },
+          )
+        end
 
-      it do
-        is_expected.to contain_nebula__exposed_port('100 SSH').with(
-          port: 22,
-          block: 'umich::networks::all_trusted_machines',
-        )
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_nebula__exposed_port('100 SSH').with(
+            port: 22,
+            block: 'umich::networks::all_trusted_machines',
+          )
+        end
+      end
+
+      context 'when publicly inaccessible' do
+        let(:facts) do
+          super().merge(
+            'networking' => {
+              'interfaces' => { 'eth0' => { 'ip' => '10.45.67.89' } },
+            },
+          )
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_nebula__exposed_port('100 SSH').with(
+            port: 22,
+            block: 'umich::networks::private_bastion_hosts',
+          )
+        end
       end
     end
   end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -157,3 +157,9 @@ umich::networks::campus_wired_and_wireless: []
 umich::networks::staff: []
 umich::networks::bentley: []
 umich::networks::datacenter: []
+umich::networks::private_bastion_hosts: []
+umich::networks::private_blocks:
+- 10.0.0.0/8
+- 127.0.0.0/8
+- 172.16.0.0/12
+- 192.168.0.0/16

--- a/spec/functions/is_publicly_accessible_spec.rb
+++ b/spec/functions/is_publicly_accessible_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'is_publicly_accessible' do
+  let(:facts) { { 'networking' => { 'interfaces' => interfaces } } }
+  let(:interfaces) { { 'lo' => { 'ip' => '127.0.0.1' } } }
+
+  context 'with no internet connection' do
+    it { is_expected.to run.and_return(false) }
+  end
+
+  context 'with the ip address 10.1.2.3' do
+    let :interfaces do
+      super().merge('eth0' => { 'ip' => '10.1.2.3' })
+    end
+
+    it { is_expected.to run.and_return(false) }
+
+    context 'and with a nil ip address' do
+      let :interfaces do
+        super().merge('hfdlksajh' => { 'ip' => nil })
+      end
+
+      it { is_expected.to run.and_return(false) }
+    end
+
+    context 'and with the ip address 12.34.56.78' do
+      let :interfaces do
+        super().merge('eth1' => { 'ip' => '12.34.56.78' })
+      end
+
+      it { is_expected.to run.and_return(true) }
+
+      context 'and with a nil ip address' do
+        let :interfaces do
+          super().merge('hfdlksajh' => { 'ip' => nil })
+        end
+
+        it { is_expected.to run.and_return(true) }
+      end
+    end
+
+    context 'and with the ip address 21.43.65.87' do
+      let :interfaces do
+        super().merge('eth1' => { 'ip' => '21.43.65.87' })
+      end
+
+      it { is_expected.to run.and_return(true) }
+    end
+  end
+
+  context 'with the ip address 172.20.12.34' do
+    let :interfaces do
+      super().merge('eth0' => { 'ip' => '172.20.12.34' })
+    end
+
+    it { is_expected.to run.and_return(false) }
+  end
+
+  context 'with the ip address 192.168.1.123' do
+    let :interfaces do
+      super().merge('eth0' => { 'ip' => '192.168.1.123' })
+    end
+
+    it { is_expected.to run.and_return(false) }
+  end
+
+  context 'with no interfaces set' do
+    let(:facts) { { 'networking' => {} } }
+
+    it { is_expected.to run.and_return(false) }
+  end
+end


### PR DESCRIPTION
Opening to all_trusted_machines is silly when most machines aren't even
on the right private VLAN. So instead we'll open ssh just to a select
few private bastion hosts.