### PR TITLE
Add public/private awareness to prometheus node service discovery

### DIFF
--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -79,13 +79,52 @@ describe 'nebula::profile::prometheus::exporter::node' do
       end
 
       it "exports itself to the default datacenter's pushgateway" do
-        expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]}")
+        expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} #{facts[:ipaddress]}")
           .with_tag('default_pushgateway_node')
           .with_proto('tcp')
           .with_dport(9091)
           .with_source(facts[:ipaddress])
           .with_state('NEW')
           .with_action('accept')
+      end
+
+      context 'with both public and private mlibrary_ip_addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public": ["100.100.100.100", "200.200.200.200"],
+            "private": ["10.1.2.3", "10.4.5.6"]
+          })
+        end
+
+        it "exports itself to the default datacenter's service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+            .with_tag('default_prometheus_node_service_list')
+            .with_target('/etc/prometheus/nodes.yml')
+            .with_content(%r{'100\.100\.100\.100:9100'})
+        end
+
+        it "exports itself[0] to the default datacenter's pushgateway" do
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
+            .with_tag('default_pushgateway_node')
+            .with_source("100.100.100.100")
+        end
+
+        it "exports itself[1] to the default datacenter's pushgateway" do
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
+            .with_tag('default_pushgateway_node')
+            .with_source("200.200.200.200")
+        end
+      end
+
+      context 'with only private ip addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public": [],
+            "private": ["10.1.2.3", "10.4.5.6"]
+          })
+        end
+
+        it { is_expected.not_to compile }
       end
 
       context 'when our datacenter is covered' do
@@ -96,9 +135,66 @@ describe 'nebula::profile::prometheus::exporter::node' do
             .with_tag('mydatacenter_prometheus_node_service_list')
         end
 
-        it "exports itself to the default datacenter's pushgateway" do
-          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]}")
+        it "exports itself to its datacenter's pushgateway" do
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} #{facts[:ipaddress]}")
             .with_tag('mydatacenter_pushgateway_node')
+            .with_source(facts[:ipaddress])
+        end
+
+        context 'with both public and private mlibrary_ip_addresses' do
+          let(:facts) do
+            os_facts.merge(mlibrary_ip_addresses: {
+              "public": ["100.100.100.100", "200.200.200.200"],
+              "private": ["10.1.2.3", "10.4.5.6"]
+            })
+          end
+
+          it "exports itself to the default datacenter's service discovery" do
+            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+              .with_tag('mydatacenter_prometheus_node_service_list')
+              .with_target('/etc/prometheus/nodes.yml')
+              .with_content(%r{'10\.1\.2\.3:9100'})
+          end
+
+          it "exports itself[0] to its datacenter's pushgateway" do
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.1.2.3")
+              .with_tag('mydatacenter_pushgateway_node')
+              .with_source("10.1.2.3")
+          end
+
+          it "exports itself[1] to its datacenter's pushgateway" do
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.4.5.6")
+              .with_tag('mydatacenter_pushgateway_node')
+              .with_source("10.4.5.6")
+          end
+        end
+
+        context 'with only public ip addresses' do
+          let(:facts) do
+            os_facts.merge(mlibrary_ip_addresses: {
+              "public": ["100.100.100.100", "200.200.200.200"],
+              "private": []
+            })
+          end
+
+          it "exports itself to the default datacenter's service discovery" do
+            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+              .with_tag('mydatacenter_prometheus_node_service_list')
+              .with_target('/etc/prometheus/nodes.yml')
+              .with_content(%r{'100\.100\.100\.100:9100'})
+          end
+
+          it "exports itself[0] to the default datacenter's pushgateway" do
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
+              .with_tag('mydatacenter_pushgateway_node')
+              .with_source("100.100.100.100")
+          end
+
+          it "exports itself[1] to the default datacenter's pushgateway" do
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
+              .with_tag('mydatacenter_pushgateway_node')
+              .with_source("200.200.200.200")
+          end
         end
       end
 
@@ -116,6 +212,33 @@ describe 'nebula::profile::prometheus::exporter::node' do
       it do
         is_expected.to contain_concat_fragment('03 main pushgateway advanced content')
           .with_target('/usr/local/bin/pushgateway_advanced')
