### PR TITLE
Silence imgsrv watchdog stdout. Retain notification for stderr

### DIFF
--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -62,7 +62,7 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   cron { 'imgsrv responsiveness check':
-    command => '/usr/local/bin/check_imgsrv',
+    command => '/usr/local/bin/check_imgsrv > /dev/null 2>&1',
     user    => 'root',
     minute  => '*/2',
   }


### PR DESCRIPTION
For as long as we retain email notifications for this cron job, we should only need to know if it generates an error. Haproxy monitoring covers the service-related alerts.