### PR TITLE
HELIO-4186 - Add perl dependencies for monitor.pl

### DIFF
--- a/manifests/role/webhost/fulcrum_www_and_app.pp
+++ b/manifests/role/webhost/fulcrum_www_and_app.pp
@@ -13,6 +13,11 @@ class nebula::role::webhost::fulcrum_www_and_app (
   include nebula::role::umich
   include nebula::role::fulcrum::app_host
   include nebula::profile::www_lib::register_for_load_balancing
+
+  # The perl profile is needed for monitor_pl to work, but it pulls in a
+  # ton of stuff. We should probably allow for different haproxy http checks
+  # for a service, and eliminate the perl/monitor_pl dependency here.
+  include nebula::profile::www_lib::perl
   include nebula::profile::networking::firewall::http
 
   create_resources('host',$hosts)


### PR DESCRIPTION
There are a few dependencies in monitor.pl, so we add the perl profile.
This is a bummer because the minimal server is getting progressively
bloated... but, the HAProxy http checks depend on /monitor/monitor.pl.
It's slightly preferable to keep that consistent for the time being than
to change the global HAProxy configs to allow a given service to have a
different check or to have something else running at that request path.