### PR TITLE
Silence letsencrypt cron emails by directing them to logs

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -39,6 +39,7 @@ define nebula::cert (
     letsencrypt::certonly { $title:
       domains     => [$title] + $additional_domains,
       manage_cron => true,
+      cron_output => 'log',
     }
 
   } else {
@@ -52,6 +53,7 @@ define nebula::cert (
     letsencrypt::certonly { $title:
       domains       => [$title] + $additional_domains,
       manage_cron   => true,
+      cron_output   => 'log',
       plugin        => 'webroot',
       webroot_paths => $webroot_paths,
     }

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -20,6 +20,7 @@ describe 'nebula::cert' do
             .with_domains(['example.invalid'])
             .with_plugin('standalone')
             .with_manage_cron(true)
+            .with_cron_output('log')
         end
 
         it do
@@ -48,6 +49,7 @@ describe 'nebula::cert' do
               .with_plugin('webroot')
               .with_webroot_paths(['/var/www'])
               .with_manage_cron(true)
+              .with_cron_output('log')
           end
         end
 


### PR DESCRIPTION
This should append `2>&1 | logger -t letsencrypt-renew` to all cert renewal cronjobs.