### PR TITLE
Add log rotation to fulcrum.

### DIFF
--- a/manifests/profile/fulcrum/logrotate.pp
+++ b/manifests/profile/fulcrum/logrotate.pp
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::fulcrum::logrotate {
+  include nebula::profile::logrotate
+
+  logrotate::rule { 'fulcrum':
+    path          => '/home/fulcrum/app/shared/log/*.log',
+    rotate        => 7,
+    rotate_every  => 'day',
+    missingok     => true,
+    compress      => true,
+    ifempty       => false,
+    delaycompress => true,
+    copytruncate  => true,
+  }
+}

--- a/manifests/role/fulcrum.pp
+++ b/manifests/role/fulcrum.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of Michigan.
+# Copyright (c) 2021-2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -12,6 +12,7 @@ class nebula::role::fulcrum {
   include nebula::profile::ruby
   include nebula::profile::fulcrum::base
   include nebula::profile::fulcrum::app
+  include nebula::profile::fulcrum::logrotate
   include nebula::profile::fulcrum::mysql
   include nebula::profile::fulcrum::nginx
   include nebula::profile::fulcrum::shibboleth

--- a/spec/classes/profile/fulcrum/logrotate_spec.rb
+++ b/spec/classes/profile/fulcrum/logrotate_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2022 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::fulcrum::logrotate' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_class('Nebula::Profile::Logrotate') }
+
+      it do
+        is_expected.to contain_logrotate__rule('fulcrum')
+          .with_path('/home/fulcrum/app/shared/log/*.log')
+          .with_rotate(7)
+          .with_rotate_every('day')
+          .with_missingok(true)
+          .with_compress(true)
+          .with_ifempty(false)
+          .with_delaycompress(true)
+          .with_copytruncate(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
These settings are copied right from bulleit-1 for heliotrope-production
logging.