### PR TITLE
HT DEV-849 - run wordpress cron from cron

### DIFF
--- a/manifests/profile/hathitrust/apache/redirection.pp
+++ b/manifests/profile/hathitrust/apache/redirection.pp
@@ -25,7 +25,7 @@ class nebula::profile::hathitrust::apache::redirection (
   $www_servername     = "${prefix}www.${domain}"
 
 
-  ['babel', 'catalog', 'm', 'www'].each |String $vhost| {
+  ['babel', 'catalog', 'm', 'www', 'old.www'].each |String $vhost| {
     $servername = "${prefix}${vhost}.${domain}"
 
     apache::vhost { "${servername} non-ssl":

--- a/manifests/profile/hathitrust/cron/mdp_misc.pp
+++ b/manifests/profile/hathitrust/cron/mdp_misc.pp
@@ -68,6 +68,10 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       minute  => 05,
       command => "${home}/scripts/merge_application_logs.pl";
 
+    'wordpress cron':
+      minute  => 0,
+      command =>  '/usr/bin/curl -s https://www.hathitrust.org/wp-cron.php --resolve "www.hathitrust.org:443:127.0.0.1';
+
   }
 
 }

--- a/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
+++ b/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
@@ -57,6 +57,12 @@ describe 'nebula::profile::hathitrust::cron::mdp_misc' do
                   ],
                   minute: 30)
         end
+
+        it do
+          is_expected.to contain_cron('wordpress cron')
+            .with(command: %r{.*wp-cron.php.*},
+                  minute: 0)
+        end
       end
     end
   end


### PR DESCRIPTION
* Runs wordpress cron once an hour
* Hits production vhost via localhost (htaccess restricts access to wp_cron.php from elsewhere)
* redirect from http://old.www.hathitrust.org -> https://old.www.hathitrust.org