### PR TITLE
Stop alerting when htapps-cache unison takes too long

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -159,11 +159,12 @@ groups:
       severity: ticket
 
   # The staff-lib unison job is exempt because it routinely takes days
-  # sometimes.
+  # sometimes. The htapps-cache one also takes forever as a matter of
+  # routine.
   - alert: UnisonSyncFailed
     annotations:
       summary: 'Unison sync {{$labels.client}} failed on node {{$labels.hostname}}.'
-    expr: 'time() - unison_last_success{client!="nas-web-staff-lib"} > 5 * 60'
+    expr: 'time() - unison_last_success{client!="htapps-cache",client!="nas-web-staff-lib"} > 5 * 60'
     for: 30m
     labels:
       severity: ticket


### PR DESCRIPTION
This is our second unison implementation that we expect to take a very
long time, so we should probably find something other than unison to
solve these multi-datacenter problems. Until then, the bandaid is that
we won't receive alerts.