### PR TITLE
Export ssh public keys for /etc/ssh/ssh_known_hosts files

### DIFF
--- a/manifests/profile/known_host_public_keys.pp
+++ b/manifests/profile/known_host_public_keys.pp
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# This only exports resources, so it doesn't directly affect anything
+# that uses it. To import the resources,
+#
+#     concat { '/etc/ssh/ssh_known_hosts': }
+#     Concat_fragment <<| tag == 'known_host_public_keys' |>>
+#
+# This will populate the host's system-wide known_hosts file with the
+# public ssh keys from every host that uses this profile. Note that this
+# only trusts the hosts; it does not actually grant access through a
+# firewall or anything.
+class nebula::profile::known_host_public_keys {
+  $::ssh.each |$name, $key_obj| {
+    $type = $key_obj["type"]
+    $key = $key_obj["key"]
+
+    @@concat_fragment { "known host ${::fqdn} ${name}":
+      tag     => 'known_host_public_keys',
+      target  => '/etc/ssh/ssh_known_hosts',
+      content => "${::fqdn} ${type} ${key}\n",
+    }
+  }
+}

--- a/manifests/profile/kubernetes/dns_client.pp
+++ b/manifests/profile/kubernetes/dns_client.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -17,5 +17,16 @@ class nebula::profile::kubernetes::dns_client {
 
   file { '/etc/resolv.conf':
     content => template('nebula/profile/kubernetes/dns/resolv.conf.erb'),
+  }
+
+  $::ssh.each |$name, $key_obj| {
+    $type = $key_obj["type"]
+    $key = $key_obj["key"]
+
+    @@concat_fragment { "known ${cluster_name} host ${::hostname} ${name}":
+      tag     => "${cluster_name}_known_host_public_keys",
+      target  => '/etc/ssh/ssh_known_hosts',
+      content => "${::hostname} ${type} ${key}\n",
+    }
   }
 }

--- a/manifests/profile/kubernetes/dns_server.pp
+++ b/manifests/profile/kubernetes/dns_server.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -53,6 +53,9 @@ class nebula::profile::kubernetes::dns_server {
       order   => '06',
     ;
   }
+
+  concat { '/etc/ssh/ssh_known_hosts': }
+  Concat_fragment <<| tag == "${cluster_name}_known_host_public_keys" |>>
 
   if $private_zones {
     $private_zones.each |Hash $zone| {

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 The Regents of the University of Michigan.
+# Copyright (c) 2018-2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -14,6 +14,7 @@ class nebula::role::minimum (
     include nebula::profile::work_around_puppet_bugs
     include nebula::profile::prometheus::exporter::node
     include nebula::profile::authorized_keys
+    include nebula::profile::known_host_public_keys
     include nebula::profile::falcon
 
     if $::lsbdistcodename != 'jessie' {

--- a/spec/classes/profile/known_host_public_keys_spec.rb
+++ b/spec/classes/profile/known_host_public_keys_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2022 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::known_host_public_keys' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with fqdn of example.invalid and some ssh public keys' do
+        let(:facts) do
+          {
+            'fqdn' => "example.invalid",
+            "ssh" => {
+              "ecdsa" => {
+                "type" => "ecdsa-sha2-nistp256",
+                "key" => "ecdsa_key"
+              },
+              "rsa" => {
+                "type" => "ssh-rsa",
+                "key" => "rsa_key"
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it "exports an ssh_known_hosts line for its ecdsa key" do
+          expect(exported_resources).to contain_concat_fragment("known host example.invalid ecdsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("known_host_public_keys")
+            .with_content("example.invalid ecdsa-sha2-nistp256 ecdsa_key\n")
+        end
+
+        it "exports an ssh_known_hosts line for its rsa key" do
+          expect(exported_resources).to contain_concat_fragment("known host example.invalid rsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("known_host_public_keys")
+            .with_content("example.invalid ssh-rsa rsa_key\n")
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/kubernetes/dns_client_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_client_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -33,6 +33,29 @@ describe 'nebula::profile::kubernetes::dns_client' do
       it do
         is_expected.to contain_file('/etc/resolv.conf')
           .with_content("search first.cluster\nnameserver 172.16.0.1\n")
+      end
+
+      context 'with fqdn of default.invalid and an ssh-rsa public key' do
+        let(:node) { "default.invalid" }
+        let(:facts) do
+          {
+            "ssh" => {
+              "rsa" => {
+                "type" => "ssh-rsa",
+                "key" => "abc123"
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it "exports an ssh_known_hosts line for its rsa key" do
+          expect(exported_resources).to contain_concat_fragment("known first_cluster host default rsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("first_cluster_known_host_public_keys")
+            .with_content("default ssh-rsa abc123\n")
+        end
       end
     end
   end

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'

--- a/spec/fixtures/hiera/kubernetes/default.yaml
+++ b/spec/fixtures/hiera/kubernetes/default.yaml
@@ -15,6 +15,7 @@ nebula::profile::kubernetes::clusters:
     etcd_address: 172.16.0.6
     kube_api_address: 172.16.0.7
     private_domain: first.cluster
+    control_dns: public.first.cluster
     docker_version: 5:18.09.6~3-0~debian-stretch
     kubernetes_version: 1.14.2
     service_cidr: "172.16.0.0/13"
@@ -37,6 +38,7 @@ nebula::profile::kubernetes::clusters:
     etcd_address: 172.16.1.6
     kube_api_address: 172.16.1.7
     private_domain: second.cluster
+    control_dns: public.second.cluster
     docker_version: 18.06.2~ce~3-0~debian
     kubernetes_version: 1.11.9
   implicit_docker_version:


### PR DESCRIPTION
As of writing, this will only affect the known hosts files on kubernetes gateway servers, but it also sets the stage for us to make a bastion host with always up to date known hosts.

Since exported resources are always a bit unintuitive, I'll take a moment to go over the intentions for bastion hosts:

1.  I want to use a bastion host to be able to connect to any accessible host without managing my local known_hosts file. (This is made possible by the known_host_public_keys profile.)
2.  I want to use a bastion host to be able to connect to private kubernetes hosts, using whichever gateway is currently claiming the cluster ip address as a jump host, without needing to specify primary or backup by name. (This is made possible by the addition made to the keepalived kubernetes profile.)
3.  I want to use a bastion host to be able to connect to private kubernetes hosts without managing my local known_hosts file. (This is made possible by the known_host_public_keys profile, since the kubernetes hosts will also use that profile and export their keys.)

And more intentions for kubernetes gateway hosts:

1.  I want to use a gateway node with `ssh -A` as a smaller-scale bastion host to engage with the private kubernetes hosts without managing my local known_hosts file. (The private hosts export their keys in dns_client, and the gateways import them to their system-wide known_hosts file in dns_server.)