### PR TITLE
Add ImageMagick policy for fulcrum app servers

### DIFF
--- a/manifests/profile/fulcrum/app.pp
+++ b/manifests/profile/fulcrum/app.pp
@@ -7,6 +7,7 @@
 class nebula::profile::fulcrum::app (
   Array $authorized_keys = [],
   String $private_address_template = '192.168.0.%s',
+  String $image_magick_secret = 'secret',
 ) {
   $jdk_version = lookup('nebula::jdk_version')
 
@@ -126,6 +127,11 @@ class nebula::profile::fulcrum::app (
   file { '/usr/local/bin/fits.sh':
     ensure => 'symlink',
     target => '/usr/local/fits/fits.sh',
+  }
+
+  file { '/etc/ImageMagick-6/policy.xml':
+    content => template('nebula/profile/fulcrum/imagemagick-policy.xml.erb'),
+    require => Package['imagemagick'],
   }
 
   file { '/etc/systemd/system/fulcrum.target':

--- a/templates/profile/fulcrum/imagemagick-policy.xml.erb
+++ b/templates/profile/fulcrum/imagemagick-policy.xml.erb
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Managed by puppet (nebula/profile/fulcrum/imagemagick-policy.xml.erb) -->
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+  
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Let's prevent possible exploits by removing the right to use indirect reads.
+
+    <policy domain="path" rights="none" pattern="@*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, width, height, and disk resources
+  with SI prefixes (.e.g 100MB).  In addition, resource policies are maximums
+  for each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <policy domain="resource" name="memory" value="256MiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="width" value="16KP"/>
+  <policy domain="resource" name="height" value="16KP"/>
+  <policy domain="resource" name="area" value="128MB"/>
+  <policy domain="resource" name="disk" value="10GiB"/>
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <!-- not needed due to the need to use explicitly by mvg: -->
+  <!-- <policy domain="delegate" rights="none" pattern="MVG" /> -->
+  <!-- use curl -->
+  <policy domain="delegate" rights="none" pattern="URL" />
+  <policy domain="delegate" rights="none" pattern="HTTPS" />
+  <policy domain="delegate" rights="none" pattern="HTTP" />
+  <!-- in order to avoid to get image with password text -->
+  <policy domain="path" rights="none" pattern="@*"/>
+  <policy domain="cache" name="shared-secret" value="<%= @image_magick_secret %>" stealth="true"/>
+</policymap>


### PR DESCRIPTION
The large images and PDFs that we process require a specialized configuration for ImageMagick.