### PR TITLE
HathiTrust DEV-1076: support for monitoring for imgsrv

### DIFF
--- a/files/imgsrv/catprocio
+++ b/files/imgsrv/catprocio
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+pid=$1
+
+# ensure given a numeric process ID
+[[ "$pid" =~ ^[0-9]+$ ]] || exit 1
+
+# ensure running via sudo
+[[ "$(readlink /proc/$PPID/exe)" == "/usr/bin/sudo" ]] || exit 2
+
+# the grandparent of this process (i.e. the parent of sudo) must be the same as
+# the parent of the process we're checking
+
+parent=$(cut -f 4 -d ' ' "/proc/$pid/stat")
+this_grandpid=$(cut -f 4 -d ' ' "/proc/$PPID/stat")
+
+[[ "$parent" == "$this_grandpid" ]] || exit 3
+
+cat "/proc/$pid/io"

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -56,6 +56,8 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   package { 'libfcgi-bin': }
+  nebula::cpan { 'Prometheus::Tiny::Shared': }
+
   cron { 'imgsrv responsiveness check':
     command => '/usr/local/bin/check_imgsrv > /dev/null 2>&1',
     user    => 'root',
@@ -74,6 +76,17 @@ class nebula::profile::hathitrust::imgsrv (
     ensure => 'present',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/startup_app"
+  }
+
+  file { '/usr/local/bin/catprocio':
+    ensure  => 'present',
+    content => file('nebula/imgsrv/catprocio'),
+    mode    => '0755',
+  }
+
+  file { '/etc/sudoers.d/imgsrv-catprocio':
+    ensure  => 'present',
+    content => 'nobody ALL=(root) NOPASSWD: /usr/local/bin/catprocio'
   }
 
 }

--- a/spec/classes/profile/hathitrust/imgsrv_spec.rb
+++ b/spec/classes/profile/hathitrust/imgsrv_spec.rb
@@ -21,12 +21,16 @@ describe 'nebula::profile::hathitrust::imgsrv' do
 
       it { is_expected.to contain_service('imgsrv') }
       it { is_expected.to contain_package('libfcgi-bin') }
+      it { is_expected.to contain_nebula__cpan('Prometheus::Tiny::Shared') }
 
       it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^SDRROOT=/sdrroot$}) }
       it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^NPROC=10$}) }
       it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^BIND=127.0.0.1:31028}) }
 
       it { is_expected.to contain_file('/etc/systemd/system/imgsrv.service').with_content(%r{ExecStart=/usr/local/bin/startup_imgsrv}) }
+
+      it { is_expected.to contain_file('/usr/local/bin/catprocio') }
+      it { is_expected.to contain_file('/etc/sudoers.d/imgsrv-catprocio') }
     end
   end
 end


### PR DESCRIPTION
* Prometheus::Tiny::Shared via CPAN for collecting prometheus metrics in imgsrv
* Script to be run under sudo to allow a process to collect its childrens' final IO metrics

In particular, imgsrv spends much of its time in subprocesses that do a significant amount of I/O. We cannot directly instrument those processes (primarily `unzip` and `grk_decompress`), but would like to monitor some things about them. I have implemented a package in perl (https://github.com/hathitrust/mdp-lib/blob/66a5044a357387289fc60acdf679025b32392553/Utils/MonitorRun.pm#L55) that extends `IPC::Run` to collect metrics from subprocesses after they exit but before issuing a `wait()` system call (that is, the processes are in a "zombie" state). However, after a subprocess exits but before it is reaped, information about its owning user ID is no longer present, and the system makes some of its statistics readable only by root. This sudo script enables a process to read statistics information for its children.