### PR TITLE
test all roles include nebula::role::minimum

### DIFF
--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -82,6 +82,10 @@ def test_roles(slice_number = 1, slice_count = 1)
           end
 
           it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
+          it { is_expected.to contain_class('nebula::role::minimum') }
+          if role_name.match?(/^nebula::role::hathitrust/)
+            it { is_expected.to contain_class('nebula::role::hathitrust') }
+          end
         end
       end
     end


### PR DESCRIPTION
Test that all roles include nebula::role::minimum, and that all HT roles include nebula::role::hathitrust. In my testing this only adds a few seconds to the test run.