### PR TITLE
AEIM-3108 - Throttle with 429 instead of 509

### DIFF
--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -64,11 +64,11 @@ define nebula::haproxy::service(
   $nonempty_whitelists = $whitelists.filter |$whitelist,$exemptions| { $exemptions.length > 0 }
 
   if $max_requests_per_sec > 0 {
-    file { "/etc/haproxy/errors/${service}509.http":
+    file { "/etc/haproxy/errors/${service}429.http":
       ensure => 'present',
       mode   => '0644',
       notify => Service['haproxy'],
-      source => "https://${http_files}/errorfiles/${service}509.http"
+      source => "https://${http_files}/errorfiles/${service}429.http"
     }
   }
 

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -119,15 +119,15 @@ describe 'nebula::haproxy::service' do
                 http-request set-var(req.http_rate) src_http_req_rate(svc1-dc1-http-back)
                 http-request set-var(req.https_rate) src_http_req_rate(svc1-dc1-https-back)
                 acl http_req_rate_abuse var(req.http_rate),add(req.https_rate) gt 400
-                errorfile 403 /etc/haproxy/errors/svc1509.http
+                errorfile 403 /etc/haproxy/errors/svc1429.http
                 http-request deny deny_status 403 if http_req_rate_abuse
               EOT
             )
           end
 
           it do
-            is_expected.to contain_file('/etc/haproxy/errors/svc1509.http')
-              .with_source('https://default.http_files.invalid/errorfiles/svc1509.http')
+            is_expected.to contain_file('/etc/haproxy/errors/svc1429.http')
+              .with_source('https://default.http_files.invalid/errorfiles/svc1429.http')
           end
 
           context 'with no whitelists' do

--- a/templates/profile/haproxy/throttling.erb
+++ b/templates/profile/haproxy/throttling.erb
@@ -3,5 +3,5 @@ tcp-request content track-sc2 src
 http-request set-var(req.http_rate) src_http_req_rate(<%= @service_loc %>-http-back)
 http-request set-var(req.https_rate) src_http_req_rate(<%= @service_loc %>-https-back)
 acl http_req_rate_abuse var(req.http_rate),add(req.https_rate) gt <%= @max_requests_burst %>
-errorfile 403 /etc/haproxy/errors/<%= @service %>509.http
+errorfile 403 /etc/haproxy/errors/<%= @service %>429.http
 http-request deny deny_status 403 if http_req_rate_abuse


### PR DESCRIPTION
We've been serving 509s when throttling connections, but 5xx errors
imply something wrong with the server. The correct HTTP status code is
429, which correctly implies disallowed behavior on part of the client.