### PR TITLE
Configure dnsmasq with the local domain

### DIFF
--- a/manifests/profile/kubernetes/dns_server.pp
+++ b/manifests/profile/kubernetes/dns_server.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2022-2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -56,6 +56,11 @@ class nebula::profile::kubernetes::dns_server {
 
   concat { '/etc/ssh/ssh_known_hosts': }
   Concat_fragment <<| tag == "${cluster_name}_known_host_public_keys" |>>
+
+  file { "/etc/dnsmasq.d/local_domain":
+    content => "local=/${private_domain}/\n",
+    notify  => Service['dnsmasq']
+  }
 
   if $private_zones {
     $private_zones.each |Hash $zone| {

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -76,6 +76,11 @@ describe 'nebula::profile::kubernetes::dns_server' do
         end
 
         it do
+          is_expected.to contain_file('/etc/dnsmasq.d/local_domain')
+            .with_content("local=/first.cluster/\n")
+        end
+
+        it do
           is_expected.to contain_concat_fragment('/etc/hosts ipv6 debian')
             .with_target('/etc/hosts')
             .with_order('06')
@@ -90,6 +95,11 @@ describe 'nebula::profile::kubernetes::dns_server' do
         it { is_expected.to compile }
 
         it { is_expected.not_to contain_file('/etc/dnsmasq.d/smartconnect') }
+
+        it do
+          is_expected.to contain_file('/etc/dnsmasq.d/local_domain')
+            .with_content("local=/second.cluster/\n")
+        end
       end
     end
   end


### PR DESCRIPTION
Without this configured, dnsmasq was checking every upstream for dns requests that were basically for `.cluster.default`. By setting this, dnsmasq will know that it is the authority for the domain, and it won't send a nonsense request upstream.