### PR TITLE
Fix flapping windows update alert

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -167,7 +167,7 @@ groups:
   - alert: WindowsUpdateBehind
     annotations:
       summary: 'Node {{$labels.hostname}} has not updated in 40+ days.'
-    expr: 'time() - windows_update > 40*24*3600'
+    expr: 'time() - avg_over_time(windows_update[10m]) > 40 * 24 * 3600'
     for: 1h
     labels:
       severity: ticket


### PR DESCRIPTION
This alert was flapping because sometimes the server was responding with
null values intermittantly. Using the avg_over_time() function over a
period of 10 minutes shouldn't change the way this alert works, but it
will tolerate the occasional lack of response without flapping.