### PR TITLE
Test faster

### DIFF
--- a/spec/classes/all_roles_1_spec.rb
+++ b/spec/classes/all_roles_1_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require_relative './all_roles_spec'
+
+test_roles(1,5)

--- a/spec/classes/all_roles_2_spec.rb
+++ b/spec/classes/all_roles_2_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require_relative './all_roles_spec'
+
+test_roles(2,5)

--- a/spec/classes/all_roles_3_spec.rb
+++ b/spec/classes/all_roles_3_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require_relative './all_roles_spec'
+
+test_roles(3,5)

--- a/spec/classes/all_roles_4_spec.rb
+++ b/spec/classes/all_roles_4_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require_relative './all_roles_spec'
+
+test_roles(4,5)

--- a/spec/classes/all_roles_5_spec.rb
+++ b/spec/classes/all_roles_5_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+require_relative './all_roles_spec'
+
+test_roles(5,5)

--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -37,46 +37,55 @@ module RSpec::Puppet
   end
 end
 
-`find manifests/role -name '*.pp'`.each_line do |file_path|
-  role_name = puppet_role_name_from(file_path)
-  describe role_name do
-    on_supported_os.each do |os, os_facts|
-      context "on #{os}" do
-        let(:facts) { os_facts }
+# Tests are run in several roughly equal slices from other *_spec.rb files. This
+# results in spec files that each have roughly similar run time, and thus the
+# tests run much faster when parallelized.
+def test_roles(slice_number = 1, slice_count = 1)
+  slice_index = slice_number - 1 # number is 1..n, index is 0..n; using "number" for input to be less confusing
+  roles = `find manifests/role -name '*.pp'`.each_line.to_a
+  slice = roles.each_slice(roles.size/slice_count + 1).to_a[slice_index]
 
-        let(:hiera_config) { "spec/fixtures/hiera/#{hiera_fixture}_config.yaml" }
+  slice.each do |file_path|
+    role_name = puppet_role_name_from(file_path)
+    describe role_name do
+      on_supported_os.each do |os, os_facts|
+        context "on #{os}" do
+          let(:facts) { os_facts }
 
-        let(:hiera_fixture) do
-          [
-            # Each item is a pair: [<role prefix or full name>,
-            #                       <hiera fixture name>]
-            # The first pair that matches will be chosen.
-            %w[nebula::role::webhost::htvm hathitrust],
-            %w[nebula::role::hathitrust hathitrust],
-            %w[nebula::role::chipmunk chipmunk],
-            %w[nebula::role::app_host::standalone chipmunk],
-            %w[nebula::role::app_host::hyrax chipmunk],
-            %w[nebula::role::deb_server deb_server],
-            %w[nebula::role::deploy_host named_instances],
-            %w[nebula::role::kubernetes kubernetes/first_cluster],
-            %w[nebula::role::log_host log_host],
-            %w[nebula::role::webhost::www_lib_vm www_lib],
-            %w[nebula::role::webhost::fulcrum_www_and_app fulcrum],
-            %w[nebula::role::docker_registry docker_registry],
-            %w[nebula::role::fulcrum fulcrum],
-            %w[nebula default],
-          ].select { |role_base, _| role_name.start_with? role_base }.first[1]
-        end
+          let(:hiera_config) { "spec/fixtures/hiera/#{hiera_fixture}_config.yaml" }
 
-        let!(:puppetdb_query) do
-          MockFunction.new('puppetdb_query') do |f|
-            # Everything that runs puppetdb_query should be able to deal
-            # with empty results.
-            f.stubbed.returns([])
+          let(:hiera_fixture) do
+            [
+              # Each item is a pair: [<role prefix or full name>,
+              #                       <hiera fixture name>]
+              # The first pair that matches will be chosen.
+              %w[nebula::role::webhost::htvm hathitrust],
+              %w[nebula::role::hathitrust hathitrust],
+              %w[nebula::role::chipmunk chipmunk],
+              %w[nebula::role::app_host::standalone chipmunk],
+              %w[nebula::role::app_host::hyrax chipmunk],
+              %w[nebula::role::deb_server deb_server],
+              %w[nebula::role::deploy_host named_instances],
+              %w[nebula::role::kubernetes kubernetes/first_cluster],
+              %w[nebula::role::log_host log_host],
+              %w[nebula::role::webhost::www_lib_vm www_lib],
+              %w[nebula::role::webhost::fulcrum_www_and_app fulcrum],
+              %w[nebula::role::docker_registry docker_registry],
+              %w[nebula::role::fulcrum fulcrum],
+              %w[nebula default],
+            ].select { |role_base, _| role_name.start_with? role_base }.first[1]
           end
