### PR TITLE
Switch from file to concat_fragment for "simple" certs

### DIFF
--- a/manifests/profile/certbot_cloudflare.pp
+++ b/manifests/profile/certbot_cloudflare.pp
@@ -76,12 +76,22 @@ class nebula::profile::certbot_cloudflare (
   }
 
   $simple_certs.each |$domain, $sans| {
-    file { "${cert_dir}/${domain}.crt":
-      source => "/etc/letsencrypt/live/${domain}/fullchain.pem"
+    concat { "${cert_dir}/${domain}.crt":
+      group  => "puppet",
     }
 
-    file { "${cert_dir}/${domain}.key":
-      source => "/etc/letsencrypt/live/${domain}/privkey.pem"
+    concat_fragment { "${cert_dir}/${domain}.crt cert":
+      target => "${cert_dir}/${domain}.crt",
+      source => "/etc/letsencrypt/live/${domain}/fullchain.pem",
+    }
+
+    concat { "${cert_dir}/${domain}.key":
+      group  => "puppet",
+    }
+
+    concat_fragment { "${cert_dir}/${domain}.key key":
+      target => "${cert_dir}/${domain}.key",
+      source => "/etc/letsencrypt/live/${domain}/privkey.pem",
     }
   }
 }

--- a/manifests/profile/certbot_route53.pp
+++ b/manifests/profile/certbot_route53.pp
@@ -78,11 +78,21 @@ class nebula::profile::certbot_route53 (
   }
 
   $simple_certs.each |$domain, $sans| {
-    file { "${cert_dir}/${domain}.crt":
+    concat { "${cert_dir}/${domain}.crt":
+      group  => "puppet",
+    }
+
+    concat { "${cert_dir}/${domain}.key":
+      group  => "puppet",
+    }
+
+    concat_fragment { "${domain}.crt cert":
+      target => "${cert_dir}/${domain}.crt",
       source => "/etc/letsencrypt/live/${domain}/fullchain.pem"
     }
 
-    file { "${cert_dir}/${domain}.key":
+    concat_fragment { "${domain}.key key":
+      target => "${cert_dir}/${domain}.key",
       source => "/etc/letsencrypt/live/${domain}/privkey.pem"
     }
   }

--- a/spec/classes/profile/certbot_cloudflare_spec.rb
+++ b/spec/classes/profile/certbot_cloudflare_spec.rb
@@ -163,12 +163,14 @@ describe 'nebula::profile::certbot_cloudflare' do
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+          is_expected.to contain_concat_fragment("/var/local/cert_dir/abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
             .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.key")
+          is_expected.to contain_concat_fragment("/var/local/cert_dir/abc.example.key key")
+            .with_target("/var/local/cert_dir/abc.example.key")
             .with_source("/etc/letsencrypt/live/abc.example/privkey.pem")
         end
       end
@@ -213,12 +215,14 @@ describe 'nebula::profile::certbot_cloudflare' do
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+          is_expected.to contain_concat_fragment("/var/local/cert_dir/abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
             .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/xyz.example.crt")
+          is_expected.to contain_concat_fragment("/var/local/cert_dir/xyz.example.crt cert")
+            .with_target("/var/local/cert_dir/xyz.example.crt")
             .with_source("/etc/letsencrypt/live/xyz.example/fullchain.pem")
         end
       end

--- a/spec/classes/profile/certbot_route53_spec.rb
+++ b/spec/classes/profile/certbot_route53_spec.rb
@@ -175,12 +175,14 @@ describe 'nebula::profile::certbot_route53' do
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+          is_expected.to contain_concat_fragment("abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
             .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.key")
+          is_expected.to contain_concat_fragment("abc.example.key key")
+            .with_target("/var/local/cert_dir/abc.example.key")
             .with_source("/etc/letsencrypt/live/abc.example/privkey.pem")
         end
       end
@@ -225,12 +227,14 @@ describe 'nebula::profile::certbot_route53' do
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/abc.example.crt")
+          is_expected.to contain_concat_fragment("abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
             .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          is_expected.to contain_file("/var/local/cert_dir/xyz.example.crt")
+          is_expected.to contain_concat_fragment("xyz.example.crt cert")
+            .with_target("/var/local/cert_dir/xyz.example.crt")
             .with_source("/etc/letsencrypt/live/xyz.example/fullchain.pem")
         end
       end


### PR DESCRIPTION
It is apparently not possible to use a file resource to copy something from the fileserver that is symlinked there, even with links => follow.

The other parts of these profiles use concat_fragments, and I used file because I didn't know why. It appears that it is necessary, and this PR aligns the simple cert process with the others.