### PR TITLE
HathiTrust TTO-149 - disable remaining Drupal cron jobs

### DIFF
--- a/manifests/profile/hathitrust/cron/statistics.pp
+++ b/manifests/profile/hathitrust/cron/statistics.pp
@@ -19,6 +19,7 @@ class nebula::profile::hathitrust::cron::statistics (
 
   cron {
     default:
+      ensure      => 'absent',
       user        => $user,
       environment => ["MAILTO=${mail_recipient}","SDRROOT=${sdr_root}"];
 


### PR DESCRIPTION
The cron jobs no longer exist at the referenced path, and their output is not really in use. However, we may need to bring these back at some point in another location, so I want to save the reference for them.