-        end
 
-        it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
+          let!(:puppetdb_query) do
+            MockFunction.new('puppetdb_query') do |f|
+              # Everything that runs puppetdb_query should be able to deal
+              # with empty results.
+              f.stubbed.returns([])
+            end
+          end
+
+          it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
+        end
       end
     end
   end

--- a/spec/classes/profile/hathitrust/dependencies_spec.rb
+++ b/spec/classes/profile/hathitrust/dependencies_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+require_relative '../../../support/contexts/with_htvm_setup'
+
+describe 'nebula::profile::hathitrust::dependencies' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      include_context 'with setup for htvm node', os_facts
+
+      it { is_expected.to compile }
+
+      if os == 'debian-11-x86_64'
+        it { is_expected.to contain_package('mariadb-client') }
+      end
+
+    end
+  end
+end

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -20,6 +20,9 @@ describe 'nebula::profile::hathitrust::mounts' do
       it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
       it { is_expected.to contain_nebula__nfs_mount('/htapps') }
 
+      it { is_expected.to contain_file('/etc/resolv.conf').with_content(%r{nameserver 127.0.0.1}) }
+      it { is_expected.to contain_service('bind9') }
+
       context 'with /htapps specified as a non-smartconnect mount' do
         let(:params) do
           {

--- a/spec/classes/profile/hathitrust/perl_spec.rb
+++ b/spec/classes/profile/hathitrust/perl_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+require_relative '../../../support/contexts/with_htvm_setup'
+
+describe 'nebula::profile::hathitrust::perl' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      include_context 'with setup for htvm node', os_facts
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_nebula__cpan('EBook::EPUB').that_requires('Package[libmoose-perl]') }
+    end
+  end
+end

--- a/spec/classes/profile/hathitrust/php_spec.rb
+++ b/spec/classes/profile/hathitrust/php_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+require_relative '../../../support/contexts/with_htvm_setup'
+
+describe 'nebula::profile::hathitrust::php' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      include_context 'with setup for htvm node', os_facts
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_php__extension('File_MARC').with_provider('pear') }
+    end
+  end
+end

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018 The Regents of the University of Michigan.
+# Copyright (c) 2018, 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
@@ -14,22 +14,19 @@ describe 'nebula::role::webhost::htvm' do
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
-
       it do
         is_expected.to contain_class('nebula::profile::shibboleth')
           .with(startup_timeout: 1800)
           .with(watchdog_minutes: '*/30')
       end
 
-      it { is_expected.to contain_php__extension('File_MARC').with_provider('pear') }
-      it { is_expected.to contain_nebula__cpan('EBook::EPUB').that_requires('Package[libmoose-perl]') }
-
-      it { is_expected.to contain_file('/etc/resolv.conf').with_content(%r{nameserver 127.0.0.1}) }
-      it { is_expected.to contain_service('bind9') }
-
-      # default from hiera
-      it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
+      it do
+        is_expected.to contain_class('nebula::profile::hathitrust::dependencies')
+        is_expected.to contain_class('nebula::profile::hathitrust::hosts')
+        is_expected.to contain_class('nebula::profile::hathitrust::mounts')
+        is_expected.to contain_class('nebula::profile::hathitrust::perl')
+        is_expected.to contain_class('nebula::profile::hathitrust::php')
+      end
 
       it do
         is_expected.to contain_concat_fragment('monitor nfs /sdr1')
@@ -68,7 +65,6 @@ describe 'nebula::role::webhost::htvm' do
         it { is_expected.not_to contain_package('php5-dev') }
         it { is_expected.to contain_package('libapache2-mod-shib') }
         it { is_expected.not_to contain_package('libapache2-mod-shib2') }
-        it { is_expected.to contain_package('mariadb-client') }
       end
 
       # not specified explicitly as a usergroup, just brought in as part of 'all groups'


### PR DESCRIPTION
parallel_test gives each thread an equal number of files to test, so extremely large/slow spec files prevent the tests from getting much parallel speed-up. With that in mind, I split up the tests in the two slowest running spec files: htvm_webhost_spec and all_roles_spec

- htvm_webhost_spec: much of this was effectively testing the profiles required by this role, so I created new profile specs and moved the tests there, and moved tests to existing profile specs where possible. There is more that could be done, I only moved the bits that were obvious, but this is still cuts roughly 20% of the runtime off this file and (I hope) makes the spec a little easier to understand.
- split all_roles_spec into 5 slices: make the logic in all_roles_spec into a function, call it from 5 new spec files