### PR TITLE
Mount only /www and /www-dev on private app hosts

### DIFF
--- a/manifests/role/app_host/prod_private.pp
+++ b/manifests/role/app_host/prod_private.pp
@@ -13,5 +13,9 @@
 class nebula::role::app_host::prod_private {
   include nebula::role::app_host::prod
   include nebula::profile::networking::private
-  include nebula::profile::www_lib::mounts
+
+  class { 'nebula::profile::www_lib::mounts':
+    nfs_mounts  => {},
+    cifs_mounts => {},
+  }
 }


### PR DESCRIPTION
When just including www_lib::mounts unqualified, the app hosts kept
trying to mount NFS and CIFS filesystems that were www-lib specific and
that they did not have access to. This was causing puppet to raise
errors due to the failed mounts.

This commit explicitly sets those lists of extra mounts to empty hashes
so that hieradata will be ignored.