### PR TITLE
Add logrotate for keycard/checkpoint

### DIFF
--- a/manifests/profile/fulcrum/logrotate.pp
+++ b/manifests/profile/fulcrum/logrotate.pp
@@ -18,4 +18,18 @@ class nebula::profile::fulcrum::logrotate {
     su_user       => 'fulcrum',
     su_group      => 'fulcrum',
   }
+
+  logrotate::rule { 'fulcrum-keycard':
+    path          => '/fulcrum/app/releases/*/db/*.log',
+    rotate        => 7,
+    rotate_every  => 'day',
+    missingok     => true,
+    compress      => true,
+    ifempty       => false,
+    delaycompress => false,
+    copytruncate  => true,
+    su            => true,
+    su_user       => 'fulcrum',
+    su_group      => 'fulcrum',
+  }
 }


### PR DESCRIPTION
The logs for keycard and checkpoint are currently going to the current release directory, inside db/. They are also currently quite noisy, so we make sure to rotate them. They will probably go to the shared directory and will be picked up by the normal rules at some point.