### PR TITLE
replace resolv_conf module with local module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -40,6 +40,5 @@ fixtures:
     reboot:       {"repo": "puppetlabs/reboot",       "ref": "5.0.0"}
     sshkeys_core: {"repo": "puppetlabs/sshkeys_core", "ref": "2.4.0"}
     stdlib:       {"repo": "puppetlabs/stdlib",       "ref": "8.6.0"} # ?! dragons...
-    resolv_conf:  {"repo": "saz/resolv_conf",         "ref": "5.1.0"}
     debconf:      {"repo": "stm/debconf",             "ref": "6.0.0"}
     unattended_upgrades: {"repo": "puppet/unattended_upgrades", "ref": "8.0.0"}

--- a/manifests/profile/dns/smartconnect.pp
+++ b/manifests/profile/dns/smartconnect.pp
@@ -44,7 +44,7 @@ class nebula::profile::dns::smartconnect (
     $nameservers = $other_ns_ips
   }
 
-  class { 'resolv_conf':
+  class { 'nebula::resolv_conf':
     nameservers => concat(['127.0.0.1'], $nameservers),
     searchpath  => lookup('nebula::resolv_conf::searchpath'),
     require     => Service['bind9']

--- a/manifests/profile/dns/standard.pp
+++ b/manifests/profile/dns/standard.pp
@@ -9,8 +9,5 @@
 # @example
 #   include nebula::profile::dns::standard
 class nebula::profile::dns::standard {
-  class { 'resolv_conf':
-    nameservers => lookup('nebula::resolv_conf::nameservers'),
-    searchpath  => lookup('nebula::resolv_conf::searchpath'),
-  }
+  include nebula::resolv_conf
 }

--- a/manifests/resolv_conf.pp
+++ b/manifests/resolv_conf.pp
@@ -1,0 +1,17 @@
+class nebula::resolv_conf (
+  Array[String] $nameservers,
+  Array[String] $searchpath = [],
+  String        $mode = '0644',
+){
+  # replicate behavior of saz/resolv_conf for Debian based OS
+  package { 'resolvconf':
+    ensure => absent
+  }
+
+  file { '/etc/resolv.conf':
+    owner   => 'root',
+    group   => 'root',
+    mode    => $mode,
+    content => template("nebula/resolv_conf/resolv.conf.erb"),
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,6 @@
     {"name": "puppetlabs/reboot",       "version_requirement": ">= 5.0.0  < 6.0.0"},
     {"name": "puppetlabs/sshkeys_core", "version_requirement": ">= 2.4.0  < 3.0.0"},
     {"name": "puppetlabs/stdlib",       "version_requirement": "8.6.0"},
-    {"name": "saz/resolv_conf",         "version_requirement": ">= 5.1.0  < 6.0.0"},
     {"name": "stm/debconf",             "version_requirement": ">= 6.0.0  < 7.0.0"}
   ],
   "operatingsystem_support": [

--- a/spec/classes/profile/dns/smartconnect_spec.rb
+++ b/spec/classes/profile/dns/smartconnect_spec.rb
@@ -31,6 +31,18 @@ describe 'nebula::profile::dns::smartconnect' do
                                                    .with_require('Service[bind9]')
       end
 
+      it 'removes resolvconf package if present' do
+        is_expected.to contain_package('resolvconf').with_ensure('absent')
+      end
+      it 'contains expected resolv.conf file' do
+        is_expected.to contain_file('/etc/resolv.conf')
+          .with_content(/^#.*puppet/)
+          .with_content(/^search searchpath\.default\.invalid$/)
+          .with_content(/^nameserver 127.0.0.1$/)
+          .with_content(/^nameserver 5.5.5.5$/)
+          .with_content(/^nameserver 4.4.4.4$/)
+      end
+
       [
         '/etc/bind/named.conf',
         '/etc/bind/named.conf.local',

--- a/spec/classes/profile/dns/smartconnect_spec.rb
+++ b/spec/classes/profile/dns/smartconnect_spec.rb
@@ -21,7 +21,7 @@ describe 'nebula::profile::dns::smartconnect' do
       end
 
       it do
-        is_expected.to contain_class('resolv_conf').with_nameservers(
+        is_expected.to contain_class('nebula::resolv_conf').with_nameservers(
           [
             '127.0.0.1',  # localhost
             '5.5.5.5',    # nebula::resolv_conf::nameservers[0]
@@ -79,7 +79,7 @@ describe 'nebula::profile::dns::smartconnect' do
         let(:params) { { other_ns_ips: ['3.3.3.3', '2.2.2.2', '1.1.1.1'] } }
 
         it do
-          is_expected.to contain_class('resolv_conf').with_nameservers(
+          is_expected.to contain_class('nebula::resolv_conf').with_nameservers(
             [
               '127.0.0.1',
               '3.3.3.3',

--- a/spec/classes/profile/dns/standard_spec.rb
+++ b/spec/classes/profile/dns/standard_spec.rb
@@ -15,6 +15,17 @@ describe 'nebula::profile::dns::standard' do
           ['5.5.5.5', '4.4.4.4'],
         ).with_searchpath(['searchpath.default.invalid'])
       end
+
+      it 'removes resolvconf package if present' do
+        is_expected.to contain_package('resolvconf').with_ensure('absent')
+      end
+      it 'contains expected resolv.conf file' do
+        is_expected.to contain_file('/etc/resolv.conf')
+          .with_content(/^#.*puppet/)
+          .with_content(/^search searchpath\.default\.invalid$/)
+          .with_content(/^nameserver 5.5.5.5$/)
+          .with_content(/^nameserver 4.4.4.4$/)
+      end
     end
   end
 end

--- a/spec/classes/profile/dns/standard_spec.rb
+++ b/spec/classes/profile/dns/standard_spec.rb
@@ -11,7 +11,7 @@ describe 'nebula::profile::dns::standard' do
       let(:facts) { os_facts }
 
       it do
-        is_expected.to contain_class('resolv_conf').with_nameservers(
+        is_expected.to contain_class('nebula::resolv_conf').with_nameservers(
           ['5.5.5.5', '4.4.4.4'],
         ).with_searchpath(['searchpath.default.invalid'])
       end

--- a/spec/classes/resolv_conf_spec.rb
+++ b/spec/classes/resolv_conf_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nebula::resolv_conf' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      it 'removes resolvconf package if present' do
+        is_expected.to contain_package('resolvconf').with_ensure('absent')
+      end
+
+      it 'contains expected resolv.conf file' do
+        is_expected.to contain_file('/etc/resolv.conf')
+          .with_owner('root')
+          .with_group('root')
+          .with_mode('0644')
+          .with_content(/^#.*puppet/)
+          .with_content(/^search searchpath\.default\.invalid$/)
+          .with_content(/^nameserver 5.5.5.5\nnameserver 4.4.4.4$/)
+      end
+
+      context 'different nameservers' do
+        let(:params) { { nameservers: ['3.3.3.3', '2.2.2.2', '1.1.1.1'] } }
+
+        it do
+          is_expected.to contain_file('/etc/resolv.conf')
+            .with_content(/^#.*puppet/)
+            .with_content(/^search searchpath\.default\.invalid$/)
+            .with_content(/^nameserver 3.3.3.3\nnameserver 2.2.2.2\nnameserver 1.1.1.1$/)
+        end
+      end
+
+      context 'searchpath set to []' do
+        let(:params) { { searchpath: [] } }
+
+        it do
+          is_expected.to contain_file('/etc/resolv.conf')
+            .with_content(/^#.*puppet/)
+            .without_content(/^search/)
+            .with_content(/^nameserver 5.5.5.5\nnameserver 4.4.4.4$/)
+        end
+      end
+
+      context 'custom file mode' do
+        let(:params) { { mode: '0664' } }
+
+        it do
+          is_expected.to contain_file('/etc/resolv.conf')
+            .with_content(/^#.*puppet/)
+            .with_mode('0664')
+        end
+      end
+
+    end
+  end
+end

--- a/templates/resolv_conf/resolv.conf.erb
+++ b/templates/resolv_conf/resolv.conf.erb
@@ -1,0 +1,8 @@
+# Managed by puppet (nebula/resolv_conf/resolv.conf.erb)
+
+<% if !@searchpath.empty? -%>
+search <%= @searchpath.join(" ") %>
+<% end -%>
+<% @nameservers.each do |ns| -%>
+nameserver <%= ns %>
+<% end -%>


### PR DESCRIPTION
saz/resolv_conf is one of our last third party dependencies, it requires an out of date stdlib, and we don't use most of its features. Thus, this PR replaces it w/ a local rewrite.