### PR TITLE
update actions/checkout, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: |
         docker-compose --file docker-compose.test.yml build

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "rspec-puppet-utils"
   gem "faker"
+  gem "parallel_tests"
 end
 
 gem 'puppet', '~> 6.19'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   specs:
     build: .
-    command: 'bundle exec rake spec'
+    command: 'bundle exec rake parallel_spec'
 
   lint:
     build: .


### PR DESCRIPTION
- actions/checkout v2 => v3
- dependabot for gh workflows
- added parallel_tests gem, make `bundle exec rake parallel_spec` the default for ci
