### PR TITLE
AEIM-2976 - Check haproxy config on every sync and when reloading

### DIFF
--- a/manifests/profile/haproxy/prereqs.pp
+++ b/manifests/profile/haproxy/prereqs.pp
@@ -18,9 +18,9 @@ class nebula::profile::haproxy::prereqs {
   }
 
   service { 'haproxy':
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
+    ensure  => 'running',
+    enable  => true,
+    restart => '/bin/systemctl reload haproxy',
   }
 
   file { '/etc/haproxy':
@@ -29,5 +29,9 @@ class nebula::profile::haproxy::prereqs {
 
   file { '/etc/haproxy/services.d':
     ensure => 'directory'
+  }
+
+  exec { 'check haproxy config':
+    command => '/usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -c -q -f /etc/haproxy/services.d',
   }
 }

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -62,7 +62,13 @@ describe 'nebula::profile::haproxy' do
           is_expected.to contain_service('haproxy').with(
             ensure: 'running',
             enable: true,
-            hasrestart: true,
+            restart: '/bin/systemctl reload haproxy',
+          )
+        end
+
+        it do
+          is_expected.to contain_exec('check haproxy config').with(
+            command: "/usr/sbin/haproxy -f #{haproxy_conf} -c -q -f /etc/haproxy/services.d",
           )
         end
 


### PR DESCRIPTION
Systemd already checks the config when running reload, but puppet was
running restart instead of reload. This tells it to run reload instead.

Additionally, this adds an exec that checks the config on every sync, so
that, if puppet applies an invalid config, not only will haproxy fail to
reload, but also puppet will repeatedly have this exec as a failing
resource.