### PR TITLE
Always trust umich::networks::all_trusted_machines for SSH

### DIFF
--- a/manifests/profile/networking/firewall/ssh.pp
+++ b/manifests/profile/networking/firewall/ssh.pp
@@ -9,13 +9,13 @@
 # @example
 #   include nebula::profile::networking::firewall::ssh
 class nebula::profile::networking::firewall::ssh {
-  if is_publicly_accessible() {
-    nebula::exposed_port { '100 SSH':
-      port  => 22,
-      block => 'umich::networks::all_trusted_machines',
-    }
-  } else {
-    nebula::exposed_port { '100 SSH':
+  nebula::exposed_port { '100 SSH':
+    port  => 22,
+    block => 'umich::networks::all_trusted_machines',
+  }
+
+  if ! is_publicly_accessible() {
+    nebula::exposed_port { '100 Private SSH':
       port  => 22,
       block => 'umich::networks::private_bastion_hosts',
     }

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -43,6 +43,13 @@ describe 'nebula::profile::networking::firewall::ssh' do
         it do
           is_expected.to contain_nebula__exposed_port('100 SSH').with(
             port: 22,
+            block: 'umich::networks::all_trusted_machines',
+          )
+        end
+
+        it do
+          is_expected.to contain_nebula__exposed_port('100 Private SSH').with(
+            port: 22,
             block: 'umich::networks::private_bastion_hosts',
           )
         end


### PR DESCRIPTION
Not sure why, but the `is_publicly_accessible()` function appears to be flapping, which occasionally causes inaccessibility due to machines incorrectly reporting to be private-only machines.

This way, all machines will always trust ssh coming from trusted CIDRs. It should have no impact on private hosts, since they're already behind a NAT router that should make them unroutable.

And if public-ip-address hosts occasionally flap and get a few 10-net ssh allowances? No harm done, really.