### PR TITLE
HT-3017: rsyncd for datasets

### DIFF
--- a/manifests/profile/hathitrust/rsync.pp
+++ b/manifests/profile/hathitrust/rsync.pp
@@ -1,0 +1,56 @@
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::rsync
+#
+# Install rsync for public-domain datasets access
+#
+# See example structure for datasets in spec/fixtures/hiera/hathitrust.yaml
+# under nebula::profile::hathitrust::rsync::datasets
+#
+# @example
+#   include nebula::profile::hathitrust::rsync
+
+class nebula::profile::hathitrust::rsync (
+  Hash $datasets,
+  String $log_path = '/var/log/rsync',
+  String $rsync_user = 'nobody',
+) {
+  ensure_packages (
+    [
+      'rsync'
+    ]
+  )
+
+  file { $log_path:
+    ensure => 'directory',
+  }
+
+  service { 'rsync':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+    require    => Package['rsync'],
+  }
+
+  file { '/etc/rsyncd.conf':
+    require => Package[rsync],
+    notify  => Service[rsync],
+    content => template('nebula/profile/hathitrust/rsync/rsyncd.conf.erb')
+  }
+
+  $datasets.each |String $name, Hash $dataset| {
+    $dataset['users'].each |Hash $user| {
+
+      firewall { "200 rsync: dataset ${name} - ${user['comment']}":
+        proto  => 'tcp',
+        dport  => 873,
+        source => $user['ip'],
+        state  => 'NEW',
+        action => 'accept'
+      }
+    }
+  }
+
+}

--- a/manifests/profile/hathitrust/secure_rsync.pp
+++ b/manifests/profile/hathitrust/secure_rsync.pp
@@ -10,5 +10,66 @@
 #   include nebula::profile::hathitrust::secure_rsync
 
 class nebula::profile::hathitrust::secure_rsync (
+  Hash   $datasets,
+  Array  $allowed_networks,
+  String $log_path = '/var/log/secure-rsync',
+  String $rsync_home = '/etc/secure-rsync',
+  String $rsync_user = 'nobody',
+  Integer $stunnel_port = 1873,
 ) {
+  ensure_packages (
+    [
+      'rsync',
+      'stunnel4'
+    ]
+  )
+
+  file { [$log_path, $rsync_home]:
+    ensure => 'directory',
+  }
+
+  file {
+    default:
+      owner   => 'root',
+      group   => 'root',
+      require => [
+        Package['rsync'],
+        Package['stunnel4'],
+      ],
+      notify  => Service[secure-rsync];
+    '/etc/systemd/system/secure-rsync.service':
+      content  => template('nebula/profile/hathitrust/secure_rsync/secure-rsync.service.erb');
+    "${rsync_home}/stunnel.conf":
+      content  => template('nebula/profile/hathitrust/secure_rsync/stunnel.conf.erb');
+    "${rsync_home}/rsyncd.conf":
+      content => template('nebula/profile/hathitrust/rsync/rsyncd.conf.erb');
+    "${rsync_home}/server.key":
+      source => 'puppet:///ssl-certs/secure-rsync/server.key',
+      mode   => '0600';
+    "${rsync_home}/server.crt":
+      source => 'puppet:///ssl-certs/secure-rsync/server.crt';
+    "${rsync_home}/client.crt":
+      source => 'puppet:///ssl-certs/secure-rsync/client.crt';
+  }
+
+  service { 'secure-rsync':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+    require    => [
+      Package['rsync'],
+      Package['stunnel4'],
+    ]
+  }
+
+  $allowed_networks.flatten.each |$network| {
+    firewall { "200 secure-rsync ${network['name']}":
+      proto     => 'tcp',
+      dport     => $stunnel_port,
+      source    => $network['block'],
+      src_range => $network['range'],
+      state     => 'NEW',
+      action    => 'accept',
+    }
+  }
 }

--- a/manifests/profile/hathitrust/secure_rsync.pp
+++ b/manifests/profile/hathitrust/secure_rsync.pp
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::secure_rsync
+#
+# Install rsync+stunnel for secure HTRC datasets access
+#
+# @example
+#   include nebula::profile::hathitrust::secure_rsync
+
+class nebula::profile::hathitrust::secure_rsync (
+) {
+}

--- a/manifests/role/hathitrust/datasets.pp
+++ b/manifests/role/hathitrust/datasets.pp
@@ -23,5 +23,5 @@ class nebula::role::hathitrust::datasets (
   }
 
   include nebula::profile::hathitrust::rsync
-  #  include nebula::profile::hathitrust::secure_rsync
+  include nebula::profile::hathitrust::secure_rsync
 }

