### PR TITLE
Make feedd.service enableable

### DIFF
--- a/templates/profile/hathitrust/ingest_service/feedd.service.erb
+++ b/templates/profile/hathitrust/ingest_service/feedd.service.erb
@@ -12,4 +12,4 @@ ExecStart=/usr/bin/perl /htapps/babel/feed/bin/feedd.pl
 Restart=always
 
 [Install]
-
+WantedBy=multi-user.target


### PR DESCRIPTION
@daaang  reported that ingest did not automatically get re-enabled on reboot because of the missing WantedBy.