### PR TITLE
DEV-7: perl module for new geoip format

### DIFF
--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -143,6 +143,7 @@ class nebula::profile::hathitrust::perl () {
     'Algorithm::LUHN',
     'OAuth::Lite',
     'EBook::EPUB',
+    'IP::Geolocation::MMDB',
     'Sub::Uplevel',
     'Test::Exception',
     'Devel::Cycle',


### PR DESCRIPTION
Per @respinos. This module is not available via Debian.