### PR TITLE
Modify press_fcgi_check to report total restarts

### DIFF
--- a/templates/profile/www_lib/check_press.sh.erb
+++ b/templates/profile/www_lib/check_press.sh.erb
@@ -8,6 +8,20 @@ else
     sleep 5
     if ! /bin/nc -zw10 <%= @bind.sub(':', ' ') %>; then
       /bin/systemctl -q restart press
+      previous_restart_counter=`/usr/local/bin/pushgateway_advanced -j press_fcgi_check -q press_fcgi_check_restarts_total`
+      new_restart_count=`perl -e "printf(\"%d\\n\", $previous_restart_counter + 1);"`
+      cat <<EOF | /usr/local/bin/pushgateway_advanced -j press_fcgi_check
+# HELP press_fcgi_check_restarts_total Count of times we automatically restart press fcgi
+# TYPE press_fcgi_check_restarts_total counter
+press_fcgi_check_restarts_total $new_restart_count
+EOF
     fi
   fi
+
+  STOP_TIME=`date '+%s'`
+  cat <<EOF | /usr/local/bin/pushgateway_advanced -j press_fcgi_check
+# HELP press_fcgi_check_duration_seconds Time spent running press_fcgi_check
+# TYPE press_fcgi_check_duration_seconds gauge
+press_fcgi_check_duration_seconds `echo $STOP_TIME - $START_TIME | bc`
+EOF
 fi


### PR DESCRIPTION
We don't currently know how often this script actually does restart the press service. With this change, the script will increment a counter on the pushgateway every time it actually runs systemctl restart press, and if we're ever interested, we'll be able to see how often it comes up, if ever.