### PR TITLE
always use preseed for installing debian vms

### DIFF
--- a/manifests/virtual_machine.pp
+++ b/manifests/virtual_machine.pp
@@ -93,15 +93,11 @@ define nebula::virtual_machine(
     ensure => 'directory',
   }
 
-  if $build == 'stretch' or $build == 'buster' {
-    file { "${tmpdir}/preseed.cfg":
-      content => template("nebula/virtual_machine/${build}.cfg.erb"),
-    }
-
-    $initrd_inject = "--initrd-inject '${tmpdir}/preseed.cfg'"
-  } else {
-    $initrd_inject = ''
+  file { "${tmpdir}/preseed.cfg":
+    content => template("nebula/virtual_machine/${build}.cfg.erb"),
   }
+
+  $initrd_inject = "--initrd-inject '${tmpdir}/preseed.cfg'"
 
   unless $::vm_guests.member($title) {
     exec { "${prefix}::virt-install":

--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -278,18 +278,18 @@ describe 'nebula::virtual_machine' do
         end
       end
 
-      context 'with build set to jessie' do
-        let(:params) { { build: 'jessie' } }
+      context 'with build set to somecodename' do
+        let(:params) { { build: 'somecodename' } }
 
         it do
           is_expected.to contain_install.with_command(
-            %r{ --location http://ftp\.us\.debian\.org/debian/dists/jessie/main/installer-amd64/},
+            %r{ --location http://ftp\.us\.debian\.org/debian/dists/somecodename/main/installer-amd64/},
           )
         end
 
-        it { is_expected.not_to contain_preseed }
+        it { is_expected.to contain_preseed }
 
-        it { is_expected.not_to contain_install.with_command(%r{--initrd-inject}) }
+        it { is_expected.to contain_install.with_command(%r{--initrd-inject}) }
       end
 
       context 'with domain set to awesome.com' do


### PR DESCRIPTION
This appears to have been a special case we were using to support jessie
vms, which are no longer supported. It was breaking bullseye support, and would
also break any future releases.