### PR TITLE
Unset Shib headers before setting to prevent spoofing

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -346,6 +346,15 @@ class nebula::profile::hathitrust::apache::babel (
     ",
 
     request_headers             => [
+      # Remove existing X-Shib- headers before setting new ones based on shib env vars
+      'unset X-Shib-Persistent-ID',
+      'unset X-Shib-eduPersonPrincipalName',
+      'unset X-Shib-displayName',
+      'unset X-Shib-mail',
+      'unset X-Shib-eduPersonScopedAffiliation',
+      'unset X-Shib-Authentication-Method',
+      'unset X-Shib-AuthnContext-Class',
+      'unset X-Shib-Identity-Provider',
       # Explicitly forward attributes extracted via Shibboleth
       'set X-Shib-Persistent-ID %{persistent-id}e ENV=persistent-id',
       'set X-Shib-eduPersonPrincipalName %{eppn}e ENV=eppn',

--- a/manifests/profile/www_lib/vhosts/fulcrum.pp
+++ b/manifests/profile/www_lib/vhosts/fulcrum.pp
@@ -98,6 +98,15 @@ class nebula::profile::www_lib::vhosts::fulcrum (
 
     # TODO: Review Shib headers for apache 2.4
     request_headers => [
+      # Remove existing X-Shib- headers before setting new ones based on shib env vars
+      'unset X-Shib-Persistent-ID',
+      'unset X-Shib-eduPersonPrincipalName',
+      'unset X-Shib-displayName',
+      'unset X-Shib-mail',
+      'unset X-Shib-eduPersonScopedAffiliation',
+      'unset X-Shib-Authentication-Method',
+      'unset X-Shib-AuthnContext-Class',
+      'unset X-Shib-Identity-Provider',
       # Explicitly forward attributes extracted via Shibboleth
       'set X-Shib-Persistent-ID %{persistent-id}e ENV=persistent-id',
       'set X-Shib-eduPersonPrincipalName %{eppn}e ENV=eppn',


### PR DESCRIPTION
When we always set the X-Shib header (regardless of whether the env var
from mod_shib was present), any client-supplied header would get wiped
out. When conditionally setting the header, a client-supplied header
could be injected if mod_shib does not supply a value. This is not the
behavior we want.

I've tested this on beta-1.babel.hathitrust.org and verified that 1) this pattern (`RequestHeader unset` followed by a conditional `RequestHeader set`) still passes through the Shib-supplied env vars and that 2) with this pattern, client-supplied headers don't make it through.