### PR TITLE
Use PROXY protocol from gateway to ingress controllers

### DIFF
--- a/manifests/profile/kubernetes/destination_port/https.pp
+++ b/manifests/profile/kubernetes/destination_port/https.pp
@@ -8,7 +8,7 @@ class nebula::profile::kubernetes::destination_port::https {
   @@concat_fragment { "haproxy kubernetes https ${::hostname}":
     target  => '/etc/haproxy/services.d/https.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:30443 check\n",
+    content => "  server ${::hostname} ${::ipaddress}:30443 check send-proxy\n",
     tag     => "${cluster_name}_haproxy_kubernetes_https",
   }
 }

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -9,7 +9,6 @@ require 'spec_helper'
   ['api',        6443],
   ['etcd',       2379],
   ['http',      30080],
-  ['https',     30443],
   ['https_alt', 31443],
   ['gelf_tcp',  32201],
 ].each do |service, port|
@@ -29,6 +28,33 @@ require 'spec_helper'
               .with_target("/etc/haproxy/services.d/#{service}.cfg")
               .with_order('02')
               .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} check\n")
+              .with_tag("first_cluster_haproxy_kubernetes_#{service}")
+          end
+        end
+      end
+    end
+  end
+end
+
+[
+  ['https',     30443],
+].each do |service, port|
+  describe "nebula::profile::kubernetes::destination_port::#{service}" do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+        let(:facts) { os_facts }
+
+        it { is_expected.to compile }
+
+        describe 'exported resources' do
+          subject { exported_resources }
+
+          it do
+            is_expected.to contain_concat_fragment("haproxy kubernetes #{service.tr('_', ' ')} #{facts[:hostname]}")
+              .with_target("/etc/haproxy/services.d/#{service}.cfg")
+              .with_order('02')
+              .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} check send-proxy\n")
               .with_tag("first_cluster_haproxy_kubernetes_#{service}")
           end
         end


### PR DESCRIPTION
This sends the original client IP in additional metadata outside of the HTTP request. It must be "accepted" by the ingress controller to function.

See also:

* https://www.haproxy.com/documentation/haproxy-configuration-tutorials/client-ip-preservation/enable-proxy-protocol/
* https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/
* https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-proxy-protocol