### PR TITLE
AEIM-3023 - Install NTP to fix clock skew

### DIFF
--- a/manifests/role/kubernetes/backup_gateway.pp
+++ b/manifests/role/kubernetes/backup_gateway.pp
@@ -4,6 +4,7 @@
 
 class nebula::role::kubernetes::backup_gateway {
   include nebula::role::minimum
+  include nebula::profile::ntp
   include nebula::profile::kubernetes::dns_server
   include nebula::profile::kubernetes::kubectl
   include nebula::profile::kubernetes::haproxy

--- a/manifests/role/kubernetes/controller.pp
+++ b/manifests/role/kubernetes/controller.pp
@@ -7,6 +7,7 @@ class nebula::role::kubernetes::controller {
     internal_routing => 'kubernetes_calico',
   }
 
+  include nebula::profile::ntp
   include nebula::profile::kubernetes::dns_client
   include nebula::profile::kubernetes::kubelet
   include nebula::profile::kubernetes::kubeadm

--- a/manifests/role/kubernetes/etcd.pp
+++ b/manifests/role/kubernetes/etcd.pp
@@ -7,6 +7,7 @@ class nebula::role::kubernetes::etcd {
     internal_routing => 'kubernetes_calico',
   }
 
+  include nebula::profile::ntp
   include nebula::profile::kubernetes::dns_client
   include nebula::profile::kubernetes::kubelet
   include nebula::profile::kubernetes::destination_port::etcd

--- a/manifests/role/kubernetes/primary_gateway.pp
+++ b/manifests/role/kubernetes/primary_gateway.pp
@@ -4,6 +4,7 @@
 
 class nebula::role::kubernetes::primary_gateway {
   include nebula::role::minimum
+  include nebula::profile::ntp
   include nebula::profile::kubernetes::dns_server
   include nebula::profile::kubernetes::kubectl
   include nebula::profile::kubernetes::haproxy

--- a/manifests/role/kubernetes/worker.pp
+++ b/manifests/role/kubernetes/worker.pp
@@ -7,6 +7,7 @@ class nebula::role::kubernetes::worker {
     internal_routing => 'kubernetes_calico',
   }
 
+  include nebula::profile::ntp
   include nebula::profile::kubernetes::dns_client
   include nebula::profile::kubernetes::kubelet
   include nebula::profile::kubernetes::kubeadm

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -24,6 +24,8 @@ require 'spec_helper'
           )
         end
 
+        it { is_expected.to contain_class('Nebula::Profile::Ntp') }
+
         it { is_expected.to contain_service('haproxy').that_notifies('Service[keepalived]') }
       end
     end
@@ -48,6 +50,8 @@ end
             },
           )
         end
+
+        it { is_expected.to contain_class('Nebula::Profile::Ntp') }
 
         it { is_expected.not_to contain_resources('firewall').with_purge(true) }
 


### PR DESCRIPTION
Apparently rook/ceph gets upset when clocks disagree with one another,
and kubernetes nodes should always be running NTP. This tells all our
kubernetes nodes to pull in our NTP profile.