### PR TITLE
Set Fulcrum env vars in .profile, not only in systemd EnvironmentFile

### DIFF
--- a/manifests/profile/fulcrum/app.pp
+++ b/manifests/profile/fulcrum/app.pp
@@ -152,6 +152,22 @@ class nebula::profile::fulcrum::app (
     notify  => Service['fulcrum'],
   }
 
+  file_line { 'fulcrum-profile-rails-env':
+    ensure => present,
+    path   => '/fulcrum/.profile',
+    line   => 'export RAILS_ENV=production',
+    match  => '^export RAILS_ENV=',
+    require => User['fulcrum'],
+  }
+
+  file_line { 'fulcrum-profile-bootsnap-cache':
+    ensure  => present,
+    path    => '/fulcrum/.profile',
+    line    => 'export BOOTSNAP_CACHE_DIR=/fulcrum/tmp',
+    match   => '^export BOOTNSAP_CACHE_DIR=',
+    require => User['fulcrum'],
+  }
+
   service { 'fulcrum':
     ensure  => 'running',
     enable  => true,


### PR DESCRIPTION
There is no good way to use something shell-compatible in systemd and there is no good way to use something systemd-compatible in the shell.

So, we JRO: Just Repeat Ourselves.