### PR TITLE
Add validate_cmd for shibboleth2.xml

### DIFF
--- a/manifests/profile/shibboleth.pp
+++ b/manifests/profile/shibboleth.pp
@@ -79,10 +79,11 @@ class nebula::profile::shibboleth (
   }
 
   file { '/etc/shibboleth/shibboleth2.xml':
-    mode   => '0440',
-    owner  => '_shibd',
-    group  => 'nogroup',
-    source => "${config_source}/shibboleth2.xml"
+    mode         => '0440',
+    owner        => '_shibd',
+    group        => 'nogroup',
+    source       => "${config_source}/shibboleth2.xml",
+    validate_cmd => '/usr/sbin/shibd -t -c %'
   }
 
   file { '/etc/systemd/system/shibd.service.d':

--- a/manifests/role/webhost/htvm.pp
+++ b/manifests/role/webhost/htvm.pp
@@ -8,6 +8,7 @@
 #   include nebula::role::webhost::htvm
 class nebula::role::webhost::htvm (
   String $private_address_template = '192.168.0.%s',
+  String $shibboleth_config_source = 'puppet:///shibboleth'
 ) {
   include nebula::role::hathitrust
 
@@ -33,7 +34,7 @@ class nebula::role::webhost::htvm (
   include nebula::profile::unison
 
   class { 'nebula::profile::shibboleth':
-    config_source    => 'puppet:///shibboleth',
+    config_source    => $shibboleth_config_source,
     startup_timeout  => 1800,
     watchdog_minutes => '*/30',
   }


### PR DESCRIPTION
This should, in theory, validate proposed changes to shibboleth2.xml before putting them in place. I thought that shibd would refuse to reload an invalid shibboleth2.xml (and that may be true), but it also (surprisingly to me) causes apache / mod_shib to fail. 

This does NOT validate changes to other Shibboleth configuration files (e.g. attribute-map.xml or attribute-policy.xml); I'm not sure how we would do that with either `shibd -t` or with the puppet configuration that just puts the entire directory in place, but I'm also reasonably certain that I've pushed out changes to those files with errors and that it does not bring down the web server, so... :shrug: 

The upcoming change to shibboleth SP version 3 in Debian 11 might give us a good chance to rethink workflow here. If nothing else, it would be ideal to 1) have the configuration files for shibboleth managed somewhere version-controlled and 2) to have a way to easily try out a change on e.g. `test.babel.hathitrust.org` without applying it everywhere. That concern is somewhat orthogonal to actually pushing out a broken config, though.