### PR TITLE
AEIM-2980 - Fix PHP5 cosign-only directories

### DIFF
--- a/manifests/apache/www_lib_vhost.pp
+++ b/manifests/apache/www_lib_vhost.pp
@@ -14,6 +14,7 @@ define nebula::apache::www_lib_vhost (
   String $ssl_cn = $servername,
   Array[Hash] $directories = [],
   Array[Hash] $cosign_public_access_off_dirs = [],
+  Array[Hash] $cosign_public_access_off_php5_dirs = [],
   Optional[Array] $rewrites = undef,
   Optional[Array] $aliases = undef,
   String $logging_prefix = '',
@@ -137,6 +138,15 @@ define nebula::apache::www_lib_vhost (
       $dir.merge( {
         custom_fragment => $cosign_public_access_off,
         require         => [],
+      })
+    } + $cosign_public_access_off_php5_dirs.map |$dir| {
+      $dir.merge( {
+        custom_fragment => $cosign_public_access_off,
+        require         => [],
+        addhandlers => [{
+          extensions => ['.php'],
+          handler => 'application/x-httpd-php'
+        }],
       })
     }
   } else {


### PR DESCRIPTION
They were showing up as

    AllowOverride None
    Require all granted
    <FilesMatch ".+(\.php)$">
        SetHandler application/x-httpd-php
    </FilesMatch>
    CosignAllowPublicAccess off

But what we want is

     AllowOverride None
    -Require all granted
     <FilesMatch ".+(\.php)$">
         SetHandler application/x-httpd-php
     </FilesMatch>
     CosignAllowPublicAccess off
    +AuthType Cosign
    +Require valid-user

This does this while also adding a cosign_public_access_off_php5_dirs
parameter to the www_lib_vhost type, in the same style as
cosign_public_access_off_dirs, but adding the SetHandler for PHP5 as
well.