### PR TITLE
Add geoip support to the quod general profile

### DIFF
--- a/manifests/profile/quod/dependencies/packages.pp
+++ b/manifests/profile/quod/dependencies/packages.pp
@@ -13,6 +13,7 @@ class nebula::profile::quod::dependencies::packages () {
     [
       'curl',
       'emacs',
+      'geoip-bin',
       'git',
       'imagemagick',
       'libapache2-mod-authz-umichlib',
@@ -22,4 +23,7 @@ class nebula::profile::quod::dependencies::packages () {
       'oracle-instantclient12.1-devel',
     ]
   )
+  file { '/usr/share/GeoIP':
+    target =>  '/quod/misc/g/geoip'
+  }
 }

--- a/manifests/profile/quod/dependencies/perl.pp
+++ b/manifests/profile/quod/dependencies/perl.pp
@@ -79,6 +79,7 @@ class nebula::profile::quod::dependencies::perl () {
     'libfile-slurp-perl',
     'libfont-afm-perl',
     'libfont-freetype-perl',
+    'libgeo-ip-perl',
     'libgssapi-perl',
     'libhtml-format-perl',
     'libhtml-form-perl',
@@ -202,6 +203,7 @@ class nebula::profile::quod::dependencies::perl () {
     'File::Namaste',
     'File::Pairtree',
     'File::Value',
+    'IP::Geolocation::MMDB',
     'Mail::Sender',
     'Net::IDN::Encode',
     'OAuth::Lite']:


### PR DESCRIPTION
This includes perl packages, geoip executables, and a symlink to where the country db is located on shared quod storage.

Roger has confirmed these changes are sufficient for his needs to add country identification for a new collection. We'll need to implement a scheduled refresh process for the database separately. Currently HT owns the service and the refresh after many years of LIT owning it. HT is fine sharing with us for this reviced purpose, as long as we document the arrangement.