### PR TITLE
AEIM-3213 - Add some new alerts for filling up disks

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -23,6 +23,7 @@ class nebula::profile::prometheus (
   String $version = 'latest',
 ) {
   include nebula::profile::docker
+  $hostname = $::hostname
 
   docker::run { 'prometheus':
     image            => "prom/prometheus:${version}",

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -24,6 +24,8 @@ scrape_configs:
 - job_name: prometheus
   static_configs:
   - targets: [ localhost:9090 ]
+    labels:
+      hostname: '<%= @hostname %>'
 - job_name: node
   file_sd_configs:
   - files: [ nodes.yml ]

--- a/templates/profile/prometheus/exporter/haproxy/defaults.sh.erb
+++ b/templates/profile/prometheus/exporter/haproxy/defaults.sh.erb
@@ -3,7 +3,14 @@
     Due to shell scaping, to pass backslashes for regexes, you need to double
     them (\\d for \d). If running under systemd, you need to double them again
     (\\\\d to mean \d), and escape newlines too. -%>
-ARGS="--haproxy.scrape-uri='http://localhost:8001/stats/;csv'"
+<%# This is the default list of metric fields with these additions:
+    12. Request errors
+    48. Number of http requests received
+    58. Average queue time
+    59. Average connect time
+    60. Average response time
+    61. Average total session time -%>
+ARGS="--haproxy.scrape-uri='http://localhost:8001/stats/;csv' --haproxy.server-metric-fields='2,3,4,5,6,7,8,9,12,13,14,15,16,17,18,21,24,30,33,35,38,39,40,41,42,43,44,48,49,50,58,59,60,61'"
 
 <%#
 usage: haproxy_exporter [<flags>]

--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -2,6 +2,13 @@
 groups:
 - name: hardware
   rules:
+  - alert: PrometheusNotRunning
+    annotations:
+      summary: 'Prometheus server {{$labels.hostname}} isn''t collecting metrics.'
+    expr: 'absent(up{job="prometheus"})'
+    for: 5m
+    labels:
+      severity: page
   - alert: PuppetBehind
     annotations:
       summary: 'Node {{$labels.host | reReplaceAll "\\..*" ""}} hasn''t recently synced with puppet.'
@@ -40,6 +47,28 @@ groups:
       summary: 'Windows node {{$labels.hostname}} isn''t responding to Prometheus.'
     expr: 'up{job="wmi"} == 0'
     for: 30m
+    labels:
+      severity: page
+  - alert: DiskSlowlyFillingUp
+    annotations:
+      summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} will fill up in a few days.'
+    expr: >
+      predict_linear(
+        node_filesystem_avail_bytes{mountpoint!="/aspace", fstype!="afs", fstype!="tmpfs", device!="rootfs"}[1d],
+        4 * 60 * 60 * 24
+      ) < 0
+    for: 30m
+    labels:
+      severity: ticket
+  - alert: DiskAboutToFillUp
+    annotations:
+      summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} is filling up fast.'
+    expr: >
+      predict_linear(
+        node_filesystem_avail_bytes{mountpoint!="/aspace", fstype!="afs", fstype!="tmpfs", device!="rootfs"}[1h],
+        4 * 60 * 60
+      ) < 0
+    for: 5m
     labels:
       severity: page
   - alert: DiskPressure
@@ -93,14 +122,14 @@ groups:
     labels:
       severity: ticket
 
-  # We like to keep at least 2T free at all times for deep blue data,
+  # We like to keep at least 3T free at all times for deep blue data,
   # but their ingest process requires double the capacity of any files
   # being ingested, so it is common for them to claim a lot of space
   # only temporarily. Hence the lengthy 1d alert threshold.
   - alert: DeepBlueDataProdStoragePressure
     annotations:
-      summary: 'deepbluedata-prod ({{$labels.hostname}}:{{$labels.mountpoint}}) has less than 2T of free space'
-    expr: 'node_filesystem_avail_bytes{device="deepbluedata-prod.value.storage.umich.edu:/deepbluedata-prod"} < 2 * 1024 * 1024 * 1024 * 1024'
+      summary: 'deepbluedata-prod ({{$labels.hostname}}:{{$labels.mountpoint}}) has less than 3T of free space'
+    expr: 'node_filesystem_avail_bytes{device="deepbluedata-prod.value.storage.umich.edu:/deepbluedata-prod"} < 3 * 1024 * 1024 * 1024 * 1024'
     for: 1d
     labels:
       severity: ticket


### PR DESCRIPTION
Three new alerts:

1.  Notice when prometheus isn't collecting metrics
2.  Notice when a disk will fill up within 4 days (based on the past 24 hours)
3.  Notice when a disk will fill up within 4 hours (based on the past hour)

Also tweaked the DeepBlueDataProdStoragePressure alert to give it a
threshold of 3T instead of 2T, since it takes less than 24 hours to go
from 2T free to 0B free.

Also added the hostname to the prometheus config so that the
PrometheusNotRunning alert will produce a helpful error message (without
this, all we'd be able to get is "one of the prometheus servers isn't
working" without any indication as to which).