### PR TITLE
Use private IP addresses for EC2 node metrics

### DIFF
--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -108,7 +108,7 @@ class nebula::profile::prometheus::exporter::node (
   realize User['prometheus']
 
   $role = lookup_role()
-  $ipaddress = public_ip()
+  $ipaddress = $::ipaddress
   $datacenter = $::datacenter
   $hostname = $::hostname
 


### PR DESCRIPTION
While these hosts were scraped by a prometheus server in our own
datacenter, we needed to refer to them by their public ip address. Now
that we are running prometheus servers in AWS, they can communicate over
their own LAN.