### PR TITLE
Add mod_auth_openidc support and migrate from cosign to auth_openidc for www_lib profile and vhosts

### DIFF
--- a/manifests/profile/apache/auth_openidc.pp
+++ b/manifests/profile/apache/auth_openidc.pp
@@ -1,0 +1,57 @@
+# Copyright (c) 2019-2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::apache::auth_openidc
+#
+# Configures auth_openidc for apache
+#
+# @param oidc_metadata The OIDC provider metadata URL, for example:
+#   "https://weblogin.lib.umich.edu/.well-known/openid-configuration"
+#
+# @param oidc_client_id The OIDC client ID, foir example
+#   "darkblue"
+#
+# @param oidc_client_secret The value of the secret shared by the client and provider
+#
+# @param oidc_crypto The hash used to encrypt the local session cache
+#   can be generated from "openssl rand -hex 128"
+#
+# @example
+#   include nebula::profile::apache::auth_openidc
+
+class nebula::profile::apache::auth_openidc (
+  String $oidc_metadata,
+  String $oidc_client_id,
+  String $oidc_client_secret,
+  String $oidc_crypto,
+) {
+
+  apache::mod { 'auth_openidc':
+    package       => 'libapache2-mod-auth-openidc',
+  }
+  include apache::mod::authn_core
+  include apache::mod::authz_user
+
+  file { 'auth_openidc.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/auth_openidc.conf",
+    mode    => '0700',
+    content => template('nebula/profile/apache/auth_openidc.conf.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['apache::service'],
+  }
+
+  file { '/var/cache/apache2/mod_auth_openidc':
+    ensure => 'directory',
+  }
+
+  file { '/var/cache/apache2/mod_auth_openidc/oidc-sessions':
+    ensure => 'directory',
+    owner  => 'nobody',
+    group  => 'nogroup',
+    mode   => '0700'
+  }
+
+}

--- a/manifests/profile/www_lib/apache/misc.pp
+++ b/manifests/profile/www_lib/apache/misc.pp
@@ -16,7 +16,7 @@ class nebula::profile::www_lib::apache::misc (
   String $domain = 'lib.umich.edu',
 ) {
   include nebula::profile::apache::authz_umichlib
-  include nebula::profile::apache::cosign
+  include nebula::profile::apache::auth_openidc
 
   class { 'apache::mod::php':
     # we'll configure php 7.3 separately

--- a/manifests/profile/www_lib/cron.pp
+++ b/manifests/profile/www_lib/cron.pp
@@ -40,12 +40,6 @@ class nebula::profile::www_lib::cron (
       user => 'root',
     ;
 
-    'purge cosign tickets':
-      hour    => 0,
-      minute  => 7,
-      command => '/usr/bin/find /var/cosign/filter -type f -mtime +1 -exec /bin/rm {} \; > /dev/null 2>&1',
-    ;
-
     'purge apache access logs 1/2':
       hour    => 1,
       minute  => 7,

--- a/manifests/profile/www_lib/dependencies.pp
+++ b/manifests/profile/www_lib/dependencies.pp
@@ -13,7 +13,6 @@ class nebula::profile::www_lib::dependencies {
 
   ensure_packages (
     [
-      'libapache2-mod-cosign',
       'curl',
       'git',
       'emacs',

--- a/manifests/profile/www_lib/vhosts/fulcrum.pp
+++ b/manifests/profile/www_lib/vhosts/fulcrum.pp
@@ -81,7 +81,7 @@ class nebula::profile::www_lib::vhosts::fulcrum (
       },
       {
         comment      => 'Reverse proxy application to app hostname and port',
-        rewrite_cond => ['%{REQUEST_URI} !^/cosign/valid', '%{REQUEST_URI} !^/Shibboleth.sso'],
+        rewrite_cond => ['%{REQUEST_URI} !^/Shibboleth.sso'],
         rewrite_rule => "^(/.*)$ http://${app_host}:${app_port}\$1 [P]",
       },
     ],

--- a/manifests/profile/www_lib/vhosts/mgetit.pp
+++ b/manifests/profile/www_lib/vhosts/mgetit.pp
@@ -48,7 +48,6 @@ class nebula::profile::www_lib::vhosts::mgetit (
 
     ssl                         => true,
     ssl_cn                      => $ssl_cn,
-    cosign                      => false,
     usertrack                   => true,
 
     setenv                      => ['HTTPS on'],

--- a/manifests/profile/www_lib/vhosts/midaily.pp
+++ b/manifests/profile/www_lib/vhosts/midaily.pp
@@ -46,8 +46,9 @@ class nebula::profile::www_lib::vhosts::midaily (
 
     ssl                         => true,
     ssl_cn                      => $ssl_cn,
-    cosign                      => true,
     usertrack                   => true,
+    auth_openidc                => true,
+    auth_openidc_redirect_uri   => 'https://digital.bentley.umich.edu/openid-connect/callback',
 
     setenv                      => ['HTTPS on'],
 
@@ -59,7 +60,7 @@ class nebula::profile::www_lib::vhosts::midaily (
       },
       {
         comment      => 'Reverse proxy application to app hostname and port',
-        rewrite_cond => '%{REQUEST_URI} !^/cosign/valid',
+        rewrite_cond => '%{REQUEST_URI} !^/openid-connect',
         rewrite_rule => '^(/.*)$ http://app-midaily-production:30500$1 [P]',
       },
     ],
@@ -77,12 +78,24 @@ class nebula::profile::www_lib::vhosts::midaily (
         allow_override => 'None',
         require        => $nebula::profile::www_lib::apache::default_access,
       },
+      # Standard mod_auth_openidc pasive login
+      {
+        provider        => 'location',
+        path            => '/',
+        auth_type       => 'openid-connect',
+        auth_require    => 'valid-user',
+        custom_fragment => @(EOT)
+        OIDCUnAuthAction pass
+        | EOT
+      },
       {
         provider        => 'location',
         path            => '/login',
-        auth_type       => 'cosign',
+        auth_type       => 'openid-connect',
         auth_require    => 'valid-user',
-        custom_fragment => 'CosignAllowPublicAccess Off',
+        custom_fragment => @(EOT)
+        OIDCUnAuthAction auth true
+        | EOT
       },
     ],
 

--- a/manifests/profile/www_lib/vhosts/openmich.pp
+++ b/manifests/profile/www_lib/vhosts/openmich.pp
@@ -42,7 +42,6 @@ class nebula::profile::www_lib::vhosts::openmich (
 
     ssl            => true,
     ssl_cn         => $ssl_cn,
-    cosign         => false,
 
     directories    => [
       {

--- a/manifests/profile/www_lib/vhosts/press.pp
+++ b/manifests/profile/www_lib/vhosts/press.pp
@@ -95,7 +95,6 @@ class nebula::profile::www_lib::vhosts::press (
       {
         rewrite_cond => [
           '%{DOCUMENT_ROOT}/%{REQUEST_URI} !-f',
-          '%{REQUEST_URI} !^/cosign',
         ],
         rewrite_rule => "^(.*) http://${bind}\$1 [P]"
       }

--- a/manifests/profile/www_lib/vhosts/staff_lib.pp
+++ b/manifests/profile/www_lib/vhosts/staff_lib.pp
@@ -31,8 +31,8 @@ class nebula::profile::www_lib::vhosts::staff_lib (
     ssl_cn                             => 'apps.staff.lib.umich.edu',
     ssl                                => true,
     usertrack                          => true,
-    cosign                             => true,
-    cosign_service                     => 'apps.staff.lib.umich.edu',
+    auth_openidc                       => true,
+    auth_openidc_redirect_uri          => 'https://apps.staff.lib.umich.edu/openid-connect/callback',
     docroot                            => $docroot,
     setenvifnocase                     => ['^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1'],
     default_allow_override             => ['AuthConfig','FileInfo','Limit','Options'],
@@ -53,6 +53,11 @@ class nebula::profile::www_lib::vhosts::staff_lib (
           # TODO: Extract version or socket path to params/hiera
           handler    => 'proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost'
         }],
+        auth_type       => 'openid-connect',
+        auth_require    => 'valid-user',
+        custom_fragment => @(EOT)
+        OIDCUnAuthAction pass
+        | EOT
       },
       {
         provider       => 'directory',
@@ -75,53 +80,82 @@ class nebula::profile::www_lib::vhosts::staff_lib (
         path     => '^\.ph(ar|p|ps|tml)$',
         require  => 'all denied'
       },
-    ],
-
-    # Don't allow passive auth for directories still protected by auth system
-    cosign_public_access_off_dirs      => [
-      # results in odd looping behavior
-      # {
-      #   provider => 'location',
-      #   path     => '/user/login'
-      # },
+      # Don't allow passive auth for directories still protected by auth system
       {
-        provider => 'directory',
-        path     => "${docroot}/funds_transfer",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/funds_transfer",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/sites/staff.lib.umich.edu.funds_transfer",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/sites/staff.lib.umich.edu.funds_transfer",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/linkscan",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/linkscan",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/linkscan117",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/linkscan117",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/pagerate",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/pagerate",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/ts",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/ts",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true'
       },
-    ],
-
-    cosign_public_access_off_php5_dirs => [
+      # Those that need php-related settings too
       {
-        provider => 'directory',
-        path     => "${docroot}/coral",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/coral",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true',
+        addhandlers     => [{
+          extensions    => ['.php'],
+          handler       => 'application/x-httpd-php'
+        }]
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/ptf",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/ptf",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true',
+        addhandlers     => [{
+          extensions    => ['.php'],
+          handler       => 'application/x-httpd-php'
+        }]
       },
       {
-        provider => 'directory',
-        path     => "${docroot}/sites/staff.lib.umich.edu/local",
+        provider        => 'directorymatch',
+        path            => "^${docroot}/sites/staff.lib.umich.edu/local",
+        auth_type       => 'openid-connect',
+        require         => 'valid-user',
+        custom_fragment => 'OIDCUnAuthAction auth true',
+        addhandlers     => [{
+          extensions    => ['.php'],
+          handler       => 'application/x-httpd-php'
+        }]
       },
     ],
 

--- a/manifests/profile/www_lib/vhosts/www_lib.pp
+++ b/manifests/profile/www_lib/vhosts/www_lib.pp
@@ -21,7 +21,6 @@ class nebula::profile::www_lib::vhosts::www_lib (
     servername                    => "${prefix}www.${domain}",
     ssl                           => true,
     usertrack                     => true,
-    cosign                        => false,
     docroot                       => $docroot,
     directories                   => [
       {

--- a/spec/classes/profile/www_lib/cron_spec.rb
+++ b/spec/classes/profile/www_lib/cron_spec.rb
@@ -15,14 +15,12 @@ describe 'nebula::profile::www_lib::cron' do
       context 'with user set to "cron_friend"' do
         let(:params) { { user: 'cron_friend' } }
 
-        it { is_expected.to contain_cron('purge cosign tickets').with_user('root') }
         it { is_expected.to contain_cron('staff.lib parse').with_user('cron_friend') }
       end
 
       context 'with mailto set to "crons@umich.edu"' do
         let(:params) { { mailto: 'crons@umich.edu' } }
 
-        it { is_expected.to contain_cron('purge cosign tickets').without_environment }
         it { is_expected.to contain_cron('staff.lib parse').with_environment(['MAILTO=crons@umich.edu']) }
       end
 

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -147,18 +147,6 @@ describe 'nebula::role::webhost::www_lib_vm' do
           .with_ssl_cert('/etc/ssl/certs/apps.staff.lib.umich.edu.crt')
       end
 
-      it 'defaults to allowing .htaccess for staff.lib' do
-        directories = catalogue.resource('Apache::Vhost', 'apps.staff.lib ssl')[:directories]
-        funds_transfer = directories.select { |x| x['path'] == '/www/staff.lib/web/funds_transfer' }
-
-        expect(funds_transfer.first['allow_override']).to contain_exactly(
-          'AuthConfig',
-          'FileInfo',
-          'Limit',
-          'Options',
-        )
-      end
-
       it do
         is_expected.to contain_apache__vhost('www.publishing-http')
       end
@@ -238,7 +226,6 @@ describe 'nebula::role::webhost::www_lib_vm' do
           .with_content(%r{PORT\s+=\s+1234})
       end
 
-      it { is_expected.to contain_cron('purge cosign tickets') }
       it { is_expected.to contain_cron('purge apache access logs 1/2') }
       it { is_expected.to contain_cron('purge apache access logs 2/2') }
       it { is_expected.to contain_cron('reload fcgi for Press site nightly') }

--- a/spec/fixtures/hiera/www_lib.yaml
+++ b/spec/fixtures/hiera/www_lib.yaml
@@ -35,6 +35,10 @@ nebula::profile::apache::authz_umichlib::oracle_servers:
     - ORCL.MYSERVER2_ALIAS1
     - ORCL.MYSERVER2_ALIAS2
 
+nebula::profile::apache::auth_openidc::oidc_metadata: someURL
+nebula::profile::apache::auth_openidc::oidc_client_id: something
+nebula::profile::apache::auth_openidc::oidc_client_secret: clientsecret
+nebula::profile::apache::auth_openidc::oidc_crypto: crypt
 
 nebula::profile::www_lib::vhosts::fulcrum::docroot: "/hydra/heliotrope-production/current/public"
 nebula::profile::www_lib::vhosts::fulcrum::derivatives_path: "/hydra/heliotrope-production/current/tmp/derivatives"

--- a/templates/profile/apache/auth_openidc.conf.erb
+++ b/templates/profile/apache/auth_openidc.conf.erb
@@ -1,0 +1,38 @@
+OIDCProviderMetadataURL <%= @oidc_metadata %>
+OIDCClientID <%= @oidc_client_id %>
+OIDCClientSecret <%= @oidc_client_secret %>
+OIDCCryptoPassphrase <%= @oidc_crypto %>
+
+# Essential, as the default client_secret_basic is not supported by ITS' shib OIDC provider config
+OIDCProviderTokenEndpointAuth client_secret_post
+
+# Defaults to code, but be explicit for transparency
+OIDCResponseType code
+
+OIDCScope "openid email profile"
+OIDCRemoteUserClaim preferred_username
+
+# Always protect the default redirect URI in all vhosts
+<Location /openid-connect/callback>
+    AuthType openid-connect
+    Require valid-user
+</Location>
+
+# Setup file-based session cache
+OIDCCacheType file
+OIDCCacheDir "/var/cache/apache2/mod_auth_openidc/oidc-sessions"
+OIDCCacheFileCleanInterval 60
+OIDCSessionCacheFallbackToCookie On
+OIDCSessionInactivityTimeout 28800
+OIDCSessionType server-cache
+OIDCCacheEncrypt On
+
+# Indicates whether POST data will be preserved across authentication requests.
+# Preservation is done via HTML 5 local storage. Note that this can lead to private
+# data exposure on shared terminals, that is why the default is "Off". Can be
+# configured on a per Directory/Location basis.
+OIDCPreservePost On
+OIDCRefreshAccessTokenBeforeExpiry 300 logout_on_error
+
+# A redirect URI must be defined to load the module successfully
+OIDCRedirectURI "https://missing-callback.invalid/check-the-apache-oidc-configuration"

--- a/templates/profile/apache/authz_umichlib.conf.erb
+++ b/templates/profile/apache/authz_umichlib.conf.erb
@@ -10,5 +10,5 @@ DBDriver oracle
 
 DLPSAuthExemptionPolicy checkOnlyListed
 DLPSAuthExemptionPaths  /www/www.lib/cgi /www/staff.lib/web/coral /www/staff.lib/web/linkscan /www/staff.lib/web/linkscan117 /www/staff.lib/web/pagerate /www/staff.lib/web/ptf /www/staff.lib/web/ts /www/staff.lib/web/sites/staff.lib.umich.edu/local /www/staff.lib/web/funds_transfer /www/staff.lib/web/sites/staff.lib.umich.edu.funds_transfer /tb/www.lib/instruction-request /instruction/request
-DLPSAuthFilenameHandlers application/x-httpd-php bwshare-info bwshare-trace cgi-script cosign redirect-handler server-status drupal_security_do_not_remove_see_sa_2006_006 fcgid-script drupal_security_do_not_remove_see_sa_2013_003 shib-handler proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost
+DLPSAuthFilenameHandlers application/x-httpd-php bwshare-info bwshare-trace cgi-script auth_openidc redirect-handler server-status drupal_security_do_not_remove_see_sa_2006_006 fcgid-script drupal_security_do_not_remove_see_sa_2013_003 shib-handler proxy:unix:/run/php/php8.1-fpm.sock|fcgi://localhost
 DLPSAuthURIHandlers jakarta-servlet proxy-server

--- a/templates/profile/www_lib/check_press.sh.erb
+++ b/templates/profile/www_lib/check_press.sh.erb
@@ -8,6 +8,20 @@ else
     sleep 5
     if ! /bin/nc -zw10 <%= @bind.sub(':', ' ') %>; then
       /bin/systemctl -q restart press
+      previous_restart_counter=`/usr/local/bin/pushgateway_advanced -j press_fcgi_check -q press_fcgi_check_restarts_total`
+      new_restart_count=`perl -e "printf(\"%d\\n\", $previous_restart_counter + 1);"`
+      cat <<EOF | /usr/local/bin/pushgateway_advanced -j press_fcgi_check
+# HELP press_fcgi_check_restarts_total Count of times we automatically restart press fcgi
+# TYPE press_fcgi_check_restarts_total counter
+press_fcgi_check_restarts_total $new_restart_count
+EOF
     fi
   fi
+
+  STOP_TIME=`date '+%s'`
+  cat <<EOF | /usr/local/bin/pushgateway_advanced -j press_fcgi_check
+# HELP press_fcgi_check_duration_seconds Time spent running press_fcgi_check
+# TYPE press_fcgi_check_duration_seconds gauge
+press_fcgi_check_duration_seconds `echo $STOP_TIME - $START_TIME | bc`
+EOF
 fi


### PR DESCRIPTION
The auth related changes are in two commits to reflect general mod_auth_openidc support in apache vs changes specific to www_lib.

The press_fcgi_check script commit is included as that change was needed while this branch was live in production.