--- a/manifests/role/hathitrust/datasets.pp
+++ b/manifests/role/hathitrust/datasets.pp
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# HathiTrust datasets server
+#
+# @example
+#   include nebula::role::hathitrust::datasets
+class nebula::role::hathitrust::datasets (
+  String $private_address_template = '192.168.0.%s',
+) {
+  include nebula::role::hathitrust
+
+  class { 'nebula::profile::networking::private':
+    address_template => $private_address_template
+  }
+
+  include nebula::profile::hathitrust::hosts
+
+  class { 'nebula::profile::hathitrust::mounts':
+    smartconnect_mounts => ['/htapps','/htprep'],
+    readonly            => true,
+  }
+
+  include nebula::profile::hathitrust::rsync
+  #  include nebula::profile::hathitrust::secure_rsync
+}

--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018,2021 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+require 'faker'
+
+describe 'nebula::role::hathitrust::datasets' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_package('nfs-common') }
+      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
+      it { is_expected.to contain_mount('/htprep') }
+
+      it { is_expected.to contain_package('rsync') }
+      it { is_expected.to contain_service('rsync').with_enable(true) }
+
+      it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 1, University of East Westtestland, testuser1@default.invalid').with_source('192.0.2.102') }
+      it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 2, University of West Easttestland, testuser2@default.invalid').with_source('198.51.100.10') }
+      it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid').with_source('192.0.2.108') }
+      it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid').with_source('198.51.100.15') }
+
+      it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
+      it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
+    end
+  end
+end

--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -18,16 +18,34 @@ describe 'nebula::role::hathitrust::datasets' do
       it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
       it { is_expected.to contain_mount('/htprep') }
 
-      it { is_expected.to contain_package('rsync') }
-      it { is_expected.to contain_service('rsync').with_enable(true) }
+      describe 'unencrypted rsync' do
+        it { is_expected.to contain_package('rsync') }
+        it { is_expected.to contain_service('rsync').with_enable(true) }
 
-      it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 1, University of East Westtestland, testuser1@default.invalid').with_source('192.0.2.102') }
-      it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 2, University of West Easttestland, testuser2@default.invalid').with_source('198.51.100.10') }
-      it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid').with_source('192.0.2.108') }
-      it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid').with_source('198.51.100.15') }
+        it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 1, University of East Westtestland, testuser1@default.invalid').with_source('192.0.2.102') }
+        it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 2, University of West Easttestland, testuser2@default.invalid').with_source('198.51.100.10') }
+        it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid').with_source('192.0.2.108') }
+        it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid').with_source('198.51.100.15') }
 
-      it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
-      it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
+        it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
+        it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
+      end
+
+      describe 'encrypted rsync' do
+        it { is_expected.to contain_package('stunnel4') }
+        it { is_expected.to contain_service('secure-rsync').with_enable(true) }
+        it { is_expected.to contain_file('/etc/systemd/system/secure-rsync.service').with_content(%r{ExecStart=/usr/bin/stunnel /etc/secure-rsync/stunnel.conf}) }
+        it { is_expected.to contain_file('/etc/secure-rsync') }
+        it { is_expected.to contain_file('/etc/secure-rsync/stunnel.conf').with_content(%r{rsync.*/etc/secure-rsync/rsyncd.conf.*CAfile=/etc/secure-rsync/client.crt}m) }
+        it { is_expected.to contain_file('/etc/secure-rsync/rsyncd.conf').with_content(%r{/datasets/secure_dataset}m) }
+        it { is_expected.to contain_file('/etc/secure-rsync/server.key') }
+        it { is_expected.to contain_file('/etc/secure-rsync/server.crt') }
+        it { is_expected.to contain_file('/etc/secure-rsync/client.crt') }
+
+        it { is_expected.to contain_firewall('200 secure-rsync Net One').with_source('10.0.1.0/24') }
+        it { is_expected.to contain_firewall('200 secure-rsync VPN').with_source('10.0.3.0/24') }
+        it { is_expected.to contain_firewall('200 secure-rsync secure network').with_src_range('192.0.2.1-192.0.2.4') }
+      end
     end
   end
 end

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -130,3 +130,21 @@ nebula::role::hathitrust::backup::tsm_servername: tsmserver
 nebula::role::hathitrust::backup::tsm_serveraddress: tsm.default.invalid
 
 nebula::role::hathitrust::ingest_indexing::dataden_target: dataden.default.invalid:/dataden/hathitrust
