### PR TITLE
nebula::exposed_port: handle duplicate blocks

### DIFF
--- a/manifests/exposed_port.pp
+++ b/manifests/exposed_port.pp
@@ -60,7 +60,7 @@ define nebula::exposed_port(
   String $block,
   String $protocol = 'tcp',
 ) {
-  lookup($block).flatten.each |$cidr| {
+  lookup($block).flatten.unique.each |$cidr| {
     firewall { "${title}: ${cidr['name']}":
       proto  => $protocol,
       dport  => $port,

--- a/spec/defines/exposed_port_spec.rb
+++ b/spec/defines/exposed_port_spec.rb
@@ -55,6 +55,23 @@ describe 'nebula::exposed_port' do
         end
       end
 
+      context 'with duplicate blocks' do
+        let(:title) { '200 solr' }
+        let(:params) { { port: 8081, block: 'networks::one_and_two' } }
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_firewall('200 solr: Net One').with(source: '10.0.1.0/24') }
+        it { is_expected.to contain_firewall('200 solr: Net Two').with(source: '10.0.2.0/24') }
+        it { is_expected.to contain_firewall('200 solr: Net Three').with(source: '10.0.3.0/24') }
+      end
+
+      context 'with contradictory blocks' do
+        let(:title) { '200 solr' }
+        let(:params) { { port: 8081, block: 'networks::one_and_three' } }
+
+        it { is_expected.not_to compile }
+      end
+
       context 'with block "devs_and_users"' do
         let(:title) { '250 HTTPS' }
         let(:params) { { port: 443, block: 'devs_and_users' } }

--- a/spec/fixtures/hiera/exposed_port.yaml
+++ b/spec/fixtures/hiera/exposed_port.yaml
@@ -11,3 +11,25 @@ users:
   block: 10.10.10.0/24
 - name: On-site users
   block: 10.10.11.0/24
+
+networks::one:
+  - name: 'Net One'
+    block: '10.0.1.0/24'
+  - name: 'Net Three'
+    block: '10.0.3.0/24'
+networks::two:
+  - name: 'Net Two'
+    block: '10.0.2.0/24'
+  - name: 'Net Three'
+    block: '10.0.3.0/24'
+networks::three:
+  - name: 'Net Three'
+    block: '10.0.3.0/25'
+
+networks::one_and_two:
+- "%{alias('networks::one')}"
+- "%{alias('networks::two')}"
+
+networks::one_and_three:
+- "%{alias('networks::one')}"
+- "%{alias('networks::three')}"


### PR DESCRIPTION
At some point we decided it was important that if we use network block lists like `hathitrust::networks::staff` somewhere other than apache, that we properly handle the case that a block is listed twice:

https://github.com/mlibrary/nebula/blob/962b9b213a0fadd474af7e0aa0e13ecd53815dd6/spec/fixtures/hiera/hathitrust.yaml#L44-L60

I actually need to use `hathitrust::networks::staff` with `nebula::exposed_port`. So, in an effort to _not break_ this canary/test, I added support for duplicate blocks in `nebula::exposed_port`

- `nebula::exposed_port` merges identical blocks
- will still fail if a block name is repeated, but with different content
