### PR TITLE
Support for private DNS zone in dnsmasq for k8s cluster

### DIFF
--- a/manifests/profile/kubernetes/dns_server.pp
+++ b/manifests/profile/kubernetes/dns_server.pp
@@ -9,6 +9,7 @@ class nebula::profile::kubernetes::dns_server {
   $kube_api_address = $cluster['kube_api_address']
   $node_cidr = $cluster['node_cidr']
   $private_domain = $cluster['private_domain']
+  $private_zones = $cluster['private_zones']
 
   package { 'dnsmasq': }
 
@@ -51,6 +52,15 @@ class nebula::profile::kubernetes::dns_server {
       content => template('nebula/profile/kubernetes/dns/hosts_06_ipv6_debian.erb'),
       order   => '06',
     ;
+  }
+
+  if $private_zones {
+    $private_zones.each |Hash $zone| {
+      file { "/etc/dnsmasq.d/${$zone[name]}":
+        content => "server=/${$zone[domain]}/${$zone[resolver]}\n",
+        notify  => Service['dnsmasq']
+      }
+    }
   }
 
   firewall {

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -8,72 +8,88 @@ require 'spec_helper'
 describe 'nebula::profile::kubernetes::dns_server' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
-      let(:facts) do
-        os_facts.merge(
-          'networking'   => {
-            'interfaces' => {
-              'ens4'     => {
-                'ip'     => '10.123.234.5',
+      context 'with cluster set to first_cluster' do
+        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+        let(:facts) do
+          os_facts.merge(
+            'networking'   => {
+              'interfaces' => {
+                'ens4'     => {
+                  'ip'     => '10.123.234.5',
+                },
               },
             },
-          },
-        )
-      end
+          )
+        end
 
-      it { is_expected.to compile }
+        it { is_expected.to compile }
 
-      it { is_expected.to contain_package('dnsmasq') }
-      it { is_expected.to contain_service('dnsmasq').that_requires('Package[dnsmasq]') }
+        it { is_expected.to contain_package('dnsmasq') }
+        it { is_expected.to contain_service('dnsmasq').that_requires('Package[dnsmasq]') }
 
-      it { is_expected.to contain_firewall('200 Nameserver (TCP)').with_proto('tcp') }
-      it { is_expected.to contain_firewall('200 Nameserver (UDP)').with_proto('udp') }
+        it { is_expected.to contain_firewall('200 Nameserver (TCP)').with_proto('tcp') }
+        it { is_expected.to contain_firewall('200 Nameserver (UDP)').with_proto('udp') }
 
-      %w[TCP UDP].each do |proto|
+        %w[TCP UDP].each do |proto|
+          it do
+            is_expected.to contain_firewall("200 Nameserver (#{proto})")
+              .with_dport(53)
+              .with_source('172.28.0.0/14')
+              .with_state('NEW')
+              .with_action('accept')
+          end
+        end
+
+        it { is_expected.to contain_concat('/etc/hosts').that_notifies('Service[dnsmasq]') }
+
         it do
-          is_expected.to contain_firewall("200 Nameserver (#{proto})")
-            .with_dport(53)
-            .with_source('172.28.0.0/14')
-            .with_state('NEW')
-            .with_action('accept')
+          is_expected.to contain_concat_fragment('/etc/hosts ipv4 localhost')
+            .with_target('/etc/hosts')
+            .with_order('01')
+            .with_content("127.0.0.1 localhost\n")
+        end
+
+        it do
+          is_expected.to contain_concat_fragment('/etc/hosts ipv4 etcd-all')
+            .with_target('/etc/hosts')
+            .with_order('02')
+            .with_content("172.16.0.6 etcd.first.cluster etcd\n")
+        end
+
+        it do
+          is_expected.to contain_concat_fragment('/etc/hosts ipv4 kube-api')
+            .with_target('/etc/hosts')
+            .with_order('03')
+            .with_content("172.16.0.7 kube-api.first.cluster kube-api\n")
+        end
+
+        it do
+          is_expected.to contain_concat_fragment('/etc/hosts ipv6 localhost')
+            .with_target('/etc/hosts')
+            .with_order('05')
+            .with_content("::1 localhost ip6-localhost ip6-loopback\n")
+        end
+
+        it do
+          is_expected.to contain_file('/etc/dnsmasq.d/smartconnect')
+            .with_content("server=/sc.default.invalid/192.0.2.7\n")
+        end
+
+        it do
+          is_expected.to contain_concat_fragment('/etc/hosts ipv6 debian')
+            .with_target('/etc/hosts')
+            .with_order('06')
+            .with_content("ff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n")
         end
       end
 
-      it { is_expected.to contain_concat('/etc/hosts').that_notifies('Service[dnsmasq]') }
+      context 'with cluster set to second_cluster' do
+        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+        let(:facts) { os_facts }
 
-      it do
-        is_expected.to contain_concat_fragment('/etc/hosts ipv4 localhost')
-          .with_target('/etc/hosts')
-          .with_order('01')
-          .with_content("127.0.0.1 localhost\n")
-      end
+        it { is_expected.to compile }
 
-      it do
-        is_expected.to contain_concat_fragment('/etc/hosts ipv4 etcd-all')
-          .with_target('/etc/hosts')
-          .with_order('02')
-          .with_content("172.16.0.6 etcd.first.cluster etcd\n")
-      end
-
-      it do
-        is_expected.to contain_concat_fragment('/etc/hosts ipv4 kube-api')
-          .with_target('/etc/hosts')
-          .with_order('03')
-          .with_content("172.16.0.7 kube-api.first.cluster kube-api\n")
-      end
-
-      it do
-        is_expected.to contain_concat_fragment('/etc/hosts ipv6 localhost')
-          .with_target('/etc/hosts')
-          .with_order('05')
-          .with_content("::1 localhost ip6-localhost ip6-loopback\n")
-      end
-
-      it do
-        is_expected.to contain_concat_fragment('/etc/hosts ipv6 debian')
-          .with_target('/etc/hosts')
-          .with_order('06')
-          .with_content("ff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n")
+        it { is_expected.not_to contain_file('/etc/dnsmasq.d/smartconnect') }
       end
     end
   end

--- a/spec/fixtures/hiera/kubernetes/default.yaml
+++ b/spec/fixtures/hiera/kubernetes/default.yaml
@@ -27,6 +27,10 @@ nebula::profile::kubernetes::clusters:
         first cluster public key value
       private: |
         first cluster private key value
+    private_zones:
+      - name: smartconnect
+        domain: 'sc.default.invalid'
+        resolver: '192.0.2.7'
   second_cluster:
     public_address: 10.0.0.2
     router_address: 172.16.1.1


### PR DESCRIPTION
This is to support Isilon SmartConnect, which relies on delegating
queries for a particular zone to its private DNS server.