### PR TITLE
Stop managing fileserver directories on the puppetserver

### DIFF
--- a/manifests/profile/puppet/master.pp
+++ b/manifests/profile/puppet/master.pp
@@ -51,38 +51,6 @@ class nebula::profile::puppet::master (
     require => Package['puppetserver'],
   }
 
-  $fileservers.each |$name, $data| {
-    if $data =~ String {
-      $path = $data
-      $options = {}
-    } else {
-      $path = $data['location']
-
-      if 'options' in $data {
-        $options = $data['options']
-      } else {
-        $options = {}
-      }
-    }
-
-    file { $path:
-      ensure  => 'directory',
-      source  => "puppet:///${name}",
-      recurse => true,
-      purge   => true,
-      force   => true,
-      *       => $options,
-      require => Package['puppetserver'],
-    }
-
-    find_all_files_under($path).each |$f| {
-      file { "${path}/${f}":
-        ensure => 'file',
-        source => "puppet:///${name}/${f}",
-      }
-    }
-  }
-
   package { 'puppetserver':
     require => Rbenv::Gem['r10k', 'librarian-puppet'],
   }

--- a/spec/classes/profile/puppet/master_spec.rb
+++ b/spec/classes/profile/puppet/master_spec.rb
@@ -68,57 +68,6 @@ describe 'nebula::profile::puppet::master' do
         end
       end
 
-      %w[/default_invalid/opt/repos /default_invalid/opt/wherever /default_invalid/etc/ssl].each do |dir|
-        it do
-          is_expected.to contain_file(dir).with(
-            ensure: 'directory',
-            recurse: true,
-            purge: true,
-            force: true,
-            require: 'Package[puppetserver]',
-          )
-        end
-      end
-
-      it do
-        is_expected.to contain_file('/default_invalid/opt/repos')
-          .with_source('puppet:///repos')
-      end
-
-      it do
-        is_expected.to contain_file('/default_invalid/opt/wherever')
-          .with_source('puppet:///long-form-without-options')
-      end
-
-      it do
-        is_expected.to contain_file('/default_invalid/etc/ssl').with(
-          source: 'puppet:///ssl-certs',
-          owner: 'root',
-          group: 'wheel',
-          mode: '0700',
-        )
-      end
-
-      context 'when given a fileserver serving real_file.txt' do
-        let(:params) { { fileservers: { 'real_files' => 'spec/test_server' } } }
-
-        before(:each) do
-          `mkdir spec/test_server`
-          `touch spec/test_server/real_file.txt`
-        end
-
-        after(:each) do
-          `rm -r spec/test_server`
-        end
-
-        it do
-          is_expected.to contain_file('spec/test_server/real_file.txt').with(
-            ensure: 'file',
-            source: 'puppet:///real_files/real_file.txt',
-          )
-        end
-      end
-
       it do
         is_expected.to contain_package('puppetserver')
           .that_requires(['Rbenv::Gem[r10k]', 'Rbenv::Gem[librarian-puppet]'])


### PR DESCRIPTION
This practice has always been (a) weird and (b) of questionable value. The idea was that we're talking about the directories that puppet distributes files from, and the question is where those files come from. If they're unmanaged, when someone has to copy them by hand when creating a new puppetserver.

With this code, it was possible to create a new puppetserver and let the old puppetserver hand it all these files. In practice however, it also means that most of the time, when there's exactly one puppetserver, every 30 minutes, the puppetserver checks to make sure that every single file matches... itself. It's an increasingly expensive operation that cannot possibly accomplish anything of value.

Now that we're starting to add some certificate renewal automation to our existing certificate distribution flow, we have a conflict. Now there are two different file resources trying to claim control over those certificates.

Deleting all the fileserver directory management just for the sake of a handful of certs could look like throwing the baby out with the bathwater, but what I hope I've conveyed here is that there never was a baby in that bathwater.