### PR TITLE
Generate etcd yaml with erb

### DIFF
--- a/manifests/profile/kubernetes/bootstrap/etcd_config.pp
+++ b/manifests/profile/kubernetes/bootstrap/etcd_config.pp
@@ -1,9 +1,15 @@
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
 class nebula::profile::kubernetes::bootstrap::etcd_config {
   include nebula::profile::kubernetes::kubelet
+  $cluster_name = lookup('nebula::profile::kubernetes::cluster')
+  $cluster = lookup('nebula::profile::kubernetes::clusters')[$cluster_name]
+
+  $router_address = $cluster['router_address']
+  $private_domain = $cluster['private_domain']
+  $initial_cluster = $cluster['etcd_initial_cluster']
 
   file { '/etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf':
     content => template('nebula/profile/kubernetes/bootstrap/etcd/systemd.conf.erb'),
@@ -13,6 +19,13 @@ class nebula::profile::kubernetes::bootstrap::etcd_config {
 
   file { '/etc/systemd/system/kubelet.service.d':
     ensure => 'directory',
+  }
+
+  if $initial_cluster {
+    file { '/tmp/etcd.yaml':
+      ensure => 'file',
+      content => template('nebula/profile/kubernetes/etcd/etcd.yaml.erb'),
+    }
   }
 
   exec { 'kubelet reload daemon':

--- a/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
@@ -29,6 +29,14 @@ describe 'nebula::profile::kubernetes::bootstrap::etcd_config' do
           .with_refreshonly(true)
           .that_notifies('Service[kubelet]')
       end
+
+      it { is_expected.to contain_file('/tmp/etcd.yaml') }
+
+      context 'with cluster set to second_cluster' do
+        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+
+        it { is_expected.not_to contain_file('/tmp/etcd.yaml') }
+      end
     end
   end
 end

--- a/spec/fixtures/hiera/kubernetes/default.yaml
+++ b/spec/fixtures/hiera/kubernetes/default.yaml
@@ -23,6 +23,7 @@ nebula::profile::kubernetes::clusters:
     node_cidr: "172.28.0.0/14"
     dex_cluster_id: default-invalid
     dex_url: https://dex.default.invalid
+    etcd_initial_cluster: "some_string_here"
     bootstrap_keys:
       public: |
         first cluster public key value

--- a/templates/profile/kubernetes/etcd/etcd.yaml.erb
+++ b/templates/profile/kubernetes/etcd/etcd.yaml.erb
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: etcd
+    tier: control-plane
+  name: etcd
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - etcd
+    - --advertise-client-urls=https://<%= @router_address %>:2379
+    - --cert-file=/etc/kubernetes/pki/server.crt
+    - --client-cert-auth=true
+    - --data-dir=/var/lib/etcd
+    - --initial-advertise-peer-urls=https://<%= @ipaddress %>:2380
+    - --initial-cluster=<%= @initial_cluster %>
+    - --initial-cluster-state=new
+    - --key-file=/etc/kubernetes/pki/server.key
+    - --listen-client-urls=https://127.0.0.1:2379,https://<%= @ipaddress %>:2379
+    - --listen-peer-urls=https://<%= @ipaddress %>:2380
+    - --name=<%= @fqdn %>
+    - --peer-cert-file=/etc/kubernetes/pki/peer.crt
+    - --peer-client-cert-auth=true
+    - --peer-key-file=/etc/kubernetes/pki/peer.key
+    - --peer-trusted-ca-file=/etc/kubernetes/pki/ca.crt
+    - --snapshot-count=10000
+    - --trusted-ca-file=/etc/kubernetes/pki/ca.crt
+    - --listen-metrics-urls=http://127.0.0.1:2381
+    image: quay.io/coreos/etcd:v3.4.9
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 2381
+      failureThreshold: 8
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: etcd
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/etcd
+      name: etcd-data
+    - mountPath: /etc/kubernetes/pki
+      name: etcd-certs
+  hostNetwork: true
+  priorityClassName: system-cluster-critical
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/pki
+      type: DirectoryOrCreate
+    name: etcd-certs
+  - hostPath:
+      path: /var/lib/etcd
+      type: DirectoryOrCreate
+    name: etcd-data
+status: {}


### PR DESCRIPTION
Config is written to /tmp on etcd nodes, iff etcd_initial_cluster var is defined for the present cluster.

This approach requires moving /tmp/etcd.yaml manually. Could also write directly to /etc if we aren't concerned about etcd coming up w/o proper certs (or add additional conditional).