### PR TITLE
HT-2959: Shibboleth + Dex OIDC <-> SAML proxy

### DIFF
--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -12,6 +12,8 @@ nebula::profile::hathitrust::imgsrv::bind: '127.0.0.1:31028'
 nebula::profile::hathitrust::apache::babel::gwt_code: 'somecode'
 nebula::profile::hathitrust::apache::babel::otis_endpoint: 'https://otis.default.invalid:3000'
 nebula::profile::hathitrust::apache::babel::otis_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
+nebula::profile::hathitrust::apache::babel::dex_endpoint: 'https://dex.default.invalid:3000'
+nebula::profile::hathitrust::apache::babel::dex_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
 
 nebula::profile::hathitrust::hosts::mysql_sdr: '10.1.2.4'
 nebula::profile::hathitrust::hosts::mysql_htdev: '2.2.2.2'


### PR DESCRIPTION
This adds the Apache configuration to:

- reverse proxy to Dex from Apache, providing relevant Shibboleth headers
- automatically force authentication with Shibboleth at the correct time when authenticating through Dex
- Consume an entityID IdP hint parameter and redirect the user to log in through Shibboleth

There are certainly some duplications here with otis; if we were committed to puppet-apache + proxied access to apps in the long term I would want to consider refactoring this à la what we did for moku apps, but my sense is that we aren't committed to puppet-apache in the long term, that we will hopefully not need to use the apache basic auth for proxied apps all that much longer, and that eventually (at least for HathiTrust) I'll likely eventually want to containerize Apache itself, I don't think that refactoring would be worthwhile.