### PR TITLE
Move global shib settings out of the require block

### DIFF
--- a/manifests/profile/www_lib/vhosts/fulcrum.pp
+++ b/manifests/profile/www_lib/vhosts/fulcrum.pp
@@ -19,8 +19,6 @@ class nebula::profile::www_lib::vhosts::fulcrum (
   String $servername = 'www.fulcrum.org'
 ) {
   $authz_base_requires = {
-    auth_type       => 'shibboleth',
-    custom_fragment => 'ShibRequestSetting requireSession 0',
     enforce         => 'all',
     requires        => [
       'not env badrobot',
@@ -90,9 +88,11 @@ class nebula::profile::www_lib::vhosts::fulcrum (
 
     directories     => [
       {
-        provider => 'location',
-        path     => '/',
-        require  => $authz_base_requires,
+        provider        => 'location',
+        path            => '/',
+        auth_type       => 'shibboleth',
+        custom_fragment => 'ShibRequestSetting requireSession 0',
+        require         => $authz_base_requires,
       },
       {
         provider       => 'directory',


### PR DESCRIPTION
The first pass at restoring "badrobots" functionality inadvertently had the global settings to enable shib passively for the Fuclrum vhost within the  config for a require block. This resulted in these settings being ignored and not applied. The changes in this PR address that issue.