### PR TITLE
Dynamic weighting for haproxy back ends

### DIFF
--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -98,7 +98,7 @@ define nebula::haproxy::service(
 
   if $dynamic_weighting {
     cron { "dynamic weighting for ${service}":
-      command     => "ruby /usr/local/bin/set_weights.rb ${::datacenter} ${service}",
+      command     => "/usr/bin/ruby /usr/local/bin/set_weights.rb ${::datacenter} ${service} > /dev/null 2>&1",
       user        => lookup('nebula::profile::haproxy::monitoring_user')['name'],
       minute      => '*/5',
       environment => ["HAPROXY_SMOOTHING_FACTOR=${dynamic_weight_smoothing}"]

--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -32,6 +32,19 @@
 #   haproxy "acl -f" functionality; see
 #   https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#7
 #
+# @param dynamic_weighting Use dynamic weighting for servers in the pool based
+# on checking the load in each member server. Weight is set to the inverse
+# proportion of the maximum load plus the smoothing factor.
+#
+# For example, if server A has a load of 5, server B has a load of 2, and the
+# smoothing factor is set to 2, then the weights would be computed as:
+#
+# server A = 1/2 * 5 + 2 = 4.5; rounded up, 5
+# server B = 1/5 * 5 + 2 = 3
+#
+# @param dynamic_weight_smoothing This value is added to the weight for each
+# backend server regardless of server load to help "smooth" the effect of the weighting
+#
 # @example
 #   nebula::haproxy::service { 'www-whatever':
 #     floating_ip          => '1.2.3.4'
@@ -54,7 +67,9 @@ define nebula::haproxy::service(
   Integer          $max_requests_per_sec = 0,
   Integer          $max_requests_burst = 0,
   Hash             $whitelists = {},
-  Boolean          $custom_503 = false
+  Boolean          $custom_503 = false,
+  Boolean          $dynamic_weighting = false,
+  Integer          $dynamic_weight_smoothing = 2
 ) {
 
   include nebula::profile::haproxy::prereqs
@@ -78,6 +93,15 @@ define nebula::haproxy::service(
       mode   => '0644',
       notify => Service['haproxy'],
       source => "https://${http_files}/errorfiles/${service}503.http"
+    }
+  }
+
+  if $dynamic_weighting {
+    cron { "dynamic weighting for ${service}":
+      command     => "ruby /usr/local/bin/set_weights.rb ${::datacenter} ${service}",
+      user        => lookup('nebula::profile::haproxy::monitoring_user')['name'],
+      minute      => '*/5',
+      environment => ["HAPROXY_SMOOTHING_FACTOR=${dynamic_weight_smoothing}"]
     }
   }
 

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -60,6 +60,25 @@ class nebula::profile::haproxy(
     require => [Package['haproxy'], Package['haproxyctl']]
   }
 
+  file { "${monitoring_user['home']}/.ssh/id_ecdsa":
+    source => "puppet:///ssh-keys/${monitoring_user['name']}/id_ecdsa",
+    mode   => '0600',
+    owner  => $monitoring_user['name'],
+    group  => 'haproxy'
+  }
+  file { "${monitoring_user['home']}/.ssh/id_ecdsa.pub":
+    source => "puppet:///ssh-keys/${monitoring_user['name']}/id_ecdsa.pub",
+    mode   => '0644',
+    owner  => $monitoring_user['name'],
+    group  => 'haproxy'
+  }
+  $http_files = lookup('nebula::http_files')
+  file { '/usr/local/bin/set_weights.rb':
+    ensure => 'present',
+    mode   => '0755',
+    source => "https://${http_files}/ae-utils/bins/set_weights.rb"
+  }
+
   package { 'keepalived': }
   package { 'ipset': }
 

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -12,7 +12,18 @@ class nebula::profile::hathitrust::apache (
   String $prefix = '',
   String $domain = 'hathitrust.org',
   String $sdrroot = '/htapps/babel',
+  String $monitoring_user = 'haproxyctl',
+  Optional[Hash] $monitoring_pubkey = undef
 ) {
+
+
+  if($monitoring_pubkey) {
+    nebula::authzd_user { $monitoring_user:
+      gid  => 'nogroup',
+      home => '/nonexistent',
+      key  => $monitoring_pubkey
+    }
+  }
 
   ensure_packages(['bsd-mailx'])
 

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -299,6 +299,15 @@ describe 'nebula::profile::haproxy' do
             .that_notifies('Service[haproxy]')
         end
       end
+
+      describe 'server monitoring / dynamic weighting' do
+        it 'includes the private key' do
+          is_expected.to contain_file('/var/haproxyctl/.ssh/id_ecdsa')
+        end
+        it 'includes the monitoring script' do
+          is_expected.to contain_file('/usr/local/bin/set_weights.rb')
+        end
+      end
     end
   end
 end

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -135,6 +135,24 @@ describe 'nebula::profile::hathitrust::apache' do
         is_expected.to contain_cron('purge caches')
           .with_command('/htapps/babel/mdp-misc/scripts/managecache.sh /somewhere/whatever:1:2 /elsewhere/whatever:3:4')
       end
+
+      describe 'monitoring user' do
+        it do
+          is_expected.to have_nebula__authzd_user_resource_count(0)
+        end
+
+        context 'with specified key' do
+          let(:params) do
+            {
+              monitoring_pubkey: {},
+            }
+          end
+
+          it do
+            is_expected.to contain_nebula__authzd_user('haproxyctl')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -227,6 +227,19 @@ describe 'nebula::haproxy::service' do
             end
           end
         end
+
+        context 'with dynamic weighting' do
+          let(:params) do
+            super().merge(dynamic_weighting: true)
+          end
+
+          it do
+            is_expected.to contain_cron('dynamic weighting for svc1')
+              .with_command('ruby /usr/local/bin/set_weights.rb dc1 svc1')
+              .with_user('haproxyctl')
+              .with_environment(['HAPROXY_SMOOTHING_FACTOR=2'])
+          end
+        end
       end
 
       describe 'http service config' do

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -235,7 +235,7 @@ describe 'nebula::haproxy::service' do
 
           it do
             is_expected.to contain_cron('dynamic weighting for svc1')
-              .with_command('ruby /usr/local/bin/set_weights.rb dc1 svc1')
+              .with_command('/usr/bin/ruby /usr/local/bin/set_weights.rb dc1 svc1 > /dev/null 2>&1')
               .with_user('haproxyctl')
               .with_environment(['HAPROXY_SMOOTHING_FACTOR=2'])
           end


### PR DESCRIPTION
Uses "set-weights.rb" from ae-utils to set weights dynamically based on
server load

Tested on ictc-haproxy-001 with ictc-ht-web-*