### PR TITLE
Purge support for copyright.umich.edu

### DIFF
--- a/manifests/profile/www_lib/apache/misc.pp
+++ b/manifests/profile/www_lib/apache/misc.pp
@@ -30,7 +30,6 @@ class nebula::profile::www_lib::apache::misc (
     [
       'apps.lib.umich.edu',
       'apps.staff.lib.umich.edu',
-      'copyright.umich.edu',
       'datamart.lib.umich.edu',
       'deepblue.lib.umich.edu',
       'developingwritersbook.com',

--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -103,25 +103,6 @@ class nebula::profile::www_lib::vhosts::redirects(
     ]
   }
 
-  nebula::apache::redirect_vhost_http { 'copyright.umich.edu':
-    serveraliases => ['www.copyright.umich.edu'],
-    target        => 'https://copyright.umich.edu/'
-  }
-
-  nebula::apache::www_lib_vhost { 'copyright.umich.edu-redirect-https-all':
-    priority      => false,
-    ssl           => true,
-    ssl_cn        => 'copyright.umich.edu',
-    docroot       => false,
-    servername    => 'copyright.umich.edu',
-    serveraliases => ['www.copyright.umich.edu'],
-    rewrites      => [
-      {
-        rewrite_rule => ['^/.*$ https://www.lib.umich.edu/copyright/?utm_source=copyright.umich.edu&utm_medium=redirect [redirect,noescape]']
-      }
-    ]
-  }
-
   apache::vhost { 'searchtools.lib.umich.edu-redirect-http':
     priority      => false,
     port          => '80',

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -214,19 +214,6 @@ describe 'nebula::role::webhost::www_lib_vm' do
       end
 
       it do
-        is_expected.to contain_apache__vhost('copyright.umich.edu-redirect-http')
-          .with_servername('copyright.umich.edu')
-          .with_port(80)
-      end
-
-      it do
-        is_expected.to contain_apache__vhost('copyright.umich.edu-redirect-https-all')
-          .with_servername('copyright.umich.edu')
-          .with_ssl_cert('/etc/ssl/certs/copyright.umich.edu.crt')
-          .with_port(443)
-      end
-
-      it do
         is_expected.to contain_apache__vhost('apps.lib-https')
           .with(servername: 'apps.lib.umich.edu',
                 port: 443,


### PR DESCRIPTION
This domain has been sunset per the Library Copyright office and in coordination with ITS.