### PR TITLE
AEIM-3022 Expose Graylog via GELF/TCP to datacenter nodes

### DIFF
--- a/manifests/profile/kubernetes/destination_port/gelf_tcp.pp
+++ b/manifests/profile/kubernetes/destination_port/gelf_tcp.pp
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::kubernetes::destination_port::gelf_tcp {
+  $cluster_name = lookup('nebula::profile::kubernetes::cluster')
+
+  @@concat_fragment { "haproxy kubernetes gelf tcp ${::hostname}":
+    target  => '/etc/haproxy/services.d/gelf_tcp.cfg',
+    order   => '02',
+    content => "  server ${::hostname} ${::ipaddress}:32201 check\n",
+    tag     => "${cluster_name}_haproxy_kubernetes_gelf_tcp",
+  }
+}

--- a/manifests/profile/kubernetes/haproxy.pp
+++ b/manifests/profile/kubernetes/haproxy.pp
@@ -34,7 +34,7 @@ class nebula::profile::kubernetes::haproxy {
     notify  => Service['haproxy'],
   }
 
-  ['api', 'etcd', 'http', 'https', 'https_alt'].each |$service| {
+  ['api', 'etcd', 'gelf_tcp', 'http', 'https', 'https_alt'].each |$service| {
     concat { "/etc/haproxy/services.d/${service}.cfg":
       notify => Service['haproxy'],
     }
@@ -77,6 +77,11 @@ class nebula::profile::kubernetes::haproxy {
   nebula::exposed_port { '200 private https_alt':
     block => 'umich::networks::datacenter',
     port  => 8443,
+  }
+
+  nebula::exposed_port { '200 private gelf_tcp':
+    block => 'umich::networks::datacenter',
+    port  => 12201,
   }
 
   file { '/etc/haproxy/haproxy.cfg':

--- a/manifests/role/kubernetes/worker.pp
+++ b/manifests/role/kubernetes/worker.pp
@@ -12,6 +12,7 @@ class nebula::role::kubernetes::worker {
   include nebula::profile::kubernetes::kubeadm
   include nebula::profile::kubernetes::filesystems
   include nebula::profile::kubernetes::prometheus
+  include nebula::profile::kubernetes::destination_port::gelf_tcp
   include nebula::profile::kubernetes::destination_port::http
   include nebula::profile::kubernetes::destination_port::https
   include nebula::profile::kubernetes::destination_port::https_alt

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -11,6 +11,7 @@ require 'spec_helper'
   ['http',      30080],
   ['https',     30443],
   ['https_alt', 31443],
+  ['gelf_tcp',  32201],
 ].each do |service, port|
   describe "nebula::profile::kubernetes::destination_port::#{service}" do
     on_supported_os.each do |os, os_facts|

--- a/spec/classes/profile/kubernetes/haproxy_spec.rb
+++ b/spec/classes/profile/kubernetes/haproxy_spec.rb
@@ -52,11 +52,12 @@ describe 'nebula::profile::kubernetes::haproxy' do
         it { is_expected.to contain_file('/etc/haproxy/services.d').with_ensure('directory') }
 
         [
-          [:kube_api, 6443, 'api'],
-          [:etcd,     2379, 'etcd'],
-          [:public,   80,   'http'],
-          [:public,   443,  'https'],
-          [:private,  8443, 'https_alt'],
+          [:kube_api, 6443,  'api'],
+          [:etcd,     2379,  'etcd'],
+          [:public,   80,    'http'],
+          [:public,   443,   'https'],
+          [:private,  8443,  'https_alt'],
+          [:private,  12201, 'gelf_tcp'],
         ].each do |ip, port, service|
           describe 'the firewall' do
             case ip

--- a/templates/profile/kubernetes/haproxy/services.d/gelf_tcp.cfg.erb
+++ b/templates/profile/kubernetes/haproxy/services.d/gelf_tcp.cfg.erb
@@ -1,0 +1,11 @@
+# Managed by puppet (nebula/profile/kubernetes/haproxy/services.d/gelf_tcp.cfg.erb)
+frontend kubernetes-gelf-tcp-front
+  bind <%= @public_address %>:12201
+  mode tcp
+  option tcplog
+  default_backend kubernetes-gelf-tcp-back
+
+backend kubernetes-gelf-tcp-back
+  mode tcp
+  option tcp-check
+  balance roundrobin


### PR DESCRIPTION
This is straightforward; it adds an HAProxy pair for GELF similar to how
we support https_alt.