### PR TITLE
AEIM-2989 - Install LVM on kubernetes worker nodes

### DIFF
--- a/manifests/profile/kubernetes/filesystems.pp
+++ b/manifests/profile/kubernetes/filesystems.pp
@@ -5,7 +5,7 @@
 class nebula::profile::kubernetes::filesystems (
   Hash[String, Hash] $cifs_mounts = {},
 ) {
-  ensure_packages(['nfs-common'], {'ensure' => 'present'})
+  ensure_packages(['nfs-common', 'lvm2'], {'ensure' => 'present'})
 
   $cifs_mounts.each |$mount_title, $mount_parameters| {
     nebula::cifs_mount { "/mnt/legacy_cifs_${mount_title}":

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -107,6 +107,8 @@ end
               .with_order('02')
               .with_content("KUBE_WORKERS=(\"${KUBE_WORKERS[@]}\" \"#{facts[:hostname]}/#{facts[:ipaddress]}\")\n")
           end
+
+          it { is_expected.to contain_package('lvm2') }
         end
       end
     end


### PR DESCRIPTION
This is required for ceph to recognize its storage volumes.