### PR TITLE
TTO-96 - remove unnecessary drupal cron jobs

### DIFF
--- a/manifests/profile/hathitrust/cron/statistics.pp
+++ b/manifests/profile/hathitrust/cron/statistics.pp
@@ -37,33 +37,10 @@ class nebula::profile::hathitrust::cron::statistics (
       minute  => '50',
       hour    => '3';
 
-    'rss create statistics':
-      command => "/usr/bin/php ${drupal_home}/modules/custom/RSSGenerateStatisticsFile.php > ${drupal_home}/cron_reporting.3 2>&1 || /usr/usr/bin/mail -s 'RSS Create Cronjob failed' ${mail_recipient}",
-      minute  => '0',
-      hour    => '3',
-      weekday => '1';
-
     'callnumber statistics':
       command => "/usr/bin/perl ${drupal_home}/extra_perl/Solr/stats.pl > ${drupal_home}/cron_reporting.4 2>&1 || /usr/bin/mail -s 'Callnumber Statistics Cronjob failed' ${mail_recipient}",
       minute  => '0',
       hour    => '4';
-
-    'rss create':
-      command => "/usr/bin/php ${drupal_home}/modules/custom/RSScreate.php > ${drupal_home}/cron_reporting.5 2>&1 || /usr/bin/mail -s 'RSS Create Cronjob failed' ${mail_recipient}",
-      minute  => '0',
-      hour    => '4',
-      weekday => '1';
-
-    'get pod volumes':
-      command  => "/usr/bin/perl ${drupal_home}/extra_perl/get_pod_volumes.pl > ${drupal_home}/cron_reporting.6 2>&1 || /usr/bin/mail -s 'Get POD Volumes Cronjob failed' ${mail_recipient}",
-      minute   => '0',
-      hour     => '0',
-      monthday => '1';
-
-    'hourly reporting':
-      command => "/usr/bin/php ${sdr_root}/command-line-cron.php > ${drupal_home}/cron_reporting.7 2>&1 || /usr/bin/mail -s 'Once-an-hour Cronjob failed' ${mail_recipient}",
-      user    => 'libadm',
-      minute  => '0';
 
   }
 }


### PR DESCRIPTION
- The hourly job ran cron jobs inside Drupal; we aren't running Drupal any more so we don't need that.

- The "RSS file" stuff appears to have driven a block on the Drupal web site, which we aren't using any more

- The publish on demand output hasn't changed in over 6 years, and is no longer a maintained service.

The remaining "stats" jobs generate textual output that is still useful for the time being.