### PR TITLE
Prevent badrobots etc at location /

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -245,7 +245,10 @@ class nebula::profile::hathitrust::apache::babel (
         provider              => 'location',
         path                  => '/',
         auth_type             => 'shibboleth',
-        require               => 'shibboleth',
+        require               => {
+          enforce  => 'all',
+          requires => ['shibboleth'] + $default_access['requires']
+        },
         shib_request_settings => { 'requireSession' => '0', 'discoveryURL' => "https://${servername}/cgi/wayf" }
       },
       {


### PR DESCRIPTION
There is one particular IP address that has been issuing a large number of requests like

```
OPTIONS /cgi/pt/error
```

For whatever reason this wasn't being caught by the `DirectoryMatch` directives. This change should ensure that it does. I will verify on preview.babel that this doesn't interfere with any Shibboleth stuff.