### PR TITLE
Adjust timing of ingest daily jobs

### DIFF
--- a/manifests/profile/hathitrust/ingest_jobs.pp
+++ b/manifests/profile/hathitrust/ingest_jobs.pp
@@ -69,7 +69,7 @@ class nebula::profile::hathitrust::ingest_jobs(
     'daily tasks':
       command => "for script in ${feed_daily}/enabled/*.pl; do ${feed_perl} \$script; done",
       hour    => 3,
-      minute  => 0;
+      minute  => 30;
 
     # copy crms renewals from latte-1
     'crms renewals':


### PR DESCRIPTION
The jobs that fetched new data from zephir run at 3:05 AM, so these (which ran at 3 AM) were potentially using data that was a day behind what was fetched from zephir.