### PR TITLE
Add non-standard name for staff.lib cosign service to make it work

### DIFF
--- a/manifests/profile/www_lib/vhosts/staff_lib.pp
+++ b/manifests/profile/www_lib/vhosts/staff_lib.pp
@@ -48,6 +48,7 @@ class nebula::profile::www_lib::vhosts::staff_lib (
     ssl                           => true,
     usertrack                     => true,
     cosign                        => true,
+    cosign_service                => 'staff.lib.umich.edu',
     docroot                       => $docroot,
     setenvifnocase                => ['^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1'],
 


### PR DESCRIPTION
Minimal change. This works. Just needs a blessing.