### PR TITLE
HathiTrust DEV-345: fix redirect to WAYF in dev

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -264,7 +264,7 @@ class nebula::profile::hathitrust::apache::babel (
         path                  => '/',
         auth_type             => 'shibboleth',
         require               => 'shibboleth',
-        shib_request_settings => { 'requireSession' => '0'}
+        shib_request_settings => { 'requireSession' => '0', 'discoveryURL' => "https://${servername}/cgi/wayf" }
       },
       {
         # Grant access to necessary directories under the document root:

--- a/manifests/profile/hathitrust/apache/crms_training.pp
+++ b/manifests/profile/hathitrust/apache/crms_training.pp
@@ -23,7 +23,7 @@ class nebula::profile::hathitrust::apache::crms_training (
 
   $imgsrv_address = lookup('nebula::profile::hathitrust::imgsrv::bind');
 
-  file { "/var/log/apache2/crms-training":
+  file { '/var/log/apache2/crms-training':
     ensure => 'directory',
     mode   => '0755',
     owner  => 'root',


### PR DESCRIPTION
We rarely rely on the SP to use the configured WAYF session initiator;
rather, the applications redirect to the WAYF as necessary. However,
there are cases when we do, especially with Dex. This change ensures
that we redirect to the WAYF for the vhost we're accessing rather than
always redirecting to https://babel.hathitrust.org