### PR TITLE
Parameterize chain_crt for http fileservers

### DIFF
--- a/manifests/profile/http_fileserver.pp
+++ b/manifests/profile/http_fileserver.pp
@@ -11,7 +11,8 @@
 
 class nebula::profile::http_fileserver (
   String $storage_path,
-  String $docroot = '/srv/www'
+  String $docroot = '/srv/www',
+  String $chain_crt = 'incommon_sha2.crt'
 ) {
 
   package { 'nfs-common': }
@@ -35,7 +36,7 @@ class nebula::profile::http_fileserver (
   class { 'apache':
     docroot           => '/srv/www',
     default_mods      => false,
-    default_ssl_chain => '/etc/ssl/certs/incommon_sha2.crt',
+    default_ssl_chain => "/etc/ssl/certs/${chain_crt}",
     default_ssl_cert  => "/etc/ssl/certs/${::fqdn}.crt",
     default_ssl_key   => "/etc/ssl/private/${::fqdn}.key",
     default_vhost     => true,

--- a/spec/classes/profile/http_fileserver_spec.rb
+++ b/spec/classes/profile/http_fileserver_spec.rb
@@ -22,6 +22,7 @@ describe 'nebula::profile::http_fileserver' do
       it do
         is_expected.to contain_class('apache').with(
           docroot: '/srv/www',
+          default_ssl_chain: '/etc/ssl/certs/incommon_sha2.crt',
           default_ssl_cert: "/etc/ssl/certs/#{fqdn}.crt",
           default_ssl_key: "/etc/ssl/private/#{fqdn}.key",
         )
@@ -31,6 +32,15 @@ describe 'nebula::profile::http_fileserver' do
       it { is_expected.to contain_file("/etc/ssl/certs/#{fqdn}.crt") }
       it { is_expected.to contain_file("/etc/ssl/private/#{fqdn}.key") }
       it { is_expected.to contain_file('/etc/ssl/certs/intermediate_ca.crt') }
+
+      context "with chain_crt set to abc.crt" do
+        let(:params) do
+          super().merge(chain_crt: 'abc.crt')
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('apache').with_default_ssl_chain('/etc/ssl/certs/abc.crt') }
+      end
     end
   end
 end


### PR DESCRIPTION
Where we previously used incommon for everything, we're starting to use
letsencrypt now, which has a different chain.