### PR TITLE
Set UseCanonicalName

### DIFF
--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -112,6 +112,7 @@ class nebula::profile::hathitrust::apache (
   }
   class { 'apache::mod::proxy_fcgi': }
   class { 'apache::mod::reqtimeout': }
+  class { 'apache::mod::setenvif': }
   class { 'apache::mod::shib': }
 
   class { 'apache::mod::remoteip':
@@ -161,7 +162,7 @@ class nebula::profile::hathitrust::apache (
   }
 
 
-  ['redirection','babel','www','catalog'].each |$vhost| {
+  ['redirection','babel','www','catalog','crms_training'].each |$vhost| {
     class { "${title}::${vhost}":
       * =>  $default_vhost_params
     }

--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -89,7 +89,7 @@ class nebula::profile::hathitrust::apache::babel (
 
   apache::vhost { "${servername} ssl":
     servername                  => $servername,
-    serveraliases               => [ "crms-training.${servername}" ],
+    use_canonical_name          => 'On',
     port                        => '443',
     docroot                     => $sdrroot,
     manage_docroot              => false,
@@ -134,12 +134,8 @@ class nebula::profile::hathitrust::apache::babel (
       "ASSERTION_EMAIL ${sdremail}",
       "PTSEARCH_SOLR ${ptsearch_solr}",
       "PTSEARCH_SOLR_BASIC_AUTH ${ptsearch_solr_basic_auth}"
-    ],
-
-    setenvifnocase              => [
-      "Host ^crms-training.${servername} CRMS_INSTANCE=crms-training",
     ] + if($prod_crms_instance) {
-      ["Host ^${servername} CRMS_INSTANCE=production"]
+      ['CRMS_INSTANCE production']
     } else{ [] },
 
     rewrites                    => [

--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -35,17 +35,18 @@ class nebula::profile::hathitrust::apache::catalog (
   }
 
   apache::vhost { "${servername} ssl":
-    servername        => $servername,
-    port              => 443,
-    manage_docroot    => false,
-    docroot           => $docroot,
-    error_log_file    => 'catalog/error.log',
-    access_log_file   => 'catalog/access.log',
-    access_log_format => 'combined',
-    directoryindex    => 'index.html index.htm index.php index.phtml index.shtml',
-    *                 => $ssl_params,
+    servername         => $servername,
+    use_canonical_name => 'On',
+    port               => 443,
+    manage_docroot     => false,
+    docroot            => $docroot,
+    error_log_file     => 'catalog/error.log',
+    access_log_file    => 'catalog/access.log',
+    access_log_format  => 'combined',
+    directoryindex     => 'index.html index.htm index.php index.phtml index.shtml',
+    *                  => $ssl_params,
 
-    directories       => [
+    directories        => [
       {
         provider => 'filesmatch',
         path     =>  '~$',
@@ -65,7 +66,7 @@ class nebula::profile::hathitrust::apache::catalog (
       },
     ],
 
-    aliases           => [
+    aliases            => [
       {
         aliasmatch => '^/favicon.ico$',
         path       => "${sdrroot}/common/web/favicon.ico"
@@ -76,7 +77,7 @@ class nebula::profile::hathitrust::apache::catalog (
       }
     ],
 
-    rewrites          => [
+    rewrites           => [
       {
 
         # redirect top-level page to www.hathitrust.org, but not for mobile or orphanworks host names

--- a/manifests/profile/hathitrust/apache/crms_training.pp
+++ b/manifests/profile/hathitrust/apache/crms_training.pp
@@ -1,0 +1,214 @@
+# Copyright (c) 2018 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::apache::crms_training
+#
+# crms-training.babel.hathitrust.org virtual host
+#
+# @example
+#   include nebula::profile::hathitrust::apache::crms_training
+class nebula::profile::hathitrust::apache::crms_training (
+  String $sdrroot,
+  Hash $default_access,
+  Array[String] $haproxy_ips,
+  Hash $ssl_params,
+  String $prefix,
+  String $domain,
+) {
+
+  ## VHOST DEFINITION
+
+  $servername = "crms-training.${prefix}babel.${domain}"
+
+  $imgsrv_address = lookup('nebula::profile::hathitrust::imgsrv::bind');
+
+  apache::vhost { "${servername} ssl":
+    servername            => $servername,
+    use_canonical_name    => 'On',
+    port                  => '443',
+    docroot               => $sdrroot,
+    manage_docroot        => false,
+    error_log_file        => 'crms-training/error.log',
+    access_log_file       => 'crms-training/access.log',
+    access_log_format     => 'combined',
+    *                     => $ssl_params,
+
+    # from babel-common
+
+    aliases               => [
+      {
+        aliasmatch => '^/robots.txt$',
+        path       => "${sdrroot}/common/web/robots.txt"
+      },
+      {
+        aliasmatch => '^/favicon.ico$',
+        path       => "${sdrroot}/common/web/favicon.ico"
+      },
+      {
+        # Used for example logo and style sheet in error templates.
+        alias => '/shibboleth-sp/main.css',
+        path  => '/usr/share/shibboleth/main.css'
+      }
+    ],
+
+    directoryindex        => 'index.html',
+
+    setenv                => [
+      "SDRROOT ${sdrroot}",
+      'SDRDATAROOT /sdr1',
+      'CRMS_INSTANCE crms-training',
+    ],
+
+    rewrites              => [
+      {
+        # Map web content URLs to the web directories within each application repository,
+        # if the file being requested exists.
+        #
+        # URLs are of the form /app/foobar and are mapped to /app/web/foobar.
+        #
+        # 2010-10-01 skorner
+        # it also supports a comment => '' field; not sure if we want to use that
+        rewrite_cond => ['%{DOCUMENT_ROOT}/$1/web/$2 -f'],
+        rewrite_rule => ['^/([^/]+)/(.*)       /$1/web/$2        [last]'],
+      },
+      {
+        # Map bare application directory URLs to allow for auto loading of index files.
+        #
+        # URLs of the form /app or /app/ are mapped to /app/web/ to auto serve /app/web/index.*
+        #
+        # 2011-11-30 rrotter
+        rewrite_cond => ['%{DOCUMENT_ROOT}/$1/web/ -d'],
+        rewrite_rule => ['^/([^/]+)/?$ /$1/web/ [last]'],
+      },
+
+      {
+
+        # serve ht widgets from /widgets/<widget name>/web/
+        #
+        # 2012-12-10 skorner
+        rewrite_cond => ['%{DOCUMENT_ROOT}/widgets/$1/web/$2 -f'],
+        rewrite_rule => ['^/widgets/([^/]+)/(.*)      /widgets/$1/web/$2      [last]'],
+      },
+
+
+      # FROM SSL
+
+      {
+        # Map cgi URLs of the traditional /cgi/app form to the cgi directories within
+        # each application repository, if the cgi being requested exists.  Also
+        # support a second level of cgi for flexibility.  Any path info formatted
+        # arguments are carried along in both cases.
+        #
+        # URLs are of the form /cgi/app and are mapped to /app/cgi/app, and
+        # /cgi/app/subdir/foobar to /app/cgi/subdir/foobar.
+        #
+        # For URLs of the form /cgi/APP/PATHINFO where a FastCGI socket exists for
+        # APP and PATHINFO doesn't match any other existing CGI, the FastCGI socket
+        # will be used and PATHINFO arguments carried along. If another script exists
+        # that matches PATHINFO (e.g. /imgsrv/pdf), that will be used instead of the
+        # FastCGI socket.
+        #
+        # Order is important; the longer pathname is matched first.
+        #
+        # The passthrough is required to pick up both the access control and cgi
+        # DirectoryMatch defined globally.
+        #
+        # 2011-04-20 aelkiss
+        # 2011-12-12 skorner
+
+        # If /htapps/VHOST/APP/cgi/SCRIPT exists, rewrite /cgi/APP/SCRIPT/PATHINFO
+        # to /APP/cgi/SCRIPT/PATHINFO and stop
+        rewrite_cond => ['  %{DOCUMENT_ROOT}/$2/cgi/$3 -f'],
+        rewrite_rule => ['  ^/(shcgi|cgi)/([^/]+)/([^/]+)(.*)$  /$2/cgi/$3$4        [skip]']
+      },
+
+      {
+        # If the above rule didn't get used see if /htapps/VHOST/APP/cgi/APP exists,
+        # and rewrite /cgi/APP/PATHINFO to /APP/cgi/APP/PATHINFO
+        rewrite_cond => ['  %{DOCUMENT_ROOT}/$2/cgi/$2 -f'],
+        rewrite_rule => ['  ^/(shcgi|cgi)/([^/]+)(.*)$    /$2/cgi/$2$3'],
+      },
+
+      {
+        # If there is a PSGI "choke" wrapper, invoke that so that the
+        # request is considered for throttling
+        rewrite_cond => ['  %{DOCUMENT_ROOT}/$1/cgi/$3.choke -f'],
+        rewrite_rule => ['  ^/([^/]+)/(shcgi|cgi)/([^/]+)(.*)$  /$1/cgi/$3.choke$4      [last]'],
+      },
+
+      {
+        rewrite_rule => ["  ^(/$|/index.html$)      https://${servername}/cgi/crms  [redirect=permanent,last]"],
+      },
+
+
+    ],
+
+    directories           => [
+      {
+        provider => 'filesmatch',
+        location =>  '~$',
+        require  => 'all denied'
+      },
+      {
+        provider       => 'directory',
+        location       => $sdrroot,
+        allow_override => ['None'],
+        require        =>  'all denied'
+      },
+      {
+        provider              => 'location',
+        path                  => '/',
+        auth_type             => 'shibboleth',
+        require               => 'shibboleth',
+        shib_request_settings => { 'requireSession' => '0'}
+      },
+      {
+        # Grant access to necessary directories under the document root:
+        # ${sdrroot}/*/cgi
+        # ${sdrroot}/*/web
+        # ${sdrroot}/cache
+        #
+        # 2010-10-01 skorner
+        provider => 'directorymatch',
+        path     => "^(${sdrroot}/(([^/]+)/(web|cgi)|widgets/([^/]+)/web|cache|mdp-web)/)(.*)",
+        require  => $default_access
+      },
+      {
+        # Enable cgi execution under ${sdrroot}/*/cgi.
+        #
+        # 2010-10-01 skorner
+        provider       => 'directorymatch',
+        path           => "^${sdrroot}/([^/]+)/cgi",
+        allow_override => 'None',
+        options        => '+ExecCGI',
+        sethandler     => 'cgi-script',
+        require        => 'unmanaged'
+      },
+      {
+        # An Apache handler needs to be established for the "handler" location.
+        # This applies the handler to any requests for a resource with a ".sso"
+        # extension.
+        #
+        # Note: this makes *.sso files (and therefore shib session initiation)
+        # public to any shib idp, but the alternatives (maintaining separate
+        # ACLs for *.sso in each vhost, or devising a scheme with environment
+        # variables and ugly IP range regexps) seem unacceptably complex
+        provider   => 'files',
+        path       => '*.sso',
+        sethandler => 'shib-handler',
+        require    => 'all granted'
+      },
+      {
+        provider => 'locationmatch',
+        path     => '^/shibboleth-sp/main.css',
+        require  => 'all granted'
+      },
+
+    ],
+
+    allow_encoded_slashes => 'on',
+
+  }
+
+}

--- a/manifests/profile/hathitrust/apache/www.pp
+++ b/manifests/profile/hathitrust/apache/www.pp
@@ -35,18 +35,19 @@ class nebula::profile::hathitrust::apache::www (
   $servername = "${prefix}www.${domain}"
 
   apache::vhost { "${servername} ssl":
-    servername        => $servername,
-    port              => '443',
-    manage_docroot    => false,
-    docroot           => $docroot,
-    error_log_file    => 'www/error.log',
-    access_log_file   => 'www/access.log',
-    access_log_format => 'combined',
-    setenv            => ["SDRROOT ${docroot}"],
-    directoryindex    => 'index.html index.htm index.php index.phtml index.shtml',
-    *                 => $ssl_params,
+    servername         => $servername,
+    use_canonical_name => 'On',
+    port               => '443',
+    manage_docroot     => false,
+    docroot            => $docroot,
+    error_log_file     => 'www/error.log',
+    access_log_file    => 'www/access.log',
+    access_log_format  => 'combined',
+    setenv             => ["SDRROOT ${docroot}"],
+    directoryindex     => 'index.html index.htm index.php index.phtml index.shtml',
+    *                  => $ssl_params,
 
-    directories       => [
+    directories        => [
       {
         provider => 'filesmatch',
         location =>  '~$',
@@ -76,7 +77,7 @@ class nebula::profile::hathitrust::apache::www (
       }
     ],
 
-    aliases           => [
+    aliases            => [
       {
         aliasmatch => '^/favicon.ico$',
         path       => "${sdrroot}/common/web/favicon.ico"
@@ -87,7 +88,7 @@ class nebula::profile::hathitrust::apache::www (
       }
     ],
 
-    rewrites          => [
+    rewrites           => [
       {
         # Serve static assets through apache
         rewrite_cond => '/htapps/apps/usdocs_registry/public/$1 -f',
@@ -95,7 +96,7 @@ class nebula::profile::hathitrust::apache::www (
       }
     ],
 
-    proxy_pass        => [
+    proxy_pass         => [
       {
         path   => '/usdocs_registry',
         url    => 'http://apps-ht:30001/',
@@ -103,7 +104,7 @@ class nebula::profile::hathitrust::apache::www (
       }
     ],
 
-    headers           => 'set "Strict-Transport-Security" "max-age=31536000"',
+    headers            => 'set "Strict-Transport-Security" "max-age=31536000"',
 
   }
 }

--- a/spec/classes/profile/hathitrust/apache/babel_spec.rb
+++ b/spec/classes/profile/hathitrust/apache/babel_spec.rb
@@ -13,8 +13,8 @@ describe 'nebula::profile::hathitrust::apache::babel' do
       let(:pre_condition) { "include apache" }
 
       let(:base_params) { {
-        sdrroot: '',
-        sdremail: '',
+        sdrroot: '/sdrroot',
+        sdremail: 'sdremail@default.invalid',
         default_access: { enforce: 'all', requires: ['all denied'] },
         haproxy_ips: [],
         ssl_params: {},
@@ -26,21 +26,18 @@ describe 'nebula::profile::hathitrust::apache::babel' do
 
       describe "CRMS_INSTANCE" do
 
-        it do 
-          is_expected.to contain_apache__vhost('babel.hathitrust.org ssl')
-          .with_setenvifnocase([
-            "Host ^crms-training.babel.hathitrust.org CRMS_INSTANCE=crms-training",
-            "Host ^babel.hathitrust.org CRMS_INSTANCE=production",
-          ])
+        let(:babel_env) do
+          catalogue.resource('apache::vhost','babel.hathitrust.org ssl')["setenv"]
+        end
+
+        it "sets crms_instance production" do 
+          expect(babel_env).to include("CRMS_INSTANCE production")
         end
 
         context("with prod_crms_instance set to false") do
           let(:params) { base_params.merge(prod_crms_instance: false) }
-          it do 
-            is_expected.to contain_apache__vhost('babel.hathitrust.org ssl')
-            .with_setenvifnocase([
-              "Host ^crms-training.babel.hathitrust.org CRMS_INSTANCE=crms-training",
-            ])
+          it "does not set CRMS_INSTANCE env var" do 
+            expect(babel_env).not_to include(/^CRMS_INSTANCE/)
           end
         end
 

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -63,7 +63,7 @@ describe 'nebula::profile::hathitrust::apache' do
       end
 
       describe 'Production HT hostnames' do
-        %w[babel catalog www].each do |vhost|
+        %w[babel catalog www crms-training.babel].each do |vhost|
           it {
             is_expected.to contain_apache__vhost("#{vhost}.hathitrust.org ssl").with(
               servername: "#{vhost}.hathitrust.org",


### PR DESCRIPTION
This is required for validating the "target" parameter in Shibboleth
sign on.

This also splits out crms-training to a separate vhost; this is required
so that Shibboleth knows the proper return target rather than having to
differentiate between crms-training.babel.hathitrust.org and
babel.hathitrust.org