### PR TITLE
HT-3042: add basic auth for ptsearch solr to env

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -22,6 +22,7 @@ class nebula::profile::hathitrust::apache::babel (
   String $dex_endpoint,
   String $dex_basic_auth,
   String $ptsearch_solr,
+  String $ptsearch_solr_basic_auth,
   Array[String] $cache_paths = [ ],
 ) {
 
@@ -109,7 +110,8 @@ class nebula::profile::hathitrust::apache::babel (
       "SDRROOT ${sdrroot}",
       'SDRDATAROOT /sdr1',
       "ASSERTION_EMAIL ${sdremail}",
-      "PTSEARCH_SOLR ${ptsearch_solr}"
+      "PTSEARCH_SOLR ${ptsearch_solr}",
+      "PTSEARCH_SOLR_BASIC_AUTH ${ptsearch_solr_basic_auth}"
     ],
 
     setenvifnocase              => [

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -15,6 +15,7 @@ nebula::profile::hathitrust::apache::babel::otis_basic_auth: 'ZmFrZV91c2VyOmZha2
 nebula::profile::hathitrust::apache::babel::dex_endpoint: 'https://dex.default.invalid:3000'
 nebula::profile::hathitrust::apache::babel::dex_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
 nebula::profile::hathitrust::apache::babel::ptsearch_solr: 'http://ptsearch.default.invalid:8983'
+nebula::profile::hathitrust::apache::babel::ptsearch_solr_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
 
 nebula::profile::hathitrust::hosts::mysql_sdr: '10.1.2.4'
 nebula::profile::hathitrust::hosts::mysql_htdev: '2.2.2.2'


### PR DESCRIPTION
Getting it via config required committing to slip-lib repo, which we did
not want to do. This brings the config for ptsearch (somewhat) more in line with what we are doing with the other kubernetes services with basic auth.