### PR TITLE
Ae 8297 add clickstream to mirlyn

### DIFF
--- a/manifests/apache/mirlyn_vhost.pp
+++ b/manifests/apache/mirlyn_vhost.pp
@@ -28,7 +28,7 @@ define nebula::apache::mirlyn_vhost (
     serveraliases  => $serveraliases,
     docroot        => $docroot,
     logging_prefix => "${prefix}mirlyn/",
-    usertrack      => false,
+    usertrack      => true,
 
     rewrites       => [
       {
@@ -49,7 +49,7 @@ define nebula::apache::mirlyn_vhost (
     ssl                         => true,
     ssl_cn                      => $ssl_cn,
     cosign                      => false,
-    usertrack                   => false,
+    usertrack                   => true,
 
     rewrites                    => [
       {

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -62,7 +62,7 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   cron { 'imgsrv responsiveness check':
-    command => '/usr/local/bin/check_imgsrv',
+    command => '/usr/local/bin/check_imgsrv > /dev/null 2>&1',
     user    => 'root',
     minute  => '*/2',
   }


### PR DESCRIPTION
For LLAP/ISR grant compliance, enable the user tracking cookie for the mirlyn vhost.