### PR TITLE
Allow Search to manage its own auth via OIDC

### DIFF
--- a/manifests/profile/www_lib/vhosts/search.pp
+++ b/manifests/profile/www_lib/vhosts/search.pp
@@ -49,8 +49,6 @@ class nebula::profile::www_lib::vhosts::search (
     ssl                         => true,
     ssl_cn                      => $ssl_cn,
     usertrack                   => true,
-    auth_openidc                => true,
-    auth_openidc_redirect_uri   => 'https://search.lib.umich.edu/openid-connect/callback',
 
     rewrites                    => [
       {
@@ -80,7 +78,6 @@ class nebula::profile::www_lib::vhosts::search (
       },
       {
         comment      => 'Reverse proxy application to app hostname and port',
-        rewrite_cond => '%{REQUEST_URI} !^/openid-connect',
         rewrite_rule => '^(/.*)$ http://app-search:30101$1 [P]',
       },
     ],
@@ -97,25 +94,6 @@ class nebula::profile::www_lib::vhosts::search (
         options        => 'FollowSymlinks',
         allow_override => 'None',
         require        => $nebula::profile::www_lib::apache::default_access,
-      },
-      # Standard mod_auth_openidc pasive login
-      {
-        provider        => 'location',
-        path            => '/',
-        auth_type       => 'openid-connect',
-        auth_require    => 'valid-user',
-        custom_fragment => @(EOT)
-        OIDCUnAuthAction pass
-        | EOT
-      },
-      {
-        provider        => 'location',
-        path            => '/login',
-        auth_type       => 'openid-connect',
-        auth_require    => 'valid-user',
-        custom_fragment => @(EOT)
-        OIDCUnAuthAction auth true
-        | EOT
       },
     ],
 


### PR DESCRIPTION
There were some odd conflicts for Search, where people were being taken through reauthentication. It has something to do with multiple data centers and server-side sessions/caches. The app can now manage OIDC logins, so we are bypassing the module here.