### PR TITLE
Alert on OOM-kill instead of on < 250M free memory

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -38,14 +38,20 @@ groups:
     for: 2h
     labels:
       severity: ticket
-  - alert: RunningOutOfRam
+  - alert: HostOomKillDetected
     annotations:
-      summary: 'Linux node {{$labels.hostname}} is running out of RAM'
-    # Less than 250M free
-    expr: 'node_memory_MemAvailable_bytes < 250000000'
-    for: 10m
+      summary: 'Linux node {{$labels.hostname}} OOM-killed a process'
+    expr: 'increase(node_vmstat_oom_kill[5m]) > 0'
+    for: 0m
     labels:
       severity: page
+  - alert: HostUnderMemoryPressure
+    annotations:
+      summary: 'Linux node {{$labels.hostname}} is under memory pressure'
+    expr: 'rate(node_vmstat_pgmajfault[1m]) > 1000'
+    for: 2m
+    labels:
+      severity: info
   - alert: LinuxInstanceDown
     annotations:
       summary: 'Linux node {{$labels.hostname}} isn''t responding to Prometheus.'


### PR DESCRIPTION
Our first attempt at a ram alert was to send a page if a host ever has
less than 250M of available memory. In practice, this was noisier than
we'd hoped, since running out of available memory isn't necessarily
indicative of a problem.

We're replacing the rule with two new rules:

1.  HostOomKillDetected will send a page but then quickly resolve itself
    whenever a host OOM-kills something.
2.  HostUnderMemoryPressure will send an info alert whenever there are
    more than 1,000 major page faults (grep pgmajfault /proc/vmstat) per
    minute. Rather than picking a number of bytes that should be free,
    this detects poor performance likely due to low memory.