### PR TITLE
Export haproxy backends with max instead of min

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -328,7 +328,7 @@ groups:
   - record: backend_datacenter:haproxy_server_up:count_servers_per_backend
     expr: >
       count without(server)(
-        min without(hostname, instance, priority)(
+        max without(hostname, instance, priority)(
           haproxy_server_up
         )
       )
@@ -336,7 +336,7 @@ groups:
   - record: backend_datacenter:haproxy_server_up:sum_servers_up_per_backend
     expr: >
       sum without(server)(
-        min without(hostname, instance, priority)(
+        max without(hostname, instance, priority)(
           haproxy_server_up
         )
       )


### PR DESCRIPTION
When an haproxy server is down, it exports 0 backends, so alerts based
on these metrics were firing every time any single haproxy server went
down. Using max instead of min will mean that if any haproxy server is
detecting a backend as up, that'll be enough.