### PR TITLE
Update php module to >= 8.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -66,7 +66,7 @@ fixtures:
       ref: "2.1.1"
     php:
       repo: "puppet/php"
-      ref: "7.1.0"
+      ref: "8.0.3"
     debconf:
       repo: "stm/debconf"
       ref: "3.2.0"

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     {"name": "puppetlabs/reboot", "version_requirement": ">= 2.0.0 < 4.0.0"},
     {"name": "puppet/letsencrypt", "version_requirement": ">= 5.0.0 < 7.0.0"},
     {"name": "puppet/nginx", "version_requirement": ">= 1.0.0 < 3.0.0"},
-    {"name": "puppet/php", "version_requirement": ">= 6.0.2 < 8.0.0"},
+    {"name": "puppet/php", "version_requirement": ">= 8.0.0 < 9.0.0"},
     {"name": "puppet/logrotate", "version_requirement": ">= 3.4.0 < 6.0.0"},
     {"name": "stm/debconf", "version_requirement": ">= 2.1.0 < 4.0.0"},
     {"name": "camptocamp/kmod", "version_requirement": ">= 2.1.0 < 3.0.0"},
@@ -41,7 +41,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "11"
       ]
     },

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -64,10 +64,8 @@ describe 'nebula::role::webhost::htvm' do
       it { is_expected.to contain_class('nebula::profile::users') }
 
       if os == 'debian-11-x86_64'
-
-        # These tests fail with puppet php module version 7.1.0 but should pass with 8.0.0
-        xit { is_expected.not_to contain_package('php5-common') }
-        xit { is_expected.not_to contain_package('php5-dev') }
+        it { is_expected.not_to contain_package('php5-common') }
+        it { is_expected.not_to contain_package('php5-dev') }
         it { is_expected.to contain_package('libapache2-mod-shib') }
         it { is_expected.not_to contain_package('libapache2-mod-shib2') }
         it { is_expected.to contain_package('mariadb-client') }


### PR DESCRIPTION
This is a minimal change to the `debian_11_support` branch to fully support PHP with Debian 11.

:warning: **DO NOT MERGE UNTIL ALL STRETCH MACHINES ARE RETIRED**