### PR TITLE
Add MARC::File::MiJ Perl module for HathiTrust

### DIFF
--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -153,7 +153,8 @@ class nebula::profile::hathitrust::perl () {
     'Mozilla::CA',
     'Noid',
     'MARC::Record',
-    'MARC::File::XML']:
+    'MARC::File::XML',
+    'MARC::File::MiJ']:
   }
 
 }


### PR DESCRIPTION
Once caveat: trying to install this module on dev-2.babel with the `cpan` command resulted in an error seemingly related to the `ex::monkeypatched` dependency (yeah, nothing at all sketchy there). But, I was trying to do a local install on a chunk of filesystem under my control, which is nontypical usage.