+      end
+
+      context "with the default domain" do
+        let(:node) { "dogbone.default.invalid" }
+
+        it "exports only its hostname to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service dogbone")
+            .with_content(%r{hostname: 'dogbone'})
+        end
+      end
+
+      context "with a subdomain of the default domain" do
+        let(:node) { "dogbone.doghouse.default.invalid" }
+
+        it "exports its full fqdn to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service dogbone")
+            .with_content(%r{hostname: 'dogbone\.doghouse\.default\.invalid'})
+        end
+      end
+
+      context "with a nondefault domain" do
+        let(:node) { "world.of.dogs" }
+
+        it "exports its full fqdn to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service world")
+            .with_content(%r{hostname: 'world\.of\.dogs'})
+        end
       end
     end
   end

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -158,13 +158,191 @@ describe 'nebula::profile::prometheus' do
       end
 
       it 'exports a firewall so that nodes can open 9100' do
-        expect(exported_resources).to contain_firewall("010 prometheus node exporter #{facts[:hostname]}")
+        expect(exported_resources).to contain_firewall("010 prometheus legacy node exporter #{facts[:hostname]}")
           .with_tag('mydatacenter_prometheus_node_exporter')
           .with_proto('tcp')
           .with_dport(9100)
           .with_source(facts[:ipaddress])
           .with_state('NEW')
           .with_action('accept')
+      end
+
+      context 'with no mlibrary_ip_addresses fact' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: nil)
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+        end
+      end
+
+      context 'with a single public ip address in mlibrary_ip_addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public"  => ["100.100.100.100"],
+            "private" => []
+          })
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
+            .with_source("100.100.100.100")
+            .with_tag('mydatacenter_prometheus_public_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+        end
+      end
+
+      context 'with two public ip addresses in mlibrary_ip_addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public"  => ["100.100.100.100", "200.200.200.200"],
+            "private" => []
+          })
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
+            .with_source("100.100.100.100")
+            .with_tag('mydatacenter_prometheus_public_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 200.200.200.200")
+            .with_source("200.200.200.200")
+            .with_tag('mydatacenter_prometheus_public_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+        end
+      end
+
+      context 'with a single private ip address in mlibrary_ip_addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public"  => [],
+            "private" => ["10.1.2.3"]
+          })
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.1.2.3")
+            .with_source("10.1.2.3")
+            .with_tag('mydatacenter_prometheus_private_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+        end
+
+        it do
+          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://10.1.2.3:9091'\n")
+        end
+      end
+
+      context 'with too many ip addresses in mlibrary_ip_addresses' do
+        let(:facts) do
+          os_facts.merge(mlibrary_ip_addresses: {
+            "public"  => ["100.100.100.100", "200.200.200.200"],
+            "private" => ["10.1.2.3", "10.2.3.4", "10.3.4.5"]
+          })
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
+            .with_source("100.100.100.100")
+            .with_tag('mydatacenter_prometheus_public_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 200.200.200.200")
+            .with_source("200.200.200.200")
+            .with_tag('mydatacenter_prometheus_public_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.1.2.3")
+            .with_source("10.1.2.3")
+            .with_tag('mydatacenter_prometheus_private_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.2.3.4")
+            .with_source("10.2.3.4")
+            .with_tag('mydatacenter_prometheus_private_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.3.4.5")
+            .with_source("10.3.4.5")
+            .with_tag('mydatacenter_prometheus_private_node_exporter')
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+            .with_target('/usr/local/bin/pushgateway_advanced')
+            .with_content("PUSHGATEWAY='http://10.1.2.3:9091'\n")
+        end
       end
 
       it 'exports a firewall so that haproxy nodes can open 9101' do
@@ -175,12 +353,6 @@ describe 'nebula::profile::prometheus' do
           .with_source(facts[:ipaddress])
           .with_state('NEW')
           .with_action('accept')
-      end
-
-      it do
-        expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
-          .with_target('/usr/local/bin/pushgateway_advanced')
-          .with_content("PUSHGATEWAY='http://#{facts[:fqdn]}:9091'\n")
       end
 
       context 'with some static nodes set' do

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -152,6 +152,7 @@ nebula::known_addresses::all_library_machines: default.invalid
 nebula::known_addresses::staff: default.invalid
 nebula::known_addresses::datacenter: default.invalid
 
+umich::default_domain: "default.invalid"
 umich::networks::all_trusted_machines: []
 umich::networks::umich_vpn: []
 umich::networks::campus_wired_and_wireless: []


### PR DESCRIPTION
Until now, prometheus's profile has only been aware of IP addresses in the sense of "every host has exactly 1 IP address, and it's public." That assumption is no longer true; some hosts have 0 public addresses and 1 private address, and most hosts have 1 public address and 1 private address.

1. When the prometheus server is crossing datacenters, it must use a **public** IP address.
2. When the node has 0 public addresses, the prometheus server must use a **private** IP address.
3. The prometheus server should prefer to use a **private** IP address when possible.
4. The prometheus server must be able to fall back to a **public** IP address if there is no available private address.