### PR TITLE
20220525 logrotate bugfix

### DIFF
--- a/manifests/profile/fulcrum/logrotate.pp
+++ b/manifests/profile/fulcrum/logrotate.pp
@@ -14,5 +14,8 @@ class nebula::profile::fulcrum::logrotate {
     ifempty       => false,
     delaycompress => true,
     copytruncate  => true,
+    su            => true,
+    su_user       => 'fulcrum',
+    su_group      => 'fulcrum',
   }
 }

--- a/manifests/profile/logrotate.pp
+++ b/manifests/profile/logrotate.pp
@@ -17,13 +17,15 @@ class nebula::profile::logrotate {
       create_mode  => '0660',
       create_owner => 'root',
       create_group => 'utmp',
-      rotate       => 1,
+      rotate       => 4,
       ;
-    'debian_wtmp':
+# Override the logrotate module definition for 
+# wtmp and btmp to apply our preferred 4 x weekly schedule 
+    'wtmp':
       path        => '/var/log/wtmp',
       create_mode => '0664',
       ;
-    'debian_btmp':
+    'btmp':
       path        => '/var/log/btmp',
       ;
   }

--- a/spec/classes/profile/fulcrum/logrotate_spec.rb
+++ b/spec/classes/profile/fulcrum/logrotate_spec.rb
@@ -24,6 +24,9 @@ describe 'nebula::profile::fulcrum::logrotate' do
           .with_ifempty(false)
           .with_delaycompress(true)
           .with_copytruncate(true)
+          .with_su(true)
+          .with_su_user('fulcrum')
+          .with_su_group('fulcrum')
       end
     end
   end

--- a/spec/classes/profile/logrotate_spec.rb
+++ b/spec/classes/profile/logrotate_spec.rb
@@ -24,26 +24,26 @@ describe 'nebula::profile::logrotate' do
       # reason to stop doing that, although we switched them from
       # monthly to weekly, as they can get very large otherwise.
       it "contains debian's wtmp logrotate config" do
-        is_expected.to contain_logrotate__rule('debian_wtmp').with(
+        is_expected.to contain_logrotate__rule('wtmp').with(
           path: '/var/log/wtmp',
           missingok: true,
           rotate_every: 'week',
           create_mode: '0664',
           create_owner: 'root',
           create_group: 'utmp',
-          rotate: 1,
+          rotate: 4,
         )
       end
 
       it "contains debian's btmp logrotate config" do
-        is_expected.to contain_logrotate__rule('debian_btmp').with(
+        is_expected.to contain_logrotate__rule('btmp').with(
           path: '/var/log/btmp',
           missingok: true,
           rotate_every: 'week',
           create_mode: '0660',
           create_owner: 'root',
           create_group: 'utmp',
-          rotate: 1,
+          rotate: 4,
         )
       end
     end


### PR DESCRIPTION
This PR includes a commit that fixes fulcrum application log rotation and a commit that fixes our override of btmp and wtmp log rotation.