+
+nebula::profile::hathitrust::rsync::datasets:
+  dataset1:
+    comment: "Dataset 1"
+    path: "/datasets/dataset1"
+    users:
+      - comment: "Test User 1, University of East Westtestland, testuser1@default.invalid"
+        ip: '192.0.2.102'
+      - comment: "Test User 2, University of West Easttestland, testuser2@default.invalid"
+        ip: '198.51.100.10'
+  dataset2:
+    comment: "Dataset 2"
+    path: "/datasets/dataset2"
+    users:
+      - comment: "Test User 3, University of East Westtestland, testuser3@default.invalid"
+        ip: '192.0.2.108'
+      - comment: "Test User 4, University of West Easttestland, testuser4@default.invalid"
+        ip: '198.51.100.15'

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -148,3 +148,13 @@ nebula::profile::hathitrust::rsync::datasets:
         ip: '192.0.2.108'
       - comment: "Test User 4, University of West Easttestland, testuser4@default.invalid"
         ip: '198.51.100.15'
+
+nebula::profile::hathitrust::secure_rsync::allowed_networks:
+  - "%{alias('networks::one')}"
+  - name: 'secure network'
+    range: '192.0.2.1-192.0.2.4'
+
+nebula::profile::hathitrust::secure_rsync::datasets:
+  secure_dataset:
+    comment: "Secure Dataset"
+    path: "/datasets/secure_dataset"

--- a/templates/profile/hathitrust/rsync/rsyncd.conf.erb
+++ b/templates/profile/hathitrust/rsync/rsyncd.conf.erb
@@ -1,11 +1,5 @@
 # File managed by puppet; changes here will be lost.
 
-# Share PD data sets to partners and researchers.
-# See the iptables config or hosts.allow for comments on the allowed IPs.
-#
-# Note: we can't let rsync use chroot because of the symlinks that must be
-# followed.
-
 uid       = <%= @rsync_user %>
 list      = false
 read only = true
@@ -16,8 +10,10 @@ read only = true
   path        = <%= dataset['path'] %>
   log file    = <%= "#{@log_path}/#{name}.log" %>
   use chroot  = false
-  hosts allow = \
-  <% dataset['users'].each do |user| -%>
-    <%= user['ip'] %> \
+  <% if dataset.has_key?('users') -%>
+    hosts allow = \
+    <% dataset['users'].each do |user| -%>
+      <%= user['ip'] %> \
+    <% end -%>
   <% end -%>
 <% end %>

--- a/templates/profile/hathitrust/rsync/rsyncd.conf.erb
+++ b/templates/profile/hathitrust/rsync/rsyncd.conf.erb
@@ -1,0 +1,23 @@
+# File managed by puppet; changes here will be lost.
+
+# Share PD data sets to partners and researchers.
+# See the iptables config or hosts.allow for comments on the allowed IPs.
+#
+# Note: we can't let rsync use chroot because of the symlinks that must be
+# followed.
+
+uid       = <%= @rsync_user %>
+list      = false
+read only = true
+
+<% @datasets.each do |name, dataset| %>
+[<%= name %>]
+  comment     = <%= dataset['comment'] %>
+  path        = <%= dataset['path'] %>
+  log file    = <%= "#{@log_path}/#{name}.log" %>
+  use chroot  = false
+  hosts allow = \
+  <% dataset['users'].each do |user| -%>
+    <%= user['ip'] %> \
+  <% end -%>
+<% end %>

--- a/templates/profile/hathitrust/secure_rsync/secure-rsync.service.erb
+++ b/templates/profile/hathitrust/secure_rsync/secure-rsync.service.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description=Secure rsync
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=<%= @rsync_home %>
+ExecStart=/usr/bin/stunnel <%= @rsync_home %>/stunnel.conf
+RemainAfterExit=no
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/templates/profile/hathitrust/secure_rsync/stunnel.conf.erb
+++ b/templates/profile/hathitrust/secure_rsync/stunnel.conf.erb
@@ -1,0 +1,14 @@
+foreground=yes
+
+[rsync]
+accept=<%= @stunnel_port %>
+cert=<%= @rsync_home %>/server.crt
+key=<%= @rsync_home %>/server.key
+client=no
+
+sslVersion=TLSv1.2
+ciphers=ECDHE-RSA-AES256-GCM-SHA384
+exec=/usr/bin/rsync
+execArgs=rsync --daemon --config <%= @rsync_home %>/rsyncd.conf
+verify=3
+CAfile=<%= @rsync_home %>/client.crt


### PR DESCRIPTION
This migrates the unencrypted rsync and the stunnel+rsync functionality that was on quik-1. Paths and IP addresses are configured in the corresponding branch in lensoftruth.