### PR TITLE
remove deprecated adoptopenjdk apt repo

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -101,13 +101,7 @@ class nebula::profile::apt (
     }
 
     apt::source { 'adoptopenjdk':
-      location => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/',
-      release  => $::lsbdistcodename,
-      repos    => 'main',
-      key      => {
-        'id'     => '8ED17AF5D7E675EB3EE3BCE98AC3B29174885C03',
-        'source' => 'https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public'
-      }
+      ensure => 'absent'
     }
 
     apt::source { 'puppet':


### PR DESCRIPTION
adoptopenjdk.jfrog.io is gone. If we need this we need to use the new repo temurin/adoptium repo, and we should probably add it to the relevant profiles rather than installing the repo on all Debian hosts.