### PR TITLE
AEIM-2978 - Restart press with systemd

### DIFF
--- a/manifests/profile/www_lib/cron.pp
+++ b/manifests/profile/www_lib/cron.pp
@@ -63,7 +63,7 @@ class nebula::profile::www_lib::cron (
       weekday => '1-6',
       hour    => 0,
       minute  => 4,
-      command => '/usr/bin/pkill -HUP -f "perl /www/www.press/script/press" > /dev/null 2>&1',
+      command => '/bin/systemctl restart press',
     ;
   }
 


### PR DESCRIPTION
On the old webservers, the press site was run directly by apache, so we
restarted it with pkill. On the newer VMs however, it's run by systemd,
so we need to restart it with systemd.