### PR TITLE
Move command argument to the right place; add alert

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -44,8 +44,9 @@ class nebula::profile::prometheus (
 
   docker::run { 'pushgateway':
     image            => "prom/pushgateway:${pushgateway_version}",
+    command          => '--persistence.file=/archive/pushgateway',
     net              => 'host',
-    extra_parameters => ['--restart=always', '--persistence.file=/archive/pushgateway'],
+    extra_parameters => ['--restart=always'],
     volumes          => ['/opt/pushgateway:/archive'],
     require          => File['/opt/pushgateway'],
   }

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -39,8 +39,9 @@ describe 'nebula::profile::prometheus' do
       it do
         is_expected.to contain_docker__run('pushgateway')
           .with_image('prom/pushgateway:latest')
+          .with_command('--persistence.file=/archive/pushgateway')
           .with_net('host')
-          .with_extra_parameters(%w[--restart=always --persistence.file=/archive/pushgateway])
+          .with_extra_parameters(%w[--restart=always])
           .with_volumes(%w[/opt/pushgateway:/archive])
           .that_requires('File[/opt/pushgateway]')
       end

--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -59,6 +59,13 @@ groups:
     for: 30m
     labels:
       severity: page
+  - alert: PrometheusExporterDown
+    annotations:
+      summary: '{{$labels.job}} exporter isn''t responding to Prometheus.'
+    expr: 'up{job!="node"} == 0'
+    for: 30m
+    labels:
+      severity: page
   - alert: WindowsInstanceDown
     annotations:
       summary: 'Windows node {{$labels.hostname}} isn''t responding to Prometheus.'


### PR DESCRIPTION
I added an argument to `docker run` that should have been an argument to
the running container. I noticed the problem because I happened to
check; the pushgateways have been down since that change, and we haven't
heard anything because we didn't have an alert for any exporters being
down other than the node exporters.