### PR TITLE
rollback stdlib version, conflicts with lvm

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -38,6 +38,6 @@ fixtures:
     puppetdb:     {"repo": "puppetlabs/puppetdb",     "ref": "7.13.0"}
     reboot:       {"repo": "puppetlabs/reboot",       "ref": "4.3.1"}
     sshkeys_core: {"repo": "puppetlabs/sshkeys_core", "ref": "2.4.0"}
-    stdlib:       {"repo": "puppetlabs/stdlib",       "ref": "8.6.0"}
+    stdlib:       {"repo": "puppetlabs/stdlib",       "ref": "6.6.0"}
     resolv_conf:  {"repo": "saz/resolv_conf",         "ref": "5.1.0"}
     debconf:      {"repo": "stm/debconf",             "ref": "5.0.0"}

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     {"name": "puppetlabs/puppetdb",     "version_requirement": ">= 7.13.0 < 8.0.0"},
     {"name": "puppetlabs/reboot",       "version_requirement": ">= 4.3.1  < 5.0.0"},
     {"name": "puppetlabs/sshkeys_core", "version_requirement": ">= 2.4.0  < 3.0.0"},
-    {"name": "puppetlabs/stdlib",       "version_requirement": ">= 8.6.0  < 9.0.0"},
+    {"name": "puppetlabs/stdlib",       "version_requirement": ">= 6.6.0  < 7.0.0"},
     {"name": "saz/resolv_conf",         "version_requirement": ">= 5.1.0  < 6.0.0"},
     {"name": "stm/debconf",             "version_requirement": ">= 5.0.0  < 6.0.0"}
   ],

--- a/spec/defines/cifs_mount_spec.rb
+++ b/spec/defines/cifs_mount_spec.rb
@@ -22,7 +22,7 @@ describe 'nebula::cifs_mount' do
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('cifs-utils').with_ensure('installed') }
+      it { is_expected.to contain_package('cifs-utils').with_ensure(/(present|installed)/) }
       it { is_expected.to contain_file(title).with_ensure('directory') }
       it { is_expected.not_to contain_file('/etc/default/an_unused_user-credentials') }
 


### PR DESCRIPTION
Use regex for present/ensure test this breaks, I'm not fixing that test a third time.