### PR TITLE
TTO-85 - add firebird-common paths

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -99,7 +99,11 @@ class nebula::profile::hathitrust::apache::babel (
       },
       {
         aliasmatch => '^/favicon.ico$',
-        path       => "${sdrroot}/common/web/favicon.ico"
+        path       => "${sdrroot}/firebird-common/dist/favicon.ico"
+      },
+      {
+        alias => '/common/firebird/',
+        path  => "${sdrroot}/firebird-common/"
       },
       {
         # Used for example logo and style sheet in error templates.
@@ -247,6 +251,11 @@ class nebula::profile::hathitrust::apache::babel (
         auth_type             => 'shibboleth',
         require               => 'shibboleth',
         shib_request_settings => { 'requireSession' => '0', 'discoveryURL' => "https://${servername}/cgi/wayf" }
+      },
+      {
+        provider => 'directory',
+        path     =>  "${sdrroot}/firebird-common",
+        require  => $default_access,
       },
       {
         # Grant access to necessary directories under the document root:

--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -61,6 +61,11 @@ class nebula::profile::hathitrust::apache::catalog (
       },
       {
         provider => 'directory',
+        path     =>  "${sdrroot}/firebird-common",
+        require  => $default_access,
+      },
+      {
+        provider => 'directory',
         path     =>  "${sdrroot}/common/web",
         require  => $default_access,
       },
@@ -69,7 +74,11 @@ class nebula::profile::hathitrust::apache::catalog (
     aliases            => [
       {
         aliasmatch => '^/favicon.ico$',
-        path       => "${sdrroot}/common/web/favicon.ico"
+        path       => "${sdrroot}/firebird-common/dist/favicon.ico"
+      },
+      {
+        alias => '/common/firebird/',
+        path  => "${sdrroot}/firebird-common/"
       },
       {
         alias => '/common/',

--- a/manifests/profile/hathitrust/apache/www.pp
+++ b/manifests/profile/hathitrust/apache/www.pp
@@ -62,6 +62,11 @@ class nebula::profile::hathitrust::apache::www (
       },
       {
         provider => 'directory',
+        path     =>  "${sdrroot}/firebird-common",
+        require  => $default_access,
+      },
+      {
+        provider => 'directory',
         path     =>  "${sdrroot}/common/web",
         require  => $default_access,
       },
@@ -70,7 +75,11 @@ class nebula::profile::hathitrust::apache::www (
     aliases            => [
       {
         aliasmatch => '^/favicon.ico$',
-        path       => "${sdrroot}/common/web/favicon.ico"
+        path       => "${sdrroot}/firebird-common/dist/favicon.ico"
+      },
+      {
+        alias => '/common/firebird/',
+        path  => "${sdrroot}/firebird-common/"
       },
       {
         alias => '/common/',


### PR DESCRIPTION
Adding `firebird-common`; it's different than `common` in that there's no `web` directory and `common/firebird` needs to resolve before `common/*`.