### PR TITLE
Support simple certs through Certbot + Cloudflare DNS

### DIFF
--- a/manifests/profile/certbot_cloudflare.pp
+++ b/manifests/profile/certbot_cloudflare.pp
@@ -2,8 +2,13 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
+# @param certs domains/certificates with haproxy services; wildcard implicitly added
+#        example: "quod": { "somejournal.org": ["san-for-journal.org"] }
+# @param simple_certs domains/certificates for standalone hosts; no implicit wildcard
+#        example: "somedomain.org": ["san-for-domain.org","*.somedomain.org"]
 class nebula::profile::certbot_cloudflare (
   Hash[String, Hash[String, Array[String]]] $certs = {},
+  Hash[String, Array[String]] $simple_certs = {},
   String $cert_dir = "/var/local/cert_dir",
   String $haproxy_cert_dir = "/var/local/haproxy_cert_dir",
   String $letsencrypt_email = "nope@nope.zone",
@@ -67,6 +72,16 @@ class nebula::profile::certbot_cloudflare (
         target => "${haproxy_cert_dir}/${service}/${main_domain}.pem",
         source => "/etc/letsencrypt/live/${main_domain}/privkey.pem"
       }
+    }
+  }
+
+  $simple_certs.each |$domain, $sans| {
+    file { "${cert_dir}/${domain}.crt":
+      source => "/etc/letsencrypt/live/${domain}/fullchain.pem"
+    }
+
+    file { "${cert_dir}/${domain}.key":
+      source => "/etc/letsencrypt/live/${domain}/privkey.pem"
     }
   }
 }

--- a/spec/classes/profile/certbot_cloudflare_spec.rb
+++ b/spec/classes/profile/certbot_cloudflare_spec.rb
@@ -145,6 +145,83 @@ describe 'nebula::profile::certbot_cloudflare' do
         it { is_expected.not_to contain_concat_fragment("abc.example.pem cert") }
         it { is_expected.not_to contain_concat_fragment("abc.example.pem key") }
       end
+
+      context "with one simple cert, no SANs" do
+        let(:params) do
+          {
+            simple_certs: {
+              "abc.example": []
+            }
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_file("/tmp/all_cert_commands_cloudflare")
+            .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example"})
+        end
+
+        it do
+          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
+        end
+
+        it do
+          is_expected.to contain_file("/var/local/cert_dir/abc.example.key")
+            .with_source("/etc/letsencrypt/live/abc.example/privkey.pem")
+        end
+      end
+
+      context "with one simple cert, two SANs" do
+        let(:params) do
+          {
+            simple_certs: {
+              "abc.example": ['san.local','xyz.local']
+            }
+          }
+        end
+
+        it do
+          is_expected.to contain_file("/tmp/all_cert_commands_cloudflare")
+            .with_content(
+              <<~EOF
+              certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example,san.local,xyz.local"
+              EOF
+            )
+        end
+      end
+
+      context "with two simple certs" do
+        let(:params) do
+          {
+            simple_certs: {
+              "abc.example": [],
+              "xyz.example": ['alt.example', '*.alt.example']
+            }
+          }
+        end
+
+        it do
+          is_expected.to contain_file("/tmp/all_cert_commands_cloudflare")
+            .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example"})
+        end
+
+        it do
+          is_expected.to contain_file("/tmp/all_cert_commands_cloudflare")
+            .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "xyz.example,alt.example,\*.alt.example"})
+        end
+
+        it do
+          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
+        end
+
+        it do
+          is_expected.to contain_file("/var/local/cert_dir/xyz.example.crt")
+            .with_source("/etc/letsencrypt/live/xyz.example/fullchain.pem")
+        end
+      end
     end
   end
 end

--- a/templates/profile/certbot_cloudflare/commands.erb
+++ b/templates/profile/certbot_cloudflare/commands.erb
@@ -5,3 +5,6 @@
 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "<%= @letsencrypt_email %>" -d "<%= full_san.join(",") %>"
 <% end -%>
 <% end -%>
+<% @simple_certs.each do |domain, sans| -%>
+certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "<%= @letsencrypt_email %>" -d "<%= [domain, sans].flatten.join(",") %>"
+<% end -%>


### PR DESCRIPTION
Exactly parallel to the Route 53 support, this allows standalone hosts in a Cloudflare zone to get Certbot + Let's Encrypt certificates.