### PR TITLE
define private_address_template only once for HT

### DIFF
--- a/manifests/profile/hathitrust/networking.pp
+++ b/manifests/profile/hathitrust/networking.pp
@@ -1,0 +1,11 @@
+# network configuration for hathitrust.org
+#
+# @example
+#   include nebula::profile::hathitrust::networking
+class nebula::profile::hathitrust::networking (
+  String $private_address_template = '192.168.0.%s',
+) {
+  class { 'nebula::profile::networking::private':
+    address_template => $private_address_template
+  }
+}

--- a/manifests/role/hathitrust/datasets.pp
+++ b/manifests/role/hathitrust/datasets.pp
@@ -6,14 +6,10 @@
 #
 # @example
 #   include nebula::role::hathitrust::datasets
-class nebula::role::hathitrust::datasets (
-  String $private_address_template = '192.168.0.%s',
-) {
+class nebula::role::hathitrust::datasets () {
   include nebula::role::hathitrust
 
-  class { 'nebula::profile::networking::private':
-    address_template => $private_address_template
-  }
+  include nebula::profile::hathitrust::networking
 
   include nebula::profile::hathitrust::hosts
 

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -6,14 +6,10 @@
 #
 # @example
 #   include nebula::role::hathitrust::ingest_indexing
-class nebula::role::hathitrust::ingest_indexing (
-  String $private_address_template = '192.168.0.%s'
-) {
+class nebula::role::hathitrust::ingest_indexing () {
   include nebula::role::hathitrust
 
-  class { 'nebula::profile::networking::private':
-    address_template => $private_address_template
-  }
+  include nebula::profile::hathitrust::networking
 
   include nebula::profile::hathitrust::ingest_hosts
   include nebula::profile::hathitrust::slip

--- a/manifests/role/webhost/htvm.pp
+++ b/manifests/role/webhost/htvm.pp
@@ -7,14 +7,11 @@
 # @example
 #   include nebula::role::webhost::htvm
 class nebula::role::webhost::htvm (
-  String $private_address_template = '192.168.0.%s',
   String $shibboleth_config_source = 'puppet:///shibboleth'
 ) {
   include nebula::role::hathitrust
 
-  class { 'nebula::profile::networking::private':
-    address_template => $private_address_template
-  }
+  include nebula::profile::hathitrust::networking
 
   include nebula::profile::networking::firewall::http
 


### PR DESCRIPTION
`private_address_template` is defined all over the place, but it's the same for all HathiTrust hosts. Allow it to be defined in one shared profile.

The advantage of this isn't so much that we get to delete a few lines from the hiera data (which is nice), but that we won't have to add another for each future VM type.