### PR TITLE
HT-3042: add PTSEARCH_SOLR env var

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -21,6 +21,7 @@ class nebula::profile::hathitrust::apache::babel (
   String $otis_basic_auth,
   String $dex_endpoint,
   String $dex_basic_auth,
+  String $ptsearch_solr,
   Array[String] $cache_paths = [ ],
 ) {
 
@@ -107,7 +108,8 @@ class nebula::profile::hathitrust::apache::babel (
     setenv                      => [
       "SDRROOT ${sdrroot}",
       'SDRDATAROOT /sdr1',
-      "ASSERTION_EMAIL ${sdremail}"
+      "ASSERTION_EMAIL ${sdremail}",
+      "PTSEARCH_SOLR ${ptsearch_solr}"
     ],
 
     setenvifnocase              => [

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -14,6 +14,7 @@ nebula::profile::hathitrust::apache::babel::otis_endpoint: 'https://otis.default
 nebula::profile::hathitrust::apache::babel::otis_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
 nebula::profile::hathitrust::apache::babel::dex_endpoint: 'https://dex.default.invalid:3000'
 nebula::profile::hathitrust::apache::babel::dex_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
+nebula::profile::hathitrust::apache::babel::ptsearch_solr: 'http://ptsearch.default.invalid:8983'
 
 nebula::profile::hathitrust::hosts::mysql_sdr: '10.1.2.4'
 nebula::profile::hathitrust::hosts::mysql_htdev: '2.2.2.2'


### PR DESCRIPTION
This seems to be the easiest way to inject a different host for ptsearch
solr at different data centers. Right now deployment assumes
configuration will be the same at both data centers and differences will
be handled by `/etc/hosts`. However, deploying ptsearch solr in Kubernetes at
multiple data centers with proxied ingress via HTTPS means we need
separate hostnames so that letsencrypt can successfully generate a
cert. We considered several options including disabling cert
verification, alternative ingress setups, etc, and this seems this least
disruptive; it also gives us an easy path to vary the solr for
test/preview in addition to production.