### PR TITLE
remove one last instance of old stdlib has_key api

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -43,7 +43,7 @@ class nebula::profile::haproxy(
   }
 
   $services.filter |$service, $params| {
-    $params.has_key('floating_ip')
+    'floating_ip' in $params
   }.each |$service, $params| {
     @nebula::haproxy::service { $service :
       cert_source => $cert_source,


### PR DESCRIPTION
Fixing the same outdated API usage as 64634a12.