### PR TITLE
Support standalone server certificate issuance

### DIFF
--- a/manifests/profile/certbot_route53.pp
+++ b/manifests/profile/certbot_route53.pp
@@ -2,8 +2,13 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
+# @param certs domains/certificates with haproxy services; wildcard implicitly added
+#        example: "quod": { "somejournal.org": ["san-for-journal.org"] }
+# @param simple_certs domains/certificates for standalone hosts; no implicit wildcard
+#        example: "somedomain.org": ["san-for-domain.org","*.somedomain.org"]
 class nebula::profile::certbot_route53 (
   Hash[String, Hash[String, Array[String]]] $certs = {},
+  Hash[String, Array[String]] $simple_certs = {},
   String $cert_dir = "/var/local/cert_dir",
   String $haproxy_cert_dir = "/var/local/haproxy_cert_dir",
   String $letsencrypt_email = "nope@nope.zone",
@@ -69,6 +74,16 @@ class nebula::profile::certbot_route53 (
         target => "${haproxy_cert_dir}/${service}/${main_domain}.pem",
         source => "/etc/letsencrypt/live/${main_domain}/privkey.pem"
       }
+    }
+  }
+
+  $simple_certs.each |$domain, $sans| {
+    file { "${cert_dir}/${domain}.crt":
+      source => "/etc/letsencrypt/live/${domain}/fullchain.pem"
+    }
+
+    file { "${cert_dir}/${domain}.key":
+      source => "/etc/letsencrypt/live/${domain}/privkey.pem"
     }
   }
 }

--- a/templates/profile/certbot_route53/commands.erb
+++ b/templates/profile/certbot_route53/commands.erb
@@ -5,3 +5,6 @@
 certbot certonly --dns-route53 -m "<%= @letsencrypt_email %>" -d "<%= full_san.join(",") %>"
 <% end -%>
 <% end -%>
+<% @simple_certs.each do |domain, sans| -%>
+certbot certonly --dns-route53 -m "<%= @letsencrypt_email %>" -d "<%= [domain, sans].flatten.join(",") %>"
+<% end -%>


### PR DESCRIPTION
Here we extend the profile for managing certificates with Certbot and Route 53. The existing "certs" parameter expects there to be an HAProxy service in place and handles the combined PEM file. The new "simple_certs" paramter supports standalone hosts where we only need the .crt and .key files in "ssl-certs".

Both parameters support SANs, so the main CN is structured as a hash. If there are no SANs, simply supply an empty array. One difference to note is that the "certs" behavior automatically adds a wildcard to the primary domain (CN). This is not assumed for simple_certs.