### PR TITLE
Increase unison alert window from 30m to 2h

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -142,9 +142,9 @@ groups:
 
   - alert: UnisonSyncFailed
     annotations:
-      summary: 'Unison sync failed on node {{$labels.hostname}}.'
-    expr: 'time() - unison_last_success > 300'
-    for: 30m
+      summary: 'Unison sync {{$labels.client}} failed on node {{$labels.hostname}}.'
+    expr: 'time() - unison_last_success > 30 * 60'
+    for: 2h
     labels:
       severity: ticket
 


### PR DESCRIPTION
At least one of the clients can be execced to take at least 90 minutes
to run to completion, so a 30 minute window is entirely inappropriate.