### PR TITLE
AEIM-3009 - Kubernetes can communicate on an external private VLAN

### DIFF
--- a/manifests/profile/kubernetes/keepalived.pp
+++ b/manifests/profile/kubernetes/keepalived.pp
@@ -12,6 +12,7 @@ class nebula::profile::kubernetes::keepalived (
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
   $cluster = lookup('nebula::profile::kubernetes::clusters')[$cluster_name]
   $public_address = $cluster['public_address']
+  $private_address = $cluster['private_address']
   $router_address = $cluster['router_address']
   $etcd_address = $cluster['etcd_address']
   $kube_api_address = $cluster['kube_api_address']

--- a/manifests/profile/kubernetes/router.pp
+++ b/manifests/profile/kubernetes/router.pp
@@ -9,6 +9,8 @@ class nebula::profile::kubernetes::router {
   $cluster = lookup('nebula::profile::kubernetes::clusters')[$cluster_name]
   $node_cidr = pick($cluster['node_cidr'], lookup('nebula::profile::kubernetes::node_cidr'))
   $public_address = $cluster['public_address']
+  $private_address = $cluster['private_address']
+  $private_cidr = $cluster['private_cidr']
 
   file { '/etc/sysctl.d/router.conf':
     content => template('nebula/profile/kubernetes/router/sysctl.conf.erb'),
@@ -24,7 +26,19 @@ class nebula::profile::kubernetes::router {
     destination => $node_cidr,
   }
 
-  firewall { '002 Give external requests our public IP':
+  if $private_address != undef {
+    firewall { '002 Give internal requests our private IP':
+      table       => 'nat',
+      chain       => 'POSTROUTING',
+      jump        => 'SNAT',
+      proto       => 'all',
+      source      => $node_cidr,
+      tosource    => $private_address,
+      destination => $private_cidr,
+    }
+  }
+
+  firewall { '003 Give external requests our public IP':
     table    => 'nat',
     chain    => 'POSTROUTING',
     jump     => 'SNAT',

--- a/spec/classes/profile/kubernetes/keepalived_spec.rb
+++ b/spec/classes/profile/kubernetes/keepalived_spec.rb
@@ -61,6 +61,7 @@ describe 'nebula::profile::kubernetes::keepalived' do
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.1 dev ens4[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.6 dev ens4[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.7 dev ens4[^\}]*\}}m,
+          %r{virtual_ipaddress \{[^\}]*192\.168\.123\.234 dev ens4[^\}]*\}}m,
         ].each do |content|
           it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(content) }
         end

--- a/spec/classes/profile/kubernetes/router_spec.rb
+++ b/spec/classes/profile/kubernetes/router_spec.rb
@@ -30,7 +30,18 @@ describe 'nebula::profile::kubernetes::router' do
       end
 
       it do
-        is_expected.to contain_firewall('002 Give external requests our public IP')
+        is_expected.to contain_firewall('002 Give internal requests our private IP')
+          .with_table('nat')
+          .with_chain('POSTROUTING')
+          .with_jump('SNAT')
+          .with_proto('all')
+          .with_source('172.28.0.0/14')
+          .with_tosource('192.168.123.234')
+          .with_destination('192.168.0.0/16')
+      end
+
+      it do
+        is_expected.to contain_firewall('003 Give external requests our public IP')
           .with_table('nat')
           .with_chain('POSTROUTING')
           .with_jump('SNAT')
@@ -48,8 +59,10 @@ describe 'nebula::profile::kubernetes::router' do
             .with_destination('10.123.234.0/24')
         end
 
+        it { is_expected.not_to contain_firewall('002 Give internal requests our private IP') }
+
         it do
-          is_expected.to contain_firewall('002 Give external requests our public IP')
+          is_expected.to contain_firewall('003 Give external requests our public IP')
             .with_source('10.123.234.0/24')
             .with_tosource('10.0.0.2')
         end

--- a/spec/fixtures/hiera/kubernetes/default.yaml
+++ b/spec/fixtures/hiera/kubernetes/default.yaml
@@ -9,6 +9,8 @@ nebula::profile::kubernetes::bootstrap_keys:
 nebula::profile::kubernetes::clusters:
   first_cluster:
     public_address: 10.0.0.1
+    private_address: 192.168.123.234
+    private_cidr: 192.168.0.0/16
     router_address: 172.16.0.1
     etcd_address: 172.16.0.6
     kube_api_address: 172.16.0.7

--- a/templates/profile/kubernetes/keepalived/keepalived_01.erb
+++ b/templates/profile/kubernetes/keepalived/keepalived_01.erb
@@ -31,6 +31,9 @@ vrrp_instance haproxy {
     <%= @router_address %> dev ens4
     <%= @etcd_address %> dev ens4
     <%= @kube_api_address %> dev ens4
+<% unless @private_address.nil? -%>
+    <%= @private_address %> dev ens4
+<% end -%>
   }
 
   unicast_src_ip <%= @ipaddress %>


### PR DESCRIPTION
Currently, the NAT router changes the source IP address on all external requests to the cluster's public IP address. This ensures that the cluster will claim a private IP address when communicating on a specified CIDR.