### PR TITLE
HathiTrust DEV-316: CRMS_INSTANCE only set for production

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -21,6 +21,7 @@ class nebula::profile::hathitrust::apache::babel (
   String $dex_endpoint,
   String $ptsearch_solr,
   String $ptsearch_solr_basic_auth,
+  Boolean $prod_crms_instance = true,
   Array[String] $cache_paths = [ ],
 ) {
 
@@ -137,8 +138,9 @@ class nebula::profile::hathitrust::apache::babel (
 
     setenvifnocase              => [
       "Host ^crms-training.${servername} CRMS_INSTANCE=crms-training",
-      "Host ^${servername} CRMS_INSTANCE=production"
-    ],
+    ] + if($prod_crms_instance) {
+      ["Host ^${servername} CRMS_INSTANCE=production"]
+    } else{ [] },
 
     rewrites                    => [
       {

--- a/spec/classes/profile/hathitrust/apache/babel_spec.rb
+++ b/spec/classes/profile/hathitrust/apache/babel_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::hathitrust::apache::babel' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:pre_condition) { "include apache" }
+
+      let(:base_params) { {
+        sdrroot: '',
+        sdremail: '',
+        default_access: { enforce: 'all', requires: ['all denied'] },
+        haproxy_ips: [],
+        ssl_params: {},
+        prefix: '',
+        domain: 'hathitrust.org',
+      } }
+
+      let(:params) { base_params }
+
+      describe "CRMS_INSTANCE" do
+
+        it do 
+          is_expected.to contain_apache__vhost('babel.hathitrust.org ssl')
+          .with_setenvifnocase([
+            "Host ^crms-training.babel.hathitrust.org CRMS_INSTANCE=crms-training",
+            "Host ^babel.hathitrust.org CRMS_INSTANCE=production",
+          ])
+        end
+
+        context("with prod_crms_instance set to false") do
+          let(:params) { base_params.merge(prod_crms_instance: false) }
+          it do 
+            is_expected.to contain_apache__vhost('babel.hathitrust.org ssl')
+            .with_setenvifnocase([
+              "Host ^crms-training.babel.hathitrust.org CRMS_INSTANCE=crms-training",
+            ])
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
This supports the need to vary `CRMS_INSTANCE` based on whether a vhost is development or production (-ish).

- `CRMS_INSTANCE=production` for actual production as well as for `preview.babel.hathitrust.org`
- Not set by default elsewhere

This isn't the prettiest fix. Currently, I'm expecting to override this via hiera where needed -- while it might be nice to set it via the test vs. prod role, that would (I think) necessitate changes to a long chain of included files:

- `nebula::role::webhost::htvm::test` and `::htvm::prod` both include
- `nebula::role::webhost::htvm` includes
- `nebula::profile::hathitrust::apache` includes
- `nebula::profile::hathitrust::apache::babel`

If anybody has a more elegant way to vary this than what's given here, I'm all for it, but I don't think it's worth spending a lot of time on at this point.


