### PR TITLE
AE-10100 - Increase jira ProxyTimeout from 60s to 300s

### DIFF
--- a/manifests/profile/tools_lib/apache.pp
+++ b/manifests/profile/tools_lib/apache.pp
@@ -62,6 +62,7 @@ class nebula::profile::tools_lib::apache (
   class { 'apache::mod::proxy':
     proxy_requests => 'Off',
     proxy_via      => 'Block',
+    proxy_timeout  => 300,
   }
 
   class { 'apache::mod::dir':


### PR DESCRIPTION
On some of the bigger projects, it's taking longer than 60 seconds for
jira to load pages, so mod_proxy is timing out, since it's currently
defaulting to the value of Timeout, which the puppet apache module sets
to 60 seconds by default.

Left to its own, apache has a default timeout of 300s, so we're not
really doing anything all that weird by having a 5 minute proxy timeout.