### PR TITLE
Local storage

### DIFF
--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -6,7 +6,7 @@
 # 
 # Create a volume to use for kubernetes local storage on a worker node
 ##
-# @param volume_name The (conventionally "${UUID}-pvc") name of the volume
+# @param volume_name The name of the volume (conventionally the UUID of the PVC)
 # @param capacity The disk capacity in MB
 
 define nebula::local_storage_volume (
@@ -28,10 +28,10 @@ define nebula::local_storage_volume (
     unless => "/usr/bin/file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }
 
-  mount { "/mnt/local-pvs/mounts/${volume_name}":
+  mount { "/mnt/local-pvs/mounts/${volume_name}-pvc":
     ensure  => 'mounted',
     device  => "/mnt/local-pvs/disks/${volume_name}",
-    options => "loop,rw,usrquote,grpquota",
+    options => "loop,rw,usrquota,grpquota",
     fstype  => 'ext4',
   }
 }

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -25,7 +25,7 @@ define nebula::local_storage_volume (
 
   exec { "make $volume_name a filesystem":
     command => "/sbin/mkfs.ext4 -m 0 /mnt/local-pvs/disks/${volume_name}",
-    unless => "file /mnt/local-pvs/disks/${volume_name} | grep ext4"
+    unless => "/usr/bin/file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }
 
   mount { "/mnt/local-pvs/mounts/${volume_name}":

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -6,31 +6,31 @@
 # 
 # Create a volume to use for kubernetes local storage on a worker node
 ##
-# @param name The name of the volume
+# @param volume_name The (conventionally "${UUID}-pvc") name of the volume
 # @param capacity The disk capacity in MB
 
 define nebula::local_storage_volume (
-  String $name,
+  String $volume_name,
   Integer $mib_capacity
 ) {
 
-  file { "/mnt/local-pvs/mounts/$name":
+  file { "/mnt/local-pvs/mounts/$volume_name":
     ensure => 'directory'
   }
 
   exec { "make disk file":
-    command => "dd if=/dev/zero of=/mnt/local-pvs/disks/${name} bs=1048576 count=${mib_capacity}",
-    creates => "/mnt/local-pvs/disks/${name}"
+    command => "dd if=/dev/zero of=/mnt/local-pvs/disks/${volume_name} bs=1048576 count=${mib_capacity}",
+    creates => "/mnt/local-pvs/disks/${volume_name}"
   }
 
   exec { "make it a filesystem":
-    command => "mkfs.ext4 -m 0 /mnt/local-pvs/disks/${name}",
-    unless => "file /mnt/local-pvs/disks/${name} | grep ext4"
+    command => "mkfs.ext4 -m 0 /mnt/local-pvs/disks/${volume_name}",
+    unless => "file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }
 
-  mount { "/mnt/local-pvs/mounts/${name}":
+  mount { "/mnt/local-pvs/mounts/${volume_name}":
     ensure  => 'mounted',
-    device  => "/mnt/local-pvs/disks/${name}",
+    device  => "/mnt/local-pvs/disks/${volume_name}",
     options => "loop,rw,usrquote,grpquota",
     fstype  => 'ext4',
   }

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -19,12 +19,12 @@ define nebula::local_storage_volume (
   }
 
   exec { "make $volume_name disk file":
-    command => "dd if=/dev/zero of=/mnt/local-pvs/disks/${volume_name} bs=1048576 count=${mib_capacity}",
+    command => "/bin/dd if=/dev/zero of=/mnt/local-pvs/disks/${volume_name} bs=1048576 count=${mib_capacity}",
     creates => "/mnt/local-pvs/disks/${volume_name}"
   }
 
   exec { "make $volume_name a filesystem":
-    command => "mkfs.ext4 -m 0 /mnt/local-pvs/disks/${volume_name}",
+    command => "/sbin/mkfs.ext4 -m 0 /mnt/local-pvs/disks/${volume_name}",
     unless => "file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }
 

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -1,0 +1,37 @@
+# Copyright (c) 2019-2020 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::local_storage_volume
+# 
+# Create a volume to use for kubernetes local storage on a worker node
+##
+# @param name The name of the volume
+# @param capacity The disk capacity in MB
+
+define nebula::local_storage_volume (
+  String $name,
+  Integer $mib_capacity
+) {
+
+  file { "/mnt/local-pvs/mounts/$name":
+    ensure => 'directory'
+  }
+
+  exec { "make disk file":
+    command => "dd if=/dev/zero of=/mnt/local-pvs/disks/${name} bs=1048576 count=${mib_capacity}",
+    creates => "/mnt/local-pvs/disks/${name}"
+  }
+
+  exec { "make it a filesystem":
+    command => "mkfs.ext4 -m 0 /mnt/local-pvs/disks/${name}",
+    unless => "file /mnt/local-pvs/disks/${name} | grep ext4"
+  }
+
+  mount { "/mnt/local-pvs/mounts/${name}":
+    ensure  => 'mounted',
+    device  => "/mnt/local-pvs/disks/${name}",
+    options => "loop,rw,usrquote,grpquota",
+    fstype  => 'ext4',
+  }
+}

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -18,12 +18,12 @@ define nebula::local_storage_volume (
     ensure => 'directory'
   }
 
-  exec { "make disk file":
+  exec { "make $volume_name disk file":
     command => "dd if=/dev/zero of=/mnt/local-pvs/disks/${volume_name} bs=1048576 count=${mib_capacity}",
     creates => "/mnt/local-pvs/disks/${volume_name}"
   }
 
-  exec { "make it a filesystem":
+  exec { "make $volume_name a filesystem":
     command => "mkfs.ext4 -m 0 /mnt/local-pvs/disks/${volume_name}",
     unless => "file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -28,7 +28,7 @@ define nebula::local_storage_volume (
     unless => "/usr/bin/file /mnt/local-pvs/disks/${volume_name} | grep ext4"
   }
 
-  mount { "/mnt/local-pvs/mounts/${volume_name}-pvc":
+  mount { "/mnt/local-pvs/mounts/${volume_name}":
     ensure  => 'mounted',
     device  => "/mnt/local-pvs/disks/${volume_name}",
     options => "loop,rw,usrquota,grpquota",

--- a/manifests/profile/kubernetes/filesystems.pp
+++ b/manifests/profile/kubernetes/filesystems.pp
@@ -4,11 +4,18 @@
 
 class nebula::profile::kubernetes::filesystems (
   Hash[String, Hash] $cifs_mounts = {},
+  Hash[String, Hash] $local_storage_volumes = {},
 ) {
   ensure_packages(['nfs-common', 'lvm2'], {'ensure' => 'present'})
 
   $cifs_mounts.each |$mount_title, $mount_parameters| {
     nebula::cifs_mount { "/mnt/legacy_cifs_${mount_title}":
+      * => $mount_parameters,
+    }
+  }
+
+  $local_storage_volumes.each |$mount_title, $mount_parameters| {
+    nebula::local_storage_volume { $mount_title:
       * => $mount_parameters,
     }
   }


### PR DESCRIPTION
Puppet can create and mount (or become aware of) local storage volumes for kubernetes worker nodes. It should not resize or remove volumes.