### PR TITLE
Begin removing offensive master/slave terminology

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -278,15 +278,15 @@ groups:
     annotations:
       summary: 'MySQL is DOWN on {{$labels.hostname}}'
       description: 'MySQL is DOWN'
-  - alert: MysqlSlaveSqlDown
+  - alert: MysqlReplicaSqlDown
     expr: >
       mysql_slave_status_slave_sql_running  == 0
     for: 5m
     labels:
       severity: page
     annotations:
-      summary: 'MySQL Slave SQL is Not Running on {{$labels.hostname}}'
-      description: 'MySQL Slave SQL is not Running'
+      summary: 'MySQL Replica SQL is Not Running on {{$labels.hostname}}'
+      description: 'MySQL Replica SQL is not Running'
   - alert: MysqlMaxPreparedStatment
     expr: >
       mysql_global_status_prepared_stmt_count / mysql_global_variables_max_prepared_stmt_count > 0.75


### PR DESCRIPTION
MariaDB 10.5 uses "replica" as a synonym for "slave", but does not remove the offensive terminology in all locations.