### PR TITLE
Correctly configure HAProxy to check HTTPS on a TCP frontend

### DIFF
--- a/manifests/profile/kubernetes/destination_port/api.pp
+++ b/manifests/profile/kubernetes/destination_port/api.pp
@@ -8,7 +8,7 @@ class nebula::profile::kubernetes::destination_port::api {
   @@concat_fragment { "haproxy kubernetes api ${::hostname}":
     target  => '/etc/haproxy/services.d/api.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:6443 check ssl verify none\n",
+    content => "  server ${::hostname} ${::ipaddress}:6443 check check-ssl verify none\n",
     tag     => "${cluster_name}_haproxy_kubernetes_api",
   }
 }

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -6,7 +6,7 @@
 require 'spec_helper'
 
 [
-  ['api',        6443, 'check ssl verify none'],
+  ['api',        6443, 'check check-ssl verify none'],
   ['etcd',       2379, 'check'],
   ['http',      30080, 'check send-proxy'],
   ['https',     30443, 'check send-proxy'],


### PR DESCRIPTION
If you use the `ssl` option instead of `check-ssl`, then HAProxy will attempt to add its own TLS encryption on top of the TCP forwarding instead of merely letting it pass through. Fortunately, you can use `check-ssl` instead of `ssl`, to tell it only to use SSL on the HTTP check, not on the main load balancing.