### PR TITLE
optimal ci runner sizing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ contains( github.event.pull_request.labels.*.name, 'use_fast_ci') && 'ubuntu-latest-16core' || 'ubuntu-latest' }}
+    runs-on: ${{ contains( github.event.pull_request.labels.*.name, 'use_fast_ci') && 'ubuntu-latest-8core' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v4
     - name: Run tests


### PR DESCRIPTION
Pushed a few times with different config to benchmark runners of various sizes.
A "fast" run now cost ~0.15 instead of ~0.25, and takes ~5m instead of ~4m.

Keeping the label for fast running because often we really don't care if it's slow, and I don't want anyone to think twice when making a commit because it costs money, even it the money involved is trivial.

Exact results results below in comments.