### PR TITLE
Update quod-prod profile perl dependencies for bullseye

### DIFF
--- a/manifests/profile/quod/prod/perl.pp
+++ b/manifests/profile/quod/prod/perl.pp
@@ -16,7 +16,6 @@ class nebula::profile::quod::prod::perl () {
     'libmime-base32-perl',
     'libarchive-extract-perl',
     'libcgi-fast-perl',
-    'libcpan-meta-perl',
     'libcrypt-ssleay-perl',
     'libdata-section-perl',
     'libfcgi-perl',


### PR DESCRIPTION
- remove libcpan-meta-perl (not present in bullseye and no replacement needed)
