### PR TITLE
SYS-239 - Alert when Fedora is down for Deep Blue Data

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -218,6 +218,14 @@ groups:
     labels:
       severity: ticket
 
+  - alert: DeepBlueDataProdFedoraDown
+    annotations:
+      summary: 'Fedora is unresponsive on node {{$labels.hostname}}.'
+    expr: 'time() - dbd_fedora_check_last_success > 65'
+    for: 15m
+    labels:
+      severity: page
+
   # This doesn't appear to grow fast, so an 100G threshold should give
   # plenty of time to address any problems.
   - alert: HTDevStoragePressure


### PR DESCRIPTION
We check Fedora every minute. If it does not respond for 15 minutes, we
send a page level alert to investigate promptly.