### PR TITLE
HT-3073: Run catalog cron job getall.sh at both sites

### DIFF
--- a/manifests/profile/hathitrust/cron/catalog.pp
+++ b/manifests/profile/hathitrust/cron/catalog.pp
@@ -30,14 +30,6 @@ class nebula::profile::hathitrust::cron::catalog (
     'clean sessions':
       minute  => [0,15,30,45],
       command => "/usr/bin/perl ${catalog_home}/derived_data/clean_sessions.pl";
-
-    # Build up translation maps. Collection codes are pulled from the HT
-    # database, and lists of languages and formats are pulled right out of the the solr data.
-
-    'translation maps':
-      minute  => '58',
-      hour    => '15',
-      command => "${catalog_home}/derived_data/getall.sh ${catalog_home}/derived_data"
   }
 
 }

--- a/manifests/profile/hathitrust/cron/mdp_misc.pp
+++ b/manifests/profile/hathitrust/cron/mdp_misc.pp
@@ -15,6 +15,7 @@ class nebula::profile::hathitrust::cron::mdp_misc (
   String $sdr_root = '/htapps/babel',
   String $sdr_data_root = '/sdr1',
   String $home = '/htapps/babel/mdp-misc',
+  String $catalog_home = '/htapps/catalog/web',
   Integer $mdp_sessions_minute = 5
 ) {
 
@@ -49,6 +50,14 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       minute  => 01,
       hour    => 00,
       command => "${sdr_root}/pt/scripts/harvest_proxy_downloads.pl 2>&1 | /usr/bin/mail -s '${::hostname} harvest_proxy_downloads output' ${mail_recipient}";
+
+    # Build up translation maps. Collection codes are pulled from the HT
+    # database, and lists of languages and formats are pulled right out of the the solr data.
+
+    'translation maps':
+      minute  => '58',
+      hour    => '15',
+      command => "${catalog_home}/derived_data/getall.sh ${catalog_home}/derived_data"
 
   }
 


### PR DESCRIPTION
This stems from an error made when originally migrating these jobs, and perhaps before that; the getall.sh cron job should in fact run at both sites.

The catalog cron job profile is only included in the HT global primary
role; the mdp_misc one is included in the site primary.

I wonder if perhaps we should rename mdp_misc to "once per site" and
catalog to "once anywhere", or if that isn't really worth it.