### PR TITLE
Switch PHP 7.3 to 8.1 for "www-lib" VMs

### DIFF
--- a/manifests/profile/www_lib/php.pp
+++ b/manifests/profile/www_lib/php.pp
@@ -9,7 +9,7 @@
 # @example
 #   include nebula::profile::www_lib::php
 class nebula::profile::www_lib::php (
-  String $default_php_version = '7.3'
+  String $default_php_version = '8.1'
 ) {
 
   # Set the php repo
@@ -51,7 +51,6 @@ class nebula::profile::www_lib::php (
       "php${default_php_version}-xdebug",
       "php${default_php_version}-curl",
       "php${default_php_version}-gd",
-      "php${default_php_version}-json",
       "php${default_php_version}-ldap",
       "php${default_php_version}-mbstring",
       "php${default_php_version}-mysql",

--- a/manifests/profile/www_lib/vhosts/apps_lib.pp
+++ b/manifests/profile/www_lib/vhosts/apps_lib.pp
@@ -107,7 +107,7 @@ class nebula::profile::www_lib::vhosts::apps_lib (
         addhandlers    => [{
           extensions => ['.php'],
           # TODO: Extract version or socket path to params/hiera
-          handler    => 'proxy:unix:/run/php/php7.3-fpm.sock|fcgi://localhost'
+          handler    => 'proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost'
         }],
       },
       {

--- a/manifests/profile/www_lib/vhosts/publishing.pp
+++ b/manifests/profile/www_lib/vhosts/publishing.pp
@@ -52,7 +52,7 @@ class nebula::profile::www_lib::vhosts::publishing (
         addhandlers    => [{
           extensions => ['.php'],
           # TODO: Extract version or socket path to params/hiera
-          handler    => 'proxy:unix:/run/php/php7.3-fpm.sock|fcgi://localhost'
+          handler    => 'proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost'
         }],
       }
     ],

--- a/manifests/profile/www_lib/vhosts/staff_lib.pp
+++ b/manifests/profile/www_lib/vhosts/staff_lib.pp
@@ -51,7 +51,7 @@ class nebula::profile::www_lib::vhosts::staff_lib (
         addhandlers    => [{
           extensions => ['.php'],
           # TODO: Extract version or socket path to params/hiera
-          handler    => 'proxy:unix:/run/php/php7.3-fpm.sock|fcgi://localhost'
+          handler    => 'proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost'
         }],
       },
       {

--- a/manifests/role/webhost/www_lib_vm.pp
+++ b/manifests/role/webhost/www_lib_vm.pp
@@ -24,7 +24,6 @@ class nebula::role::webhost::www_lib_vm (
 
   create_resources('host',$hosts)
 
-  #include nebula::profile::www_lib::php73
   include nebula::profile::www_lib::dependencies
   include nebula::profile::www_lib::perl
   include nebula::profile::www_lib::php

--- a/templates/profile/apache/authz_umichlib.conf.erb
+++ b/templates/profile/apache/authz_umichlib.conf.erb
@@ -10,5 +10,5 @@ DBDriver oracle
 
 DLPSAuthExemptionPolicy checkOnlyListed
 DLPSAuthExemptionPaths  /www/www.lib/cgi /www/staff.lib/web/coral /www/staff.lib/web/linkscan /www/staff.lib/web/linkscan117 /www/staff.lib/web/pagerate /www/staff.lib/web/ptf /www/staff.lib/web/ts /www/staff.lib/web/sites/staff.lib.umich.edu/local /www/staff.lib/web/funds_transfer /www/staff.lib/web/sites/staff.lib.umich.edu.funds_transfer /tb/www.lib/instruction-request /instruction/request
-DLPSAuthFilenameHandlers application/x-httpd-php bwshare-info bwshare-trace cgi-script cosign redirect-handler server-status drupal_security_do_not_remove_see_sa_2006_006 fcgid-script drupal_security_do_not_remove_see_sa_2013_003 shib-handler proxy:unix:/run/php/php7.3-fpm.sock|fcgi://localhost
+DLPSAuthFilenameHandlers application/x-httpd-php bwshare-info bwshare-trace cgi-script cosign redirect-handler server-status drupal_security_do_not_remove_see_sa_2006_006 fcgid-script drupal_security_do_not_remove_see_sa_2013_003 shib-handler proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost
 DLPSAuthURIHandlers jakarta-servlet proxy-server


### PR DESCRIPTION
Specific details of the changes:

- PHP has moved the json module into the core as of 8.x
- Parameterization that exists in php.pp is nice, but not useful considering www_lib::php is only used in one role and the version is not parameterized in the three vhosts that use modern php/fpm or in the authz file handler entry
- Thus I just updated the default from 7.3 to 8.1
- Leave the legacy 5.6 install as-is for legacy script support.
- Also remove the vestigial comment in the role from when we used www_lib::php73 directly (circa 2020)

These changes were applied to macc-www-lib-testing and verified by Eliot.