### PR TITLE
TDX #3266774 - Restrict iframes for Deep Blue Documents

### DIFF
--- a/manifests/profile/www_lib/vhosts/deepblue.pp
+++ b/manifests/profile/www_lib/vhosts/deepblue.pp
@@ -133,6 +133,7 @@ class nebula::profile::www_lib::vhosts::deepblue (
 
     headers                       => [
       'set "Strict-Transport-Security" "max-age=3600"',
+      'set "X-Frame-Options" "SAMEORIGIN"',
     ],
 
     ssl_proxyengine               => true,


### PR DESCRIPTION
This should make it impossible for outside actors to place iframes around Deep Blue content. This could almost certainly be set by the application and/or in tomcat, but we saw no reason not to set it here.