### PR TITLE
pin puppet/logrotate to 7.0.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,7 @@ fixtures:
     archive:      {"repo": "puppet/archive",          "ref": "7.0.0"}
     kmod:         {"repo": "puppet/kmod",             "ref": "4.0.0"}
     letsencrypt:  {"repo": "puppet/letsencrypt",      "ref": "10.1.0"}
-    logrotate:    {"repo": "puppet/logrotate",        "ref": "7.0.0"}
+    logrotate:    {"repo": "puppet/logrotate",        "ref": "7.0.1"} # 7.0.2 updates systemd, conflicts with postgres
     nginx:        {"repo": "puppet/nginx",            "ref": "5.0.0"}
     php:          {"repo": "puppet/php",              "ref": "9.0.0"}
     apt:          {"repo": "puppetlabs/apt",          "ref": "9.0.0"} # 9.0.1+ breaks, needs updated stdlib

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
     {"name": "puppet/archive",          "version_requirement": ">= 7.0.0  < 8.0.0"},
     {"name": "puppet/kmod",             "version_requirement": ">= 4.0.0  < 5.0.0"},
     {"name": "puppet/letsencrypt",      "version_requirement": ">= 10.1.0 < 11.0.0"},
-    {"name": "puppet/logrotate",        "version_requirement": ">= 7.0.0  < 8.0.0"},
+    {"name": "puppet/logrotate",        "version_requirement": "7.0.1"},
     {"name": "puppet/nginx",            "version_requirement": ">= 5.0.0  < 6.0.0"},
     {"name": "puppet/php",              "version_requirement": ">= 9.0.0  < 10.0.0"},
     {"name": "puppet/unattended_upgrades", "version_requirement": ">= 8.0.0 < 9.0.0"},


### PR DESCRIPTION
puppet/logrotate 7.0.2 updates puppet/systemd, which conflicts with puppetlabs/postgresql