### PR TITLE
Add kubelet and ipmi exporter to sysadmin boxes

### DIFF
--- a/manifests/profile/containerd.pp
+++ b/manifests/profile/containerd.pp
@@ -29,4 +29,8 @@ class nebula::profile::containerd {
     content => template('nebula/profile/containerd/config.toml.erb'),
     notify => Service['containerd']
   }
+
+  file { "/etc/containerd":
+    ensure => "directory"
+  }
 }

--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -4,7 +4,7 @@
 class nebula::profile::kubelet (
   String $kubelet_version,
   String $pod_manifest_path = "/etc/kubernetes/manifests",
-  Boolean $use_pod_manifest_path = true,
+  Boolean $manage_pods_with_puppet = true,
 ) {
   include nebula::profile::networking::sysctl
   include nebula::profile::containerd
@@ -35,9 +35,17 @@ class nebula::profile::kubelet (
     require => Package["kubelet"],
   }
 
-  if $use_pod_manifest_path {
+  if $manage_pods_with_puppet {
+    file { $pod_manifest_path:
+      ensure  => "directory",
+      recurse => true,
+      purge   => true,
+      require => Package["kubelet"],
+    }
+
     file { "/etc/systemd/system/kubelet.service.d":
-      ensure => "directory",
+      ensure  => "directory",
+      require => Package["kubelet"],
     }
 
     file { "/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf":

--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+class nebula::profile::kubelet (
+  String $kubelet_version,
+  String $pod_manifest_path = "/etc/kubernetes/manifests",
+  Boolean $use_pod_manifest_path = true,
+) {
+  include nebula::profile::networking::sysctl
+  include nebula::profile::containerd
+  include nebula::profile::kubernetes::apt
+
+  kmod::load { "overlay": }
+  kmod::load { "br_netfilter": }
+
+  file { "/etc/sysctl.d/kubelet.conf":
+    content => template("nebula/profile/kubernetes/kubelet_sysctl.conf.erb"),
+    notify  => Service["procps"],
+  }
+
+  package { "kubelet":
+    ensure  => $kubelet_version,
+    require => Apt::Source["kubernetes"],
+  }
+
+  apt::pin { "kubelet":
+    packages => ["kubelet"],
+    version  => $kubelet_version,
+    priority => 999,
+  }
+
+  service { "kubelet":
+    ensure  => "running",
+    enable  => true,
+    require => Package["kubelet"],
+  }
+
+  if $use_pod_manifest_path {
+    file { "/etc/systemd/system/kubelet.service.d":
+      ensure => "directory",
+    }
+
+    file { "/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf":
+      content => template("nebula/profile/kubelet/systemd.conf.erb"),
+      require => Package["kubelet"],
+      notify  => Exec["kubelet reload daemon"],
+    }
+
+    exec { 'kubelet reload daemon':
+      command     => "/bin/systemctl daemon-reload",
+      refreshonly => true,
+      notify      => Service["kubelet"],
+    }
+  }
+}

--- a/manifests/profile/kubernetes/kubelet.pp
+++ b/manifests/profile/kubernetes/kubelet.pp
@@ -34,9 +34,9 @@ class nebula::profile::kubernetes::kubelet {
   }
 
   class { "nebula::profile::kubelet":
-    kubelet_version       => "${kubernetes_version}-00",
-    pod_manifest_path     => "/etc/kubernetes/manifests",
-    use_pod_manifest_path => false,
+    kubelet_version         => "${kubernetes_version}-00",
+    pod_manifest_path       => "/etc/kubernetes/manifests",
+    manage_pods_with_puppet => false,
   }
 
   firewall {

--- a/manifests/profile/prometheus/exporter/ipmi.pp
+++ b/manifests/profile/prometheus/exporter/ipmi.pp
@@ -1,0 +1,49 @@
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+class nebula::profile::prometheus::exporter::ipmi (
+  Hash[String, Hash] $accounts = {}
+) {
+  if $accounts != {} {
+    include nebula::profile::kubelet
+
+    file { "/etc/kubernetes/manifests/ipmi_exporter.yaml":
+      content => template("nebula/profile/prometheus/exporter/ipmi/pod.yaml.erb")
+    }
+
+    file { "/etc/prometheus":
+      ensure => "directory"
+    }
+
+    file { "/etc/prometheus/ipmi.yaml":
+      content => template("nebula/profile/prometheus/exporter/ipmi/config.yaml.erb")
+    }
+
+    # This looks awfully similar to, but not the same as, the code in
+    # node.pp. Once mysql and haproxy exporters support public/private
+    # ip addresses, I expect a shape will emerge. Some differences are
+    # that, for ipmi exporters, I'm not supporting datacenters that lack
+    # a dedicated prometheus server, plus I don't have to care about the
+    # pushgateway script. I just need to open a port and export config.
+    $all_public_addresses = $facts["mlibrary_ip_addresses"]["public"]
+    $all_private_addresses = $facts["mlibrary_ip_addresses"]["private"]
+
+    if $all_public_addresses == [] and $all_private_addresses == [] {
+      fail("Host cannot be scraped without a public or private IP address")
+    } elsif $all_private_addresses != [] {
+      $ipaddress = $all_private_addresses[0]
+      Firewall <<| tag == "${::datacenter}_prometheus_private_ipmi_exporter" |>>
+    } else {
+      $ipaddress = $all_public_addresses[0]
+      Firewall <<| tag == "${::datacenter}_prometheus_public_ipmi_exporter" |>>
+    }
+
+    @@concat_fragment { "prometheus ipmi scrape config ${::hostname}":
+      tag     => "${::datacenter}_prometheus_ipmi_exporter",
+      target  => "/etc/prometheus/ipmi.yml",
+      order   => "02",
+      content => template("nebula/profile/prometheus/exporter/ipmi/scrape_config.yaml.erb")
+    }
+  }
+}

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -28,6 +28,7 @@ class nebula::profile::prometheus::exporter::node (
   $log_file = '/var/log/prometheus-node-exporter.log'
 
   include nebula::virtual::users
+  include nebula::profile::apt
   include nebula::profile::groups
   include nebula::subscriber::rsyslog
   include nebula::subscriber::systemctl_daemon_reload
@@ -76,6 +77,14 @@ class nebula::profile::prometheus::exporter::node (
   package { 'prometheus-node-exporter':
     ensure  => pick($version, 'installed'),
     require => [User['prometheus'], File['/var/lib/prometheus/node-exporter']],
+  }
+
+  if $version != undef {
+    apt::pin { 'prometheus-node-exporter':
+      packages => ['prometheus-node-exporter'],
+      version  => $version,
+      priority => 999,
+    }
   }
 
   file { '/var/lib/prometheus/node-exporter':

--- a/manifests/role/sysadmin_box.pp
+++ b/manifests/role/sysadmin_box.pp
@@ -13,6 +13,7 @@ class nebula::role::sysadmin_box {
   include nebula::profile::users
   include nebula::profile::ruby
   include nebula::profile::root_ssh_private_keys
+  include nebula::profile::kubelet
 
   class { 'nebula::profile::puppet::query':
     ssl_group => 'sudo',

--- a/manifests/role/sysadmin_box.pp
+++ b/manifests/role/sysadmin_box.pp
@@ -13,7 +13,7 @@ class nebula::role::sysadmin_box {
   include nebula::profile::users
   include nebula::profile::ruby
   include nebula::profile::root_ssh_private_keys
-  include nebula::profile::kubelet
+  include nebula::profile::prometheus::exporter::ipmi
 
   class { 'nebula::profile::puppet::query':
     ssl_group => 'sudo',

--- a/spec/classes/profile/containerd_spec.rb
+++ b/spec/classes/profile/containerd_spec.rb
@@ -16,6 +16,8 @@ describe 'nebula::profile::containerd' do
       it { is_expected.to contain_service('containerd').that_requires('Package[containerd.io]') }
       it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(/^disabled_plugins = \[\]$/) }
       it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(/^\s*SystemdCgroup = true$/) }
+      it { is_expected.to contain_file('/etc/containerd').with_ensure("directory") }
+      it { is_expected.to contain_file('/etc/containerd').that_comes_before("File[/etc/containerd/config.toml]") }
     end
   end
 end

--- a/spec/classes/profile/kubelet_spec.rb
+++ b/spec/classes/profile/kubelet_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::kubelet' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) { { kubelet_version: "invalid-example-version" } }
+
+      it { is_expected.to compile }
+
+      # Prerequisites according to kubernetes documentation:
+      # https://kubernetes.io/docs/setup/production-environment/container-runtimes/
+      it { is_expected.to contain_kmod__load("overlay") }
+      it { is_expected.to contain_kmod__load("br_netfilter") }
+      it { is_expected.to contain_file("/etc/sysctl.d/kubelet.conf").that_notifies("Service[procps]") }
+      ["net.bridge.bridge-nf-call-iptables",
+       "net.bridge.bridge-nf-call-ip6tables",
+       "net.ipv4.ip_forward"].each do |param|
+        it do
+          is_expected.to contain_file("/etc/sysctl.d/kubelet.conf")
+            .with_content(/^#{param} *= *1$/)
+        end
+      end
+
+      it { is_expected.to contain_service("containerd") }
+
+      it do
+        is_expected.to contain_apt__source("kubernetes")
+          .with_location("https://apt.kubernetes.io/")
+          .with_release("kubernetes-xenial")
+      end
+
+      it do
+        is_expected.to contain_package("kubelet")
+          .with_ensure("invalid-example-version")
+          .that_requires("Apt::Source[kubernetes]")
+      end
+
+      it do
+        is_expected.to contain_apt__pin("kubelet")
+          .with_packages(["kubelet"])
+          .with_version("invalid-example-version")
+          .with_priority(999)
+      end
+
+      it do
+        is_expected.to contain_service("kubelet")
+          .with_ensure("running")
+          .with_enable(true)
+          .that_requires("Package[kubelet]")
+      end
+
+      context "with kubelet_version set to 1.2.3-00" do
+        let(:params) { { kubelet_version: "1.2.3-00" } }
+
+        it { is_expected.to contain_package("kubelet").with_ensure("1.2.3-00") }
+        it { is_expected.to contain_apt__pin("kubelet").with_version("1.2.3-00") }
+      end
+
+      it do
+        is_expected.to contain_exec("kubelet reload daemon")
+          .that_notifies("Service[kubelet]")
+          .with_refreshonly(true)
+          .with_command("/bin/systemctl daemon-reload")
+      end
+
+      it do
+        is_expected.to contain_file("/etc/systemd/system/kubelet.service.d")
+          .with_ensure("directory")
+      end
+
+      it do
+        is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+          .that_requires("File[/etc/systemd/system/kubelet.service.d]")
+          .that_requires("Package[kubelet]")
+          .that_notifies("Exec[kubelet reload daemon]")
+      end
+
+      it do
+        is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+          .with_content(/^Restart=always$/)
+      end
+
+      it do
+        # This is important because we're using this file to override
+        # the contents of the original systemd file. Without this empty
+        # line, systemd might ignore our preferred ExecStart.
+        is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+          .with_content(/^ExecStart=$/)
+      end
+
+      it do
+        is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+          .with_content(/^ExecStart=\/usr\/bin\/kubelet/)
+      end
+
+      ["--address=127.0.0.1",
+       "--pod-manifest-path=/etc/kubernetes/manifests",
+       "--container-runtime=remote",
+       "--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
+       "--cgroup-driver=systemd"].each do |param|
+        it do
+          is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+            .with_content(/^ExecStart=.+ #{param}/)
+        end
+      end
+
+      context "with pod_manifest_path set to /tmp" do
+        let(:params) { { kubelet_version: "123", pod_manifest_path: "/tmp" } }
+
+        it do
+          is_expected.to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+            .with_content(/^ExecStart=.+ --pod-manifest-path=\/tmp/)
+        end
+      end
+
+      context "with use_pod_manifest_path set to false" do
+        let(:params) { { kubelet_version: "123", use_pod_manifest_path: false } }
+
+        it { is_expected.not_to contain_file("/etc/systemd/system/kubelet.service.d") }
+        it { is_expected.not_to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf") }
+        it { is_expected.not_to contain_exec("kubelet reload daemon") }
+      end
+    end
+  end
+end

--- a/spec/classes/profile/kubernetes/kubeadm_spec.rb
+++ b/spec/classes/profile/kubernetes/kubeadm_spec.rb
@@ -22,6 +22,7 @@ describe 'nebula::profile::kubernetes::kubeadm' do
           is_expected.to contain_apt__pin('kubeadm').with(
             packages: ['kubeadm'],
             version: '1.14.2-00',
+            priority: 999,
           )
         end
       end

--- a/spec/classes/profile/kubernetes/kubelet_spec.rb
+++ b/spec/classes/profile/kubernetes/kubelet_spec.rb
@@ -70,6 +70,7 @@ describe 'nebula::profile::kubernetes::kubelet' do
           is_expected.to contain_apt__pin('kubelet').with(
             packages: ['kubelet'],
             version: '1.14.2-00',
+            priority: 999,
           )
         end
 

--- a/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+describe 'nebula::profile::prometheus::exporter::ipmi' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts.merge(mlibrary_ip_addresses: {
+          "public" => [os_facts[:ipaddress]],
+          "private" => []
+        })
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.not_to contain_service("kubelet") }
+      it { is_expected.not_to contain_file("/etc/prometheus") }
+      it { is_expected.not_to contain_file("/etc/prometheus/ipmi.yaml") }
+      it { expect(exported_resources).not_to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}") }
+
+      context "with an account set" do
+        let(:params) do
+          { accounts: {
+            "remote-ipmi.example" => {
+              "username" => "myuser123",
+              "password" => "!!secret!!"
+            }
+          }}
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_service("kubelet") }
+        it { is_expected.to contain_file("/etc/kubernetes/manifests/ipmi_exporter.yaml") }
+
+        it { is_expected.to contain_file("/etc/prometheus").with_ensure("directory") }
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .that_requires("File[/etc/prometheus]")
+            .with_content(/remote-ipmi.example:\n *user: "myuser123"\n *pass: "!!secret!!"/m)
+            .with_content(/^ *privilege: "user"$/)
+            .with_content(/^ *timeout: 20000$/)
+            .with_content(/^ *driver: "LAN_2_0"$/)
+            .with_content(/collectors:\n *- "bmc"\n *- "ipmi"\n *- "chassis"/m)
+            .without_content(/exclude_sensor_ids/)
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+            .with_tag("mydatacenter_prometheus_ipmi_exporter")
+            .with_target("/etc/prometheus/ipmi.yml")
+            .with_order("02")
+            .with_content(/^ +- +"remote-ipmi.example"$/)
+            .with_content(/^ +datacenter: "mydatacenter"$/)
+            .with_content(/^ +via: "#{facts[:hostname]}"$/)
+            .with_content(/^ +replacement: "#{facts[:ipaddress]}:9290"$/)
+        end
+      end
+
+      context "with two accounts set" do
+        let(:params) do
+          { accounts: {
+            "ipmi-1.example" => {
+              "username" => "myuser1",
+              "password" => "mysecret1"
+            },
+            "ipmi-2.example" => {
+              "username" => "myuser2",
+              "password" => "mysecret2"
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/ipmi-1.example:\n *user: "myuser1"\n *pass: "mysecret1"/m)
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/ipmi-2.example:\n *user: "myuser2"\n *pass: "mysecret2"/m)
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+            .with_content(/^ +- +"ipmi-1.example"$/)
+            .with_content(/^ +- +"ipmi-2.example"$/)
+        end
+      end
+
+      context "with overridden privilege" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "privilege" => "admin"
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/^ *privilege: "admin"$/)
+        end
+
+        it do
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+            .with_content(/^ +- +"ipmi.example"$/)
+        end
+      end
+
+      context "with overridden timeout" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "timeout" => 60_000
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/^ *timeout: 60000$/)
+        end
+      end
+
+      context "with overridden driver" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "driver" => "LAN"
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/^ *driver: "LAN"$/)
+        end
+      end
+
+      context "with overridden collectors" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "collectors" => %w[ipmi sel dcmi]
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/collectors:\n *- "ipmi"\n *- "sel"\n *- "dcmi"/m)
+        end
+      end
+
+      context "with no collectors" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "collectors" => []
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/^ *collectors: \[]$/)
+        end
+      end
+
+      context "with some sensor ids excluded" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "exclude_sensor_ids" => [2, 32, 29]
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .with_content(/ +exclude_sensor_ids:\n +- +2\n +- +32\n +- +29/m)
+        end
+      end
+
+      context "with an empty list of sensor ids excluded" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "exclude_sensor_ids" => []
+            }
+          }}
+        end
+
+        it do
+          is_expected.to contain_file("/etc/prometheus/ipmi.yaml")
+            .without_content(/exclude_sensor_ids/)
+        end
+      end
+
+      context "with a basic LOM set" do
+        let(:params) do
+          { accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!"
+            }
+          }}
+        end
+
+        context "with a public IP address of 100.100.100.100" do
+          let(:facts) do
+            os_facts.merge(mlibrary_ip_addresses: {
+              "public" => ["100.100.100.100"],
+              "private" => [],
+            })
+          end
+
+          it do
+            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+              .with_content(/^ +replacement: "100.100.100.100:9290"$/)
+          end
+
+          context "and a private IP address of 10.23.45.67" do
+            let(:facts) do
+              os_facts.merge(mlibrary_ip_addresses: {
+                "public" => ["100.100.100.100"],
+                "private" => ["10.23.45.67"],
+              })
+            end
+
+            it do
+              expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+                .with_content(/^ +replacement: "10.23.45.67:9290"$/)
+            end
+          end
+        end
+
+        context "with multiple public and private IP addresses" do
+          let(:facts) do
+            os_facts.merge(mlibrary_ip_addresses: {
+              "public" => ["100.100.100.100", "100.200.200.200"],
+              "private" => ["192.168.0.100", "10.23.45.67"],
+            })
+          end
+
+          it "chooses the first private IP address" do
+            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+              .with_content(/^ +replacement: "192.168.0.100:9290"$/)
+              .without_content(/100.100.100.100/)
+              .without_content(/100.200.200.200/)
+              .without_content(/10.23.45.67/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -44,6 +44,31 @@ describe 'nebula::profile::prometheus::exporter::node' do
           .that_requires('File[/var/lib/prometheus/node-exporter]')
       end
 
+      context "with no version set" do
+        it { is_expected.not_to contain_apt__pin('prometheus-node-exporter') }
+
+        it do
+          is_expected.to contain_package('prometheus-node-exporter')
+            .with_ensure("installed")
+        end
+      end
+
+      context "with version set to v1.2.3" do
+        let(:params) { { version: "v1.2.3" } }
+
+        it do
+          is_expected.to contain_package('prometheus-node-exporter')
+            .with_ensure("v1.2.3")
+        end
+
+        it do
+          is_expected.to contain_apt__pin('prometheus-node-exporter')
+            .with_packages(["prometheus-node-exporter"])
+            .with_version("v1.2.3")
+            .with_priority(999)
+        end
+      end
+
       it do
         is_expected.to contain_file('/var/lib/prometheus/node-exporter')
           .with_ensure('directory')

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -170,3 +170,5 @@ nebula::profile::falcon::cid: default-invalid-cid
 nebula::profile::tsm::servername: tsmserver
 nebula::profile::tsm::serveraddress: tsm.default.invalid
 nebula::jdk_version: '8'
+
+nebula::profile::kubelet::kubelet_version: default.invalid

--- a/templates/profile/kubelet/systemd.conf.erb
+++ b/templates/profile/kubelet/systemd.conf.erb
@@ -1,0 +1,5 @@
+# Managed by puppet (nebula/profile/kubelet/systemd.conf.erb)
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet --address=127.0.0.1 --pod-manifest-path=<%= @pod_manifest_path %> --cgroup-driver=systemd --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock
+Restart=always

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -50,3 +50,5 @@ scrape_configs:
 <% end -%>
 <% end -%>
 <% end -%>
+scrape_config_files:
+- "ipmi.yml"

--- a/templates/profile/prometheus/exporter/ipmi/config.yaml.erb
+++ b/templates/profile/prometheus/exporter/ipmi/config.yaml.erb
@@ -1,0 +1,33 @@
+# Managed by puppet (nebula/profile/prometheus/exporter/ipmi/ipmi.yaml.erb)
+modules:
+<% @accounts.each do |hostname, account| -%>
+  <%= hostname %>:
+    user: "<%= account["username"] %>"
+    pass: "<%= account["password"] %>"
+    privilege: "<%= account["privilege"] || "user" %>"
+    timeout: <%= account["timeout"] || "20000" %>
+    driver: "<%= account["driver"] || "LAN_2_0" %>"
+<% if account.has_key?("collectors") -%>
+<% if account["collectors"].empty? -%>
+    collectors: []
+<% else -%>
+    collectors:
+<% end -%>
+<% account["collectors"].each do |collector| -%>
+    - "<%= collector %>"
+<% end -%>
+<% else -%>
+    collectors:
+    - "bmc"
+    - "ipmi"
+    - "chassis"
+<% end -%>
+<% if account.has_key?("exclude_sensor_ids") -%>
+<% unless account["exclude_sensor_ids"].empty? -%>
+    exclude_sensor_ids:
+<% account["exclude_sensor_ids"].each do |sensor_id| -%>
+    - <%= sensor_id %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% end -%>

--- a/templates/profile/prometheus/exporter/ipmi/pod.yaml.erb
+++ b/templates/profile/prometheus/exporter/ipmi/pod.yaml.erb
@@ -1,0 +1,28 @@
+# Managed by puppet (nebula/profile/prometheus/exporter/ipmi/pod.yaml.erb)
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "ipmi-exporter"
+spec:
+  hostNetwork: true
+  containers:
+  - name: "ipmi"
+    image: "prometheuscommunity/ipmi-exporter:v1.7.0"
+    args: ["--config.file", "/config.yml"]
+    volumeMounts:
+    - name: "config"
+      subPath: "ipmi.yaml"
+      mountPath: "/config.yml"
+      readOnly: true
+  - name: "configmap-reload"
+    image: "ghcr.io/jimmidyson/configmap-reload:v0.12.0"
+    args: ["--volume-dir=/config", "--webhook-url=http://127.0.0.1:9290/-/reload"]
+    volumeMounts:
+    - name: "config"
+      mountPath: "/config"
+      readOnly: true
+  volumes:
+  - name: "config"
+    hostPath:
+      path: "/etc/prometheus"
+      type: "DirectoryOrCreate"

--- a/templates/profile/prometheus/exporter/ipmi/scrape_config.yaml.erb
+++ b/templates/profile/prometheus/exporter/ipmi/scrape_config.yaml.erb
@@ -1,0 +1,27 @@
+- job_name: "ipmi"
+  scrape_interval: "60s"
+  scrape_timeout: "30s"
+  metrics_path: "/ipmi"
+  scheme: "http"
+  static_configs:
+  - targets:
+<% @accounts.each do |hostname, account| -%>
+    - "<%= hostname %>"
+<% end -%>
+    labels:
+      datacenter: "<%= @datacenter %>"
+      via: "<%= @hostname %>"
+  # lom.mgmt/ipmi -> <%= @hostname %>:9290/ipmi?module=lom.mgmt&target=lom.mgmt
+  relabel_configs:
+  - action: "replace"
+    target_label: "__param_target"
+    source_labels: ["__address__"]
+  - action: "replace"
+    target_label: "__param_module"
+    source_labels: ["__param_target"]
+  - action: "replace"
+    target_label: "instance"
+    source_labels: ["__param_target"]
+  - action: "replace"
+    target_label: "__address__"
+    replacement: "<%= @ipaddress %>:9290"


### PR DESCRIPTION
This also creates a generic kubelet profile outside kubernetes, and much of kubernetes's kubelet resources have been replaced with this profile. It's not a complete rewrite, but it's a start.

This should definitely be tested in a development environment before merging.

On the way, this should also fix the naming collision between two different prometheus node exporter packages by pinning to a specific version.