### PR TITLE
add firewall $advanced_rules

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -14,6 +14,7 @@
 class nebula::profile::networking::firewall (
   String $internal_routing = '',
   Hash $rules = {},
+  Hash $advanced_rules = {},
 ) {
   # Include standard SSH rules by default
   include nebula::profile::networking::firewall::ssh
@@ -141,6 +142,7 @@ class nebula::profile::networking::firewall (
   }
 
   create_resources(firewall,$rules,$firewall_defaults)
+  create_resources(firewall,$advanced_rules)
 
   # Default IPv4 items, sorted by title
   firewall { '001 accept related established rules':

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -68,6 +68,21 @@ describe 'nebula::profile::networking::firewall' do
       end
 
       it do
+        is_expected.to contain_firewall('900 port forwarding: an advanced rule').with(
+          table: 'nat',
+          proto: 'tcp',
+          dport: '4657',
+          jump: 'REDIRECT',
+          chain: 'PREROUTING',
+          toports: '1234',
+        )
+        is_expected.not_to contain_firewall('900 port forwarding: an advanced rule').with(
+          action: 'accept',
+          state: 'NEW',
+        )
+      end
+
+      it do
         is_expected.to contain_firewall('999 drop all').with(
           proto: 'all',
           action: 'drop',
@@ -82,7 +97,7 @@ describe 'nebula::profile::networking::firewall' do
         )
       end
 
-      it { is_expected.to have_firewall_resource_count(8) }
+      it { is_expected.to have_firewall_resource_count(9) }
 
       it { is_expected.to contain_package('iptables-persistent') }
       it { is_expected.to contain_package('netfilter-persistent') }

--- a/spec/fixtures/hiera/firewall.yaml
+++ b/spec/fixtures/hiera/firewall.yaml
@@ -13,3 +13,11 @@ nebula::profile::networking::firewall::rules:
     dport: 123
     proto: udp
 
+nebula::profile::networking::firewall::advanced_rules:
+  "900 port forwarding: an advanced rule":
+    table: 'nat'
+    proto: 'tcp'
+    dport: '4657'
+    jump: 'REDIRECT'
+    chain: 'PREROUTING'
+    toports: '1234'


### PR DESCRIPTION
This adds $advanced_rules to the firewall profile. These rules get evaluated without any defaults, which allows us to leave some fields empty.

Original post below the fold.

> I'm not going to merge this as is, clearly. Is there any way to have an entry in $rules that ignores everything in $defaults? Two of the three default fields must be empty (not merely different) for a rule I need to add. Tried undef, empty string, and the puppet Default type, none of these worked.
> 
> Worst case, I'll rename $better_tests to something, uh, better, add some tests, and make this a real PR.
> 
> > Error: Failed to apply catalog: Only one of the parameters 'action' and 'jump' can be set
> 
> > Error: Failed to apply catalog: Parameter action failed on Firewall[999 mysql port forwading]: Invalid value "undef".
> 
> > Error: Failed to apply catalog: Parameter action failed on Firewall[999 mysql port forwading]: Invalid value "".
> 
> > Error: Failed to apply catalog: Parameter action failed on Firewall[999 mysql port forwading]: Invalid value "default".