### PR TITLE
Make HAProxy better at knowing when to pull kubernetes controller nodes from load balancing

### DIFF
--- a/manifests/profile/kubernetes/destination_port/api.pp
+++ b/manifests/profile/kubernetes/destination_port/api.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -8,7 +8,7 @@ class nebula::profile::kubernetes::destination_port::api {
   @@concat_fragment { "haproxy kubernetes api ${::hostname}":
     target  => '/etc/haproxy/services.d/api.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:6443 check\n",
+    content => "  server ${::hostname} ${::ipaddress}:6443 check ssl verify none\n",
     tag     => "${cluster_name}_haproxy_kubernetes_api",
   }
 }

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2020 The Regents of the University of Michigan.
+# Copyright (c) 2020, 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 require 'spec_helper'
 
 [
-  ['api',        6443],
-  ['etcd',       2379],
-  ['https_alt', 31443],
-  ['gelf_tcp',  32201],
-].each do |service, port|
+  ['api',        6443, 'check'],
+  ['etcd',       2379, 'check'],
+  ['http',      30080, 'check send-proxy'],
+  ['https',     30443, 'check send-proxy'],
+  ['https_alt', 31443, 'check'],
+  ['gelf_tcp',  32201, 'check'],
+].each do |service, port, options|
   describe "nebula::profile::kubernetes::destination_port::#{service}" do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
@@ -26,35 +28,7 @@ require 'spec_helper'
             is_expected.to contain_concat_fragment("haproxy kubernetes #{service.tr('_', ' ')} #{facts[:hostname]}")
               .with_target("/etc/haproxy/services.d/#{service}.cfg")
               .with_order('02')
-              .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} check\n")
-              .with_tag("first_cluster_haproxy_kubernetes_#{service}")
-          end
-        end
-      end
-    end
-  end
-end
-
-[
-  ['http',      30080],
-  ['https',     30443],
-].each do |service, port|
-  describe "nebula::profile::kubernetes::destination_port::#{service}" do
-    on_supported_os.each do |os, os_facts|
-      context "on #{os}" do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
-        let(:facts) { os_facts }
-
-        it { is_expected.to compile }
-
-        describe 'exported resources' do
-          subject { exported_resources }
-
-          it do
-            is_expected.to contain_concat_fragment("haproxy kubernetes #{service.tr('_', ' ')} #{facts[:hostname]}")
-              .with_target("/etc/haproxy/services.d/#{service}.cfg")
-              .with_order('02')
-              .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} check send-proxy\n")
+              .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} #{options}\n")
               .with_tag("first_cluster_haproxy_kubernetes_#{service}")
           end
         end

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -6,7 +6,7 @@
 require 'spec_helper'
 
 [
-  ['api',        6443, 'check'],
+  ['api',        6443, 'check ssl verify none'],
   ['etcd',       2379, 'check'],
   ['http',      30080, 'check send-proxy'],
   ['https',     30443, 'check send-proxy'],

--- a/templates/profile/kubernetes/haproxy/services.d/api.cfg.erb
+++ b/templates/profile/kubernetes/haproxy/services.d/api.cfg.erb
@@ -7,5 +7,6 @@ frontend kubernetes-api-front
 
 backend kubernetes-api-back
   mode tcp
-  option tcp-check
   balance roundrobin
+  option httpchk HEAD /
+  http-check expect status 403


### PR DESCRIPTION
HAProxy's TCP check must be essentially no more than `nc -v`, which was succeeding on a controller node that was very much unavailable. `curl -k` (and `ssh`) was timing out, so this pull request aims to make HAProxy do something closer to `curl -k`. When controller nodes are up and working, as of writing, `curl -k https://addr:6443/` without any attempt at valid client certs yields a prompt `403` status.