### PR TITLE
Stop monitoring inode usage on s3fs filesystems

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -141,7 +141,12 @@ groups:
   - alert: DiskRunningOutOfINodes
     annotations:
       summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} is running out of inodes.'
-    expr: 'node_filesystem_files_free{fstype!="cifs",fstype!="vfat",fstype!="fuse.lxcfs",fstype!="rpc_pipefs"} < 10000'
+    expr: >
+      node_filesystem_files_free{fstype!="cifs",
+                                 fstype!="vfat",
+                                 fstype!="fuse.lxcfs",
+                                 fstype!="fuse.s3fs",
+                                 fstype!="rpc_pipefs"} < 10000
     for: 30m
     labels:
       severity: page


### PR DESCRIPTION
S3 mounts don't have inodes, so the alert is meaningless.