### PR TITLE
DEV-864 - install current lts node for ht dev hosts

### DIFF
--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -26,6 +26,10 @@ class nebula::role::webhost::htvm::test {
     'xsltproc'
   ])
 
+  class { 'nebula::profile::nodejs':
+    version => '18',
+  }
+
   include nebula::role::webhost::htvm
   include nebula::profile::hathitrust::apache::test
 

--- a/spec/classes/role/htvm_test_webhost_spec.rb
+++ b/spec/classes/role/htvm_test_webhost_spec.rb
@@ -11,6 +11,7 @@ describe 'nebula::role::webhost::htvm::test' do
     context "on #{os}" do
       include_context 'with setup for htvm node', os_facts
       it { is_expected.to compile }
+      it { is_expected.to contain_package('nodejs') }
     end
   end
 end


### PR DESCRIPTION
We need node/npm installed to support building the production css/js components, but do not currently need/want it in production.

nebula::role::webhost::htvm::test is the role used by the dev/test/preview HT web VMs.