### PR TITLE
Remove references to ptsearch host

### DIFF
--- a/manifests/profile/hathitrust/hosts.pp
+++ b/manifests/profile/hathitrust/hosts.pp
@@ -14,7 +14,6 @@ class nebula::profile::hathitrust::hosts(
   String $apps_ht,
   Array[String] $solr_search,
   String $solr_catalog,
-  String $solr_ptsearch,
   String $solr_usfeddocs,
   String $solr_vufind_primary,
   String $solr_vufind_failover
@@ -66,11 +65,6 @@ class nebula::profile::hathitrust::hosts(
   host { 'solr-sdr-catalog':
     comment => 'solr (ht catalog)',
     ip      => $solr_catalog
-  }
-
-  host { 'solr-sdr-ptsearch':
-    comment => 'solr (ht PT search)',
-    ip      => $solr_ptsearch
   }
 
   host { 'solr-sdr-usfeddocs':

--- a/spec/classes/profile/hathitrust/hosts_spec.rb
+++ b/spec/classes/profile/hathitrust/hosts_spec.rb
@@ -21,7 +21,6 @@ describe 'nebula::profile::hathitrust::hosts' do
           apps_ht: '3.3.3.3',
           solr_search: solr_ips,
           solr_catalog: '4.4.4.4',
-          solr_ptsearch: '5.5.5.5',
           solr_usfeddocs: '6.6.6.6',
           solr_vufind_primary: '7.7.7.7',
           solr_vufind_failover: '8.8.8.8',

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -24,7 +24,6 @@ nebula::profile::hathitrust::hosts::solr_search:
   - '4.4.4.4'
   - '5.5.5.5'
 nebula::profile::hathitrust::hosts::solr_catalog: '6.6.6.6'
-nebula::profile::hathitrust::hosts::solr_ptsearch: '7.7.7.7'
 nebula::profile::hathitrust::hosts::solr_usfeddocs: '8.8.8.8'
 nebula::profile::hathitrust::hosts::solr_vufind_primary: '9.9.9.9'
 nebula::profile::hathitrust::hosts::solr_vufind_failover: '22.22.22.22'


### PR DESCRIPTION
ptsearch is now in kubernetes; endpoint is configured
via environment variable, not /etc/hosts