### PR TITLE
Add puppetboard dashboard link to puppet alert annotations

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -12,6 +12,7 @@ groups:
   - alert: PuppetBehind
     annotations:
       summary: 'Node {{$labels.host | reReplaceAll "\\..*" ""}} hasn''t recently synced with puppet.'
+      dashboard: 'https://puppetboard.kubernetes.lib.umich.edu/node/{{$labels.host}}'
     expr: 'puppet_report{environment="production",host!="ht-web-preview.umdl.umich.edu"} < (time() - (30 * 60))'
     for: 30m
     labels:
@@ -19,6 +20,7 @@ groups:
   - alert: PuppetResourcesFailing
     annotations:
       summary: 'Node {{$labels.host | reReplaceAll "\\..*" ""}} has failing puppet resources.'
+      dashboard: 'https://puppetboard.kubernetes.lib.umich.edu/node/{{$labels.host}}'
     expr: >
       sum without(name)(
         puppet_report_events{environment="production", name="Failure"}
@@ -31,6 +33,7 @@ groups:
   - alert: PuppetZeroResources
     annotations:
       summary: 'Node {{$labels.host | reReplaceAll "\\..*" ""}} has zero puppet resources.'
+      dashboard: 'https://puppetboard.kubernetes.lib.umich.edu/node/{{$labels.host}}'
     expr: 'puppet_report_resources{environment="production", name="Total"} == 0'
     for: 2h
     labels:


### PR DESCRIPTION
This is a straightforward addition. The slack notifications in the alertmanager config already check for `{{ .CommonAnnotations.dashboard }}` and conditionally include a link.

I chose to link to the node page. We might be able to link to the specific report, but I don't know whether that info is included in the alert, and it's useful to see the node at a glance anyway.

cf. https://prometheus.io/docs/alerting/latest/notification_examples/