### PR TITLE
Purge Cosign from the www.lib fallback vhost

### DIFF
--- a/manifests/profile/www_lib/vhosts/mgetit.pp
+++ b/manifests/profile/www_lib/vhosts/mgetit.pp
@@ -48,7 +48,7 @@ class nebula::profile::www_lib::vhosts::mgetit (
 
     ssl                         => true,
     ssl_cn                      => $ssl_cn,
-    cosign                      => true,
+    cosign                      => false,
     usertrack                   => true,
 
     setenv                      => ['HTTPS on'],
@@ -77,13 +77,6 @@ class nebula::profile::www_lib::vhosts::mgetit (
         options        => 'FollowSymlinks',
         allow_override => 'None',
         require        => $nebula::profile::www_lib::apache::default_access,
-      },
-      {
-        provider        => 'location',
-        path            => '/login',
-        auth_type       => 'cosign',
-        auth_require    => 'valid-user',
-        custom_fragment => 'CosignAllowPublicAccess Off',
       },
     ],
 

--- a/manifests/profile/www_lib/vhosts/www_lib.pp
+++ b/manifests/profile/www_lib/vhosts/www_lib.pp
@@ -21,16 +21,9 @@ class nebula::profile::www_lib::vhosts::www_lib (
     servername                    => "${prefix}www.${domain}",
     ssl                           => true,
     usertrack                     => true,
-    cosign                        => true,
+    cosign                        => false,
     docroot                       => $docroot,
     directories                   => [
-      {
-        provider       => 'directory',
-        path           => "${www_lib_root}/cgi",
-        allow_override => ['None'],
-        options        => ['None'],
-        require        => $nebula::profile::www_lib::apache::default_access,
-      },
       {
         provider       => 'directory',
         path           => $docroot,

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -71,11 +71,6 @@ describe 'nebula::role::webhost::www_lib_vm' do
         is_expected.to contain_concat_file('/usr/local/lib/cgi-bin/monitor/monitor_config.yaml')
       end
 
-      it do
-        is_expected.to contain_concat_fragment('www.lib-ssl-cosign')
-          .with_content(%r{^\s*CosignCrypto\s*/etc/ssl/private/www.lib.umich.edu.key /etc/ssl/certs/www.lib.umich.edu.crt /etc/ssl/certs})
-      end
-
       # from hiera
       it { is_expected.to contain_host('mysql-web').with_ip('10.0.0.123') }
 


### PR DESCRIPTION
There is no valid weblogin use case for www.lib, so we can remove it.

Also purge Cosign from mgetit.lib where it was never in use.