### PR TITLE
HT-3278: allow overriding bridge interface names in vm

### DIFF
--- a/manifests/profile/vmhost/host.pp
+++ b/manifests/profile/vmhost/host.pp
@@ -28,6 +28,8 @@ class nebula::profile::vmhost::host (
   Array   $nameservers,
   String  $local_storage = '',
   String  $local_storage_size = '',
+  String  $internet_bridge = 'br0',
+  String  $lan_bridge      = 'br1',
 ) {
 
   file { '/etc/default/libvirt-guests':
@@ -68,17 +70,19 @@ class nebula::profile::vmhost::host (
   $vms.each |$vm_name, $vm_settings| {
     nebula::virtual_machine {
       default:
-        build         => $build,
-        cpus          => $cpus,
-        disk          => $disk,
-        ram           => $ram,
-        domain        => $domain,
-        filehost      => $filehost,
-        image_dir     => $image_dir,
-        net_interface => $net_interface,
-        netmask       => $netmask,
-        gateway       => $gateway,
-        nameservers   => $nameservers,
+        build           => $build,
+        cpus            => $cpus,
+        disk            => $disk,
+        ram             => $ram,
+        domain          => $domain,
+        filehost        => $filehost,
+        image_dir       => $image_dir,
+        net_interface   => $net_interface,
+        internet_bridge => $internet_bridge,
+        lan_bridge      => $lan_bridge,
+        netmask         => $netmask,
+        gateway         => $gateway,
+        nameservers     => $nameservers,
       ;
       $vm_name:
         *       => $vm_settings,

--- a/manifests/virtual_machine.pp
+++ b/manifests/virtual_machine.pp
@@ -59,21 +59,23 @@
 #                                           # disables the timeout
 #   }
 define nebula::virtual_machine(
-  String  $addr           = '127.0.0.1',
-  String  $build          = 'stretch',
-  Integer $cpus           = 2,
-  Integer $disk           = 16,
-  Integer $ram            = 1,
-  String  $autostart_path = '/etc/libvirt/qemu/autostart',
-  String  $image_dir      = '/var/lib/libvirt/images',
-  String  $image_path     = '',
-  String  $net_interface  = 'eth0',
-  String  $netmask        = '255.255.255.0',
-  String  $gateway        = '192.168.1.1',
-  Array   $nameservers    = ['192.168.1.1'],
-  String  $domain         = 'default.invalid',
-  String  $filehost       = 'files.default.invalid',
-  Integer $timeout        = 600,
+  String  $addr            = '127.0.0.1',
+  String  $build           = 'stretch',
+  Integer $cpus            = 2,
+  Integer $disk            = 16,
+  Integer $ram             = 1,
+  String  $autostart_path  = '/etc/libvirt/qemu/autostart',
+  String  $image_dir       = '/var/lib/libvirt/images',
+  String  $image_path      = '',
+  String  $net_interface   = 'eth0',
+  String  $netmask         = '255.255.255.0',
+  String  $gateway         = '192.168.1.1',
+  String  $internet_bridge = 'br0',
+  String  $lan_bridge      = 'br1',
+  Array   $nameservers     = ['192.168.1.1'],
+  String  $domain          = 'default.invalid',
+  String  $filehost        = 'files.default.invalid',
+  Integer $timeout         = 600,
 ) {
   require nebula::profile::vmhost::prereqs
 
@@ -123,8 +125,8 @@ define nebula::virtual_machine(
           --location ${location}                                      \
           --os-type=linux                                             \
           --disk '${full_image_path},size=${disk}'                    \
-          --network bridge=br0,model=virtio                           \
-          --network bridge=br1,model=virtio                           \
+          --network bridge=${internet_bridge},model=virtio                           \
+          --network bridge=${lan_bridge},model=virtio                           \
           --console pty,target_type=virtio                            \
           --virt-type kvm                                             \
           --graphics vnc                   ${initrd_inject}           \

--- a/spec/classes/profile/vmhost/host_spec.rb
+++ b/spec/classes/profile/vmhost/host_spec.rb
@@ -22,6 +22,23 @@ describe 'nebula::profile::vmhost::host' do
         it { is_expected.not_to contain_vm('vmname') }
       end
 
+      context 'when given bridge network interfaces' do
+        let(:params) do
+          {
+            internet_bridge: 'internet_bridge',
+            lan_bridge: 'lan_bridge',
+            vms: {
+              'vmname' => {
+                'addr' => '1.2.3.4',
+              },
+            },
+          }
+        end
+
+        it { is_expected.to contain_vm('vmname').with_internet_bridge('internet_bridge') }
+        it { is_expected.to contain_vm('vmname').with_lan_bridge('lan_bridge') }
+      end
+
       context 'when given a single hostname with an ip' do
         let(:params) do
           {
@@ -41,6 +58,8 @@ describe 'nebula::profile::vmhost::host' do
         it { is_expected.to contain_vm('vmname').with_filehost('default.filehost.invalid') }
         it { is_expected.to contain_vm('vmname').with_image_dir('default.image_dir.invalid') }
         it { is_expected.to contain_vm('vmname').with_net_interface('default.iface.invalid') }
+        it { is_expected.to contain_vm('vmname').with_internet_bridge('br0') }
+        it { is_expected.to contain_vm('vmname').with_lan_bridge('br1') }
         it { is_expected.to contain_vm('vmname').with_netmask('0.0.0.0') }
         it { is_expected.to contain_vm('vmname').with_gateway('10.1.2.3') }
         it { is_expected.to contain_vm('vmname').with_nameservers(['5.5.5.5', '4.4.4.4']) }

--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -109,6 +109,21 @@ describe 'nebula::virtual_machine' do
         end
       end
 
+      context 'with bridge interface overrides' do
+        let(:params) do
+          {
+            internet_bridge: 'internet_bridge',
+            lan_bridge: 'lan_bridge',
+          }
+        end
+
+        [
+          %r{ --network bridge=internet_bridge,model=virtio .* --network bridge=lan_bridge,model=virtio}m,
+        ].each do |command|
+          it { is_expected.to contain_install.with_command(command) }
+        end
+      end
+
       context 'with nothing but the title "secondvm"' do
         let(:title) { 'secondvm' }
 


### PR DESCRIPTION
The new vmhosts use Ubuntu, which uses netplan for network configuration
instead of /etc/network/interfaces. This allows us to use more
meaningful interface names instead of br0 and br1; however, that means
we need to be able to configure the bridge names per vmhost.