### PR TITLE
explicitly set HSTS header on 400 errors

### DIFF
--- a/files/haproxy/errors/hsts400.http
+++ b/files/haproxy/errors/hsts400.http
@@ -1,0 +1,10 @@
+HTTP/1.0 400 Bad request
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+Strict-Transport-Security: max-age=31536000
+
+<html><body><h1>400 Bad request</h1>
+Your browser sent an invalid request.
+</body></html>
+

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -19,20 +19,19 @@ class nebula::profile::haproxy(
     master => $master
   }
 
-  file { '/etc/haproxy/haproxy.cfg':
-    ensure  => 'present',
-    mode    => '0644',
-    content => template('nebula/profile/haproxy/haproxy.cfg.erb'),
-    require => Package['haproxy'],
-    notify  => Service['haproxy'],
-  }
-
-  file { '/etc/default/haproxy':
-    ensure  => 'present',
-    mode    => '0644',
-    content => template('nebula/profile/haproxy/default.erb'),
-    require => Package['haproxy'],
-    notify  => Service['haproxy'],
+  file {
+    default:
+      ensure  => 'present',
+      mode    => '0644',
+      require => Package['haproxy'],
+      notify  => Service['haproxy'],
+    ;
+    '/etc/haproxy/haproxy.cfg':
+      content => template('nebula/profile/haproxy/haproxy.cfg.erb');
+    '/etc/default/haproxy':
+      content => template('nebula/profile/haproxy/default.erb');
+    '/etc/haproxy/errors/hsts400.http':
+      source  => 'puppet:///modules/nebula/haproxy/errors/hsts400.http';
   }
 
   file { '/etc/ssl/private' :

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -183,6 +183,10 @@ describe 'nebula::profile::haproxy' do
         end
       end
 
+      describe 'haproxy errors' do
+        it { is_expected.to contain_file('/etc/haproxy/errors/hsts400.http').with_source('puppet:///modules/nebula/haproxy/errors/hsts400.http') }
+      end
+
       describe 'base keepalived config file' do
         let(:file) { keepalived_conf }
 

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -71,6 +71,7 @@ describe 'nebula::haproxy::service' do
               bind 1.2.3.4:443 ssl crt /etc/ssl/private/svc1
               stats uri /haproxy?stats
               http-response set-header "Strict-Transport-Security" "max-age=31536000"
+              errorfile 400 /etc/haproxy/errors/hsts400.http
               http-request set-header X-Client-IP %ci
               http-request set-header X-Forwarded-Proto https
               default_backend svc1-dc1-https-back

--- a/templates/profile/haproxy/frontend.erb
+++ b/templates/profile/haproxy/frontend.erb
@@ -13,6 +13,7 @@ bind <%= @floating_ip %>:<%= @protocol_options['port'] %><%= @protocol_options['
 stats uri /haproxy?stats
 <% if @protocol == "https" -%>
 http-response set-header "Strict-Transport-Security" "max-age=31536000"
+errorfile 400 /etc/haproxy/errors/hsts400.http
 <% end -%>
 http-request set-header X-Client-IP %ci
 http-request set-header X-Forwarded-Proto <%= @protocol %>


### PR DESCRIPTION
If haproxy doesn't understand the apache response it throws it away and sends a 400. Since `set-header` directive only modifies backend responces it does not apply to a 400 that is produced by haproxy itself.

This explicitly sets Strict-Transport-Security on 400 errors on https frontends to fix this issue.