### PR TITLE
Increase PuppetBehind threshold from 30m to 4h

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -14,7 +14,7 @@ groups:
       summary: 'Node {{$labels.host | reReplaceAll "\\.umdl\\.umich\\.edu" ""}} hasn''t recently synced with puppet.'
       dashboard: 'https://puppetboard.kubernetes.lib.umich.edu/node/{{$labels.host}}'
     expr: 'puppet_report{environment="production",host!="ht-web-preview.umdl.umich.edu"} < (time() - (30 * 60))'
-    for: 30m
+    for: 4h
     labels:
       severity: ticket
   - alert: PuppetResourcesFailing


### PR DESCRIPTION
Currently, the "this is bad" state amounts to "it's been more than 30 minutes since this host last synced with puppet" and we start getting alerts when something has been in that state for at least 30 minutes.

In other words, we find out whenever puppet last synced 1 hour ago.

On its own, in practice, this has not been an urgent alert. Also, we've recently started routine maintenance that involves disabling puppet for hours at a time. Such maintenance already takes roughly 2 hours, so even a 2 hour window could easily be too short.

I think 4 hours should be long enough to avoid drenching us in alerts during planned maintenance without being so long that we wish we'd received an alert sooner.