### PR TITLE
HELIO-4186 - Add default vhost for monitoring

### DIFF
--- a/manifests/role/webhost/fulcrum_www_and_app.pp
+++ b/manifests/role/webhost/fulcrum_www_and_app.pp
@@ -20,6 +20,15 @@ class nebula::role::webhost::fulcrum_www_and_app (
   include nebula::profile::www_lib::apache::base
   include nebula::profile::www_lib::apache::fulcrum
 
+  # Include a default vhost to catch monitoring requests by IP/fqdn.
+  # This is here rather than in the profile because it would be duplicate
+  # on www_lib_vm.
+  class { 'nebula::profile::www_lib::vhosts::default':
+    prefix => '',
+    domain => 'fulcrum.org',
+    ssl_cn => 'fulcrum.org',
+  }
+
   cron {
     default:
       user => 'root',


### PR DESCRIPTION
HAProxy checks /monitor/monitor.pl for backend liveness, and that is set
up in apache::base. However, we did not have a default vhost for
requests via IP/fqdn, so the checks were failing. This adds the default
vhost to the fulcrum+apache role. Ideally, it would be in the profile,
but that would collide with the standard inclusion via misc on general
servers.