### PR TITLE
Rotate wtmp and btmp logs weekly instead of monthly

### DIFF
--- a/manifests/profile/logrotate.pp
+++ b/manifests/profile/logrotate.pp
@@ -12,7 +12,7 @@ class nebula::profile::logrotate {
   logrotate::rule {
     default:
       missingok    => true,
-      rotate_every => 'month',
+      rotate_every => 'week',
       create       => true,
       create_mode  => '0660',
       create_owner => 'root',

--- a/spec/classes/profile/logrotate_spec.rb
+++ b/spec/classes/profile/logrotate_spec.rb
@@ -12,25 +12,6 @@ describe 'nebula::profile::logrotate' do
 
       it { is_expected.to compile }
 
-      # Comments after this one are the exact text from Debian's default
-      # /etc/logrotate.conf file, which is the same both in jessie and
-      # in stretch.
-
-      # # see "man logrotate" for details
-      # # rotate log files weekly
-      # weekly
-      #
-      # # keep 4 weeks worth of backlogs
-      # rotate 4
-      #
-      # # create new (empty) log files after rotating old ones
-      # create
-      #
-      # # uncomment this if you want your log files compressed
-      # #compress
-      #
-      # # packages drop log rotation information into this directory
-      # include /etc/logrotate.d
       it 'sets debian defaults in /etc/logrotate.conf' do
         is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
           create: true,
@@ -39,18 +20,14 @@ describe 'nebula::profile::logrotate' do
         )
       end
 
-      # # no packages own wtmp, or btmp -- we'll rotate them here
-      # /var/log/wtmp {
-      #     missingok
-      #     monthly
-      #     create 0664 root utmp
-      #     rotate 1
-      # }
+      # Debian by default rotates logs for wtmp and btmp, and we see no
+      # reason to stop doing that, although we switched them from
+      # monthly to weekly, as they can get very large otherwise.
       it "contains debian's wtmp logrotate config" do
         is_expected.to contain_logrotate__rule('debian_wtmp').with(
           path: '/var/log/wtmp',
           missingok: true,
-          rotate_every: 'month',
+          rotate_every: 'week',
           create_mode: '0664',
           create_owner: 'root',
           create_group: 'utmp',
@@ -58,17 +35,11 @@ describe 'nebula::profile::logrotate' do
         )
       end
 
-      # /var/log/btmp {
-      #     missingok
-      #     monthly
-      #     create 0660 root utmp
-      #     rotate 1
-      # }
       it "contains debian's btmp logrotate config" do
         is_expected.to contain_logrotate__rule('debian_btmp').with(
           path: '/var/log/btmp',
           missingok: true,
-          rotate_every: 'month',
+          rotate_every: 'week',
           create_mode: '0660',
           create_owner: 'root',
           create_group: 'utmp',


### PR DESCRIPTION
Sometimes wtmp fills up disks on our more thinly-provisioned servers. By
setting this to weekly instead of monthly, we expect that the log files
will take up less disk space.