### PR TITLE
HT-2749: install clamav-daemon on ingest machines

### DIFF
--- a/manifests/profile/hathitrust/clamav.pp
+++ b/manifests/profile/hathitrust/clamav.pp
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::clamav
+#
+# Install clamav dependencies for HT ingest
+#
+# @example
+#   include nebula::profile::hathitrust::clamav
+class nebula::profile::hathitrust::clamav () {
+
+  ensure_packages (
+    [
+      'clamav-daemon',
+      'libclamav-client-perl'
+    ]
+  )
+
+  service { 'clamav-daemon':
+    ensure => 'running',
+    enable => true,
+  }
+
+  service { 'clamav-freshclam':
+    ensure =>  'running',
+    enable => true,
+  }
+
+}

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018,2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -42,6 +42,7 @@ class nebula::role::hathitrust::ingest_indexing (
 
   include nebula::profile::hathitrust::dependencies
   include nebula::profile::hathitrust::perl
+  include nebula::profile::hathitrust::clamav
   include nebula::profile::hathitrust::ingest_service
 
   include nebula::profile::ruby

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018,2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -46,6 +46,9 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
       it { is_expected.not_to contain_user('htweb') }
 
       it { is_expected.to contain_service('feedd').with_enable(true) }
+      it { is_expected.to contain_package('clamav-daemon') }
+      it { is_expected.to contain_service('clamav-daemon').with_enable(true) }
+
       it do
         is_expected.to contain_file('/etc/systemd/system/feedd.service')
           .with_content(%r{HTFEED_CONFIG=/default/feedd.yaml})


### PR DESCRIPTION
There are some cases where we want HT ingest to virus scan material prior to ingest. This adds clamav and enables the clamav-daemon for use by https://github.com/hathitrust/feed/blob/master/lib/HTFeed/PackageType/EMMA/VirusScan.pm