### PR TITLE
AE-8443: Revert #380 (cpan version of image::info)

### DIFF
--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -65,6 +65,7 @@ class nebula::profile::hathitrust::perl () {
     'libhttp-message-perl',
     'libhttp-negotiate-perl',
     'libimage-exiftool-perl',
+    'libimage-info-perl',
     'libimage-size-perl',
     'libinline-perl',
     'libio-html-perl',
@@ -147,7 +148,6 @@ class nebula::profile::hathitrust::perl () {
     'Devel::Cycle',
     'Test::Memory::Cycle',
     'Mozilla::CA',
-    'Image::Info',
     'Noid']:
   }
 


### PR DESCRIPTION
This reverts commit fc4efb9ef7bfdd2ba3e5e3a8770512d3b1c9c53c, reversing
changes made to c1059a14b61689cbb02d4b7925f7b0d07ef3a2a7.

The CPAN version pulled in too many depencies, and (because of the
implementation of nebula::cpan) did not automatically update. To get the
update to happen this way we would have to uninstall the Debian version
and then wait for the CPAN version to build, leaving production broken
in the meantime.

A newer version of Image::Info is packaged by buster, so I suggest
installing that version in our local deb repo and then just updating
production. We have verified that new version works in development and
on ht-web-testing.