### PR TITLE
AE-8921 Create clearinghouse role/profile for scales

### DIFF
--- a/manifests/profile/scales.pp
+++ b/manifests/profile/scales.pp
@@ -1,0 +1,19 @@
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::scales
+#
+# Profile for clearinghouse scales server.
+#
+# @example
+#   include nebula::profile::scales
+class nebula::profile::scales (
+) {
+  nebula::usergroup { 'clearinghouse': }
+
+  package {
+    [ 'git', 'python3-venv', 'python3-pip',
+      'python3-setuptools', 'python3-wheel', ]:
+  }
+}

--- a/manifests/role/clearinghouse_scales.pp
+++ b/manifests/role/clearinghouse_scales.pp
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::role::clearinghouse_scales
+#
+# Scales host working in conjunction with clearinghouse production
+#
+# Note: There are additional steps that are done manually.
+# which include passwd file entries, app accounts, sudo access,
+# keys, pip packages, git repos, etc. This file only provides
+# a baseline.
+#
+# @example
+#   include nebula::role::clearinghouse_scales
+class nebula::role::clearinghouse_scales {
+  include nebula::role::aws
+  include nebula::profile::krb5
+  include nebula::profile::duo
+  include nebula::profile::scales
+}

--- a/spec/classes/profile/scales_spec.rb
+++ b/spec/classes/profile/scales_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::scales' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_nebula__usergroup('clearinghouse') }
+    end
+  end
+end


### PR DESCRIPTION
- The role includes kerberos and duo but no AFS.
- The profile adds user & group creation and base packages.
- Rest are manual steps.