### PR TITLE
AE-9671 - Redirect root of deepblue.lib to www.lib (fixed)

### DIFF
--- a/manifests/profile/www_lib/vhosts/deepblue.pp
+++ b/manifests/profile/www_lib/vhosts/deepblue.pp
@@ -53,6 +53,11 @@ class nebula::profile::www_lib::vhosts::deepblue (
 
     rewrites                      => [
       {
+        comment      => 'Deep Blue Repositories home page is on www.lib now',
+        rewrite_cond => '%{REQUEST_URI} ^((\/?|/index.html)$|/splash/)',
+        rewrite_rule => '^(.*)$	https://www.lib.umich.edu/collections/deep-blue-repositories [redirect=permanent,last]'
+      },
+      {
         # XXX: Is this really still an issue?
         # Workaround critical DSpace security bug until there is a patch.
         #
@@ -70,8 +75,8 @@ class nebula::profile::www_lib::vhosts::deepblue (
         rewrite_rule => '^(/data.*)$ https://app-deepbluedata.deepblue.lib.umich.edu:30060$1 [P]',
       },
       {
-        comment      => 'Deep Blue Documents; dont proxy cosign or the common splash page',
-        rewrite_cond => '%{REQUEST_URI} !^((\/?|/index.html)$|/splash/|/cosign/valid)',
+        comment      => 'Deep Blue Documents; dont proxy cosign',
+        rewrite_cond => '%{REQUEST_URI} !^(/cosign/valid)',
         rewrite_rule => '^(.*)$	http://bulleit-2.umdl.umich.edu:8080$1 [P]'
       },
       {


### PR DESCRIPTION
The first attempt at this had a space between the rewrite flags. This version expands the flag names and eliminates the space.