### PR TITLE
Debian 11 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,7 +18,7 @@ fixtures:
       ref: "6.5.0"
     apache:
       repo: "puppetlabs/apache"
-      ref: "5.8.0"
+      ref: "7.0.0"
     apt:
       repo: "puppetlabs/apt"
       ref: "7.6.0"

--- a/manifests/profile/hathitrust/dependencies.pp
+++ b/manifests/profile/hathitrust/dependencies.pp
@@ -25,6 +25,11 @@ class nebula::profile::hathitrust::dependencies () {
     ]
   )
 
+  file { '/l':
+    ensure => 'directory'
+  }
+
+
   file { '/l/local':
     ensure => 'directory'
   }
@@ -72,8 +77,13 @@ class nebula::profile::hathitrust::dependencies () {
     [
       'openjdk-11-jdk-headless',
       'lftp',
-      'mariadb-client-10.1'
     ]:
+  }
+
+  if $::lsbdistcodename == 'stretch' {
+    ensure_packages(['mariadb-client-10.1'])
+  } elsif $::lsbdistcodename == 'bullseye' {
+    ensure_packages(['mariadb-client'])
   }
 
 }

--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -12,6 +12,10 @@ class nebula::profile::hathitrust::perl () {
   include nebula::profile::hathitrust::dependencies
   include nebula::profile::geoip
 
+  if $::lsbdistcodename == 'stretch' {
+    package { 'libreadonly-xs-perl': }
+  }
+
   package { [
     'libalgorithm-diff-xs-perl',
     'libany-moose-perl',
@@ -101,7 +105,6 @@ class nebula::profile::hathitrust::perl () {
     'libpod-simple-perl',
     'libproc-processtable-perl',
     'libreadonly-perl',
-    'libreadonly-xs-perl',
     'libroman-perl',
     'libsoap-lite-perl',
     'libspreadsheet-writeexcel-perl',

--- a/manifests/profile/hathitrust/php.pp
+++ b/manifests/profile/hathitrust/php.pp
@@ -12,23 +12,44 @@ class nebula::profile::hathitrust::php () {
   include nebula::profile::hathitrust::apache
   include nebula::profile::geoip
 
-  package {
-    [
-      'php7.0-curl',
-      'php7.0-gd',
-      'php-geoip', # PECL
-      'php-http', # PECL
-      'php7.0-ldap',
-      'php7.0-mysql',
-      'php-mdb2',
-      'php-mdb2-driver-mysql',
-      'php-smarty',
-      'php7.0-xsl',
-      'php7.0-mbstring',
-      'php-yaml',
-      'libapache2-mod-php7.0',
-      'pear-channels'
-    ]:
+  if $::lsbdistcodename == 'stretch' {
+    package {
+      [
+        'php7.0-curl',
+        'php7.0-gd',
+        'php-geoip', # PECL
+        'php-http', # PECL
+        'php7.0-ldap',
+        'php7.0-mysql',
+        'php-mdb2',
+        'php-mdb2-driver-mysql',
+        'php-smarty',
+        'php7.0-xsl',
+        'php7.0-mbstring',
+        'php-yaml',
+        'libapache2-mod-php7.0',
+        'pear-channels'
+      ]:
+    }
+  } else {
+    package {
+      [
+        'php-curl',
+        'php-gd',
+        'php-geoip', # PECL
+        'php-http', # PECL
+        'php-ldap',
+        'php-mysql',
+        'php-mdb2',
+        'php-mdb2-driver-mysql',
+        'php-smarty',
+        'php-xml',
+        'php-mbstring',
+        'php-yaml',
+        'libapache2-mod-php',
+        'pear-channels'
+      ]:
+    }
   }
 
   -> class { '::php':

--- a/manifests/profile/shibboleth.pp
+++ b/manifests/profile/shibboleth.pp
@@ -25,12 +25,12 @@ class nebula::profile::shibboleth (
   include nebula::systemd::daemon_reload
 
   package {
-    [ 
+    [
       'unixodbc',
     ]:
   }
 
-  if $::lsbdistcodename == 'stretch' { 
+  if $::lsbdistcodename == 'stretch' {
     # stretch: Shibboleth 2
     package {
       [

--- a/manifests/profile/shibboleth.pp
+++ b/manifests/profile/shibboleth.pp
@@ -25,19 +25,58 @@ class nebula::profile::shibboleth (
   include nebula::systemd::daemon_reload
 
   package {
-    [
+    [ 
       'unixodbc',
-      'shibboleth-sp2-common',
-      'shibboleth-sp2-utils',
-      'mariadb-unixodbc'
     ]:
   }
 
-  # We require 'apache' here to make sure that this profile is used in
-  # conjunction with a managed Apache installation, rather than just pulling
-  # in an unmanaged package with APT.
-  package { 'libapache2-mod-shib2':
-    require => [Class['apache']],
+  if $::lsbdistcodename == 'stretch' { 
+    # stretch: Shibboleth 2
+    package {
+      [
+        'shibboleth-sp2-common',
+        'shibboleth-sp2-utils',
+        # locally-built -- odbc-mariadb isn't in stretch (AEIM-1678)
+        'mariadb-unixodbc'
+      ]:
+    }
+
+    # We require 'apache' here to make sure that this profile is used in
+    # conjunction with a managed Apache installation, rather than just pulling
+    # in an unmanaged package with APT.
+    package { 'libapache2-mod-shib2':
+      require => [Class['apache']],
+    }
+
+    service { 'shibd':
+      ensure     => 'running',
+      enable     => true,
+      hasrestart => true,
+      require    => [Package['shibboleth-sp2-utils'], Package['mariadb-unixodbc']]
+    }
+  } else {
+    # buster, bullseye: Shibboleth 3
+    package {
+      [
+        'shibboleth-sp-common',
+        'shibboleth-sp-utils',
+        'odbc-mariadb'
+      ]:
+    }
+
+    # We require 'apache' here to make sure that this profile is used in
+    # conjunction with a managed Apache installation, rather than just pulling
+    # in an unmanaged package with APT.
+    package { 'libapache2-mod-shib':
+      require => [Class['apache']],
+    }
+
+    service { 'shibd':
+      ensure     => 'running',
+      enable     => true,
+      hasrestart => true,
+      require    => [Package['shibboleth-sp-utils'], Package['odbc-mariadb']]
+    }
   }
 
   file { '/etc/odbcinst.ini':
@@ -60,12 +99,6 @@ class nebula::profile::shibboleth (
       |ODBCINST
   }
 
-  service { 'shibd':
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
-    require    => [Package['shibboleth-sp2-utils'], Package['mariadb-unixodbc']]
-  }
 
   file { '/etc/shibboleth':
     ensure  => 'directory',

--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -7,16 +7,6 @@
 # @example
 #   include nebula::role::webhost::htvm::test
 class nebula::role::webhost::htvm::test {
-  # Temporary until Debian 8 test instance is decommissioned
-
-  # @@nebula::haproxy::binding { "${::hostname} test-hathitrust":
-  #   service       => 'test-hathitrust',
-  #   https_offload => true,
-  #   datacenter    => $::datacenter,
-  #   hostname      => $::hostname,
-  #   ipaddress     => $::ipaddress
-  # }
-
   lookup('umich::networks::all_trusted_machines').flatten.each |$network| {
     firewall { "100 HTTP ${network['name']}":
       proto  => 'tcp',
@@ -28,7 +18,6 @@ class nebula::role::webhost::htvm::test {
   }
 
   include nebula::role::webhost::htvm
-  include nebula::profile::named_instances
   include nebula::profile::hathitrust::apache::test
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "issues_url": "https://github.com/mlibrary/nebula/issues",
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 7.0.0"},
-    {"name": "puppetlabs/apache", "version_requirement": ">= 3.4.0 < 6.0.0"},
+    {"name": "puppetlabs/apache", "version_requirement": ">= 7.0.0 < 8.0.0"},
     {"name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 8.0.0"},
     {"name": "puppetlabs/concat", "version_requirement": ">= 4.2.0 < 7.0.0"},
     {"name": "puppetlabs/docker", "version_requirement": ">= 3.4.0 < 4.0.0"},

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -41,28 +41,36 @@ describe 'nebula::role::webhost::htvm' do
           .with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml)
       end
 
-      if os == 'debian-9-x86_64'
-        context 'with ens4' do
-          let(:facts) do
-            os_facts.merge(
-              networking: {
-                ip: '1.2.3.123',
-                interfaces: { 'ens4' => {} },
-              },
-              is_virtual: true,
-            )
-          end
-
-          it { is_expected.to contain_mount('/htapps').that_requires('Exec[ifup ens4]') }
-          it { is_expected.to contain_mount('/sdr1').that_requires('Exec[ifup ens4]') }
-          it { is_expected.to contain_service('bind9').that_requires('Exec[ifup ens4]') }
+      context 'with ens4' do
+        let(:facts) do
+          os_facts.merge(
+            networking: {
+              ip: '1.2.3.123',
+              interfaces: { 'ens4' => {} },
+            },
+            is_virtual: true,
+          )
         end
 
-        it { is_expected.to contain_class('nebula::profile::networking::firewall') }
+        it { is_expected.to contain_mount('/htapps').that_requires('Exec[ifup ens4]') }
+        it { is_expected.to contain_mount('/sdr1').that_requires('Exec[ifup ens4]') }
+        it { is_expected.to contain_service('bind9').that_requires('Exec[ifup ens4]') }
+      end
 
-        it { is_expected.to contain_class('nebula::profile::krb5') }
-        it { is_expected.to contain_class('nebula::profile::afs') }
-        it { is_expected.to contain_class('nebula::profile::users') }
+      it { is_expected.to contain_class('nebula::profile::networking::firewall') }
+
+      it { is_expected.to contain_class('nebula::profile::krb5') }
+      it { is_expected.to contain_class('nebula::profile::afs') }
+      it { is_expected.to contain_class('nebula::profile::users') }
+
+      if os == 'debian-11-x86_64'
+
+        # These tests fail with puppet php module version 7.1.0 but should pass with 8.0.0
+        xit { is_expected.not_to contain_package('php5-common') }
+        xit { is_expected.not_to contain_package('php5-dev') }
+        it { is_expected.to contain_package('libapache2-mod-shib') }
+        it { is_expected.not_to contain_package('libapache2-mod-shib2') }
+        it { is_expected.to contain_package('mariadb-client') }
       end
 
       # not specified explicitly as a usergroup, just brought in as part of 'all groups'

--- a/templates/profile/dns/smartconnect/named.conf.options.erb
+++ b/templates/profile/dns/smartconnect/named.conf.options.erb
@@ -3,7 +3,8 @@
 options {
   directory "/var/cache/bind";
 
-  dnssec-validation auto;
+  dnssec-enable no;
+  dnssec-validation no;
 
   auth-nxdomain no;    # conform to RFC1035
 


### PR DESCRIPTION
This should add most of what's needed for debian 11 support for HT without breaking anything for debian 9. This is mostly ported from https://github.com/mlibrary/nebula/tree/ht-debian-11 but keeping conditionals to support both stretch and bullseye. ~Still to-do is to add back some of the tests from the ht-debian-11 branch that are not yet replicated here.~ The tests are present now.