### PR TITLE
DEV-1141: Add Prometheus::Tiny::Shared for all HT perl places

### DIFF
--- a/manifests/profile/hathitrust/dependencies.pp
+++ b/manifests/profile/hathitrust/dependencies.pp
@@ -65,4 +65,10 @@ class nebula::profile::hathitrust::dependencies () {
 
   ensure_packages(['mariadb-client'])
 
+  file { '/usr/local/bin/catprocio':
+    ensure  => 'present',
+    content => file('nebula/imgsrv/catprocio'),
+    mode    => '0755',
+  }
+
 }

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -77,12 +77,6 @@ class nebula::profile::hathitrust::imgsrv (
     source => "https://${http_files}/ae-utils/bins/startup_app"
   }
 
-  file { '/usr/local/bin/catprocio':
-    ensure  => 'present',
-    content => file('nebula/imgsrv/catprocio'),
-    mode    => '0755',
-  }
-
   file { '/etc/sudoers.d/imgsrv-catprocio':
     ensure  => 'present',
     content => 'nobody ALL=(root) NOPASSWD: /usr/local/bin/catprocio'

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -56,7 +56,6 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   package { 'libfcgi-bin': }
-  nebula::cpan { 'Prometheus::Tiny::Shared': }
 
   cron { 'imgsrv responsiveness check':
     command => '/usr/local/bin/check_imgsrv > /dev/null 2>&1',

--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -150,7 +150,8 @@ class nebula::profile::hathitrust::perl () {
     'Noid',
     'MARC::Record',
     'MARC::File::XML',
-    'MARC::File::MiJ']:
+    'MARC::File::MiJ',
+    'Prometheus::Tiny::Shared']:
   }
 
 }

--- a/manifests/profile/hathitrust/slip.pp
+++ b/manifests/profile/hathitrust/slip.pp
@@ -11,4 +11,9 @@
 class nebula::profile::hathitrust::slip (
 ) {
   nebula::usergroup { 'slip': }
+
+  file { '/etc/sudoers.d/slip-catprocio':
+    ensure  => 'present',
+    content => 'slip ALL=(root) NOPASSWD: /usr/local/bin/catprocio'
+  }
 }

--- a/spec/classes/profile/hathitrust/dependencies_spec.rb
+++ b/spec/classes/profile/hathitrust/dependencies_spec.rb
@@ -18,6 +18,7 @@ describe 'nebula::profile::hathitrust::dependencies' do
         it { is_expected.to contain_package('mariadb-client') }
       end
 
+      it { is_expected.to contain_file('/usr/local/bin/catprocio') }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/imgsrv_spec.rb
+++ b/spec/classes/profile/hathitrust/imgsrv_spec.rb
@@ -21,7 +21,6 @@ describe 'nebula::profile::hathitrust::imgsrv' do
 
       it { is_expected.to contain_service('imgsrv') }
       it { is_expected.to contain_package('libfcgi-bin') }
-      it { is_expected.to contain_nebula__cpan('Prometheus::Tiny::Shared') }
 
       it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^SDRROOT=/sdrroot$}) }
       it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^NPROC=10$}) }

--- a/spec/classes/profile/hathitrust/imgsrv_spec.rb
+++ b/spec/classes/profile/hathitrust/imgsrv_spec.rb
@@ -28,7 +28,6 @@ describe 'nebula::profile::hathitrust::imgsrv' do
 
       it { is_expected.to contain_file('/etc/systemd/system/imgsrv.service').with_content(%r{ExecStart=/usr/local/bin/startup_imgsrv}) }
 
-      it { is_expected.to contain_file('/usr/local/bin/catprocio') }
       it { is_expected.to contain_file('/etc/sudoers.d/imgsrv-catprocio') }
     end
   end

--- a/spec/classes/profile/hathitrust/slip_spec.rb
+++ b/spec/classes/profile/hathitrust/slip_spec.rb
@@ -13,6 +13,8 @@ describe 'nebula::profile::hathitrust::slip' do
       it { is_expected.to compile }
 
       it { is_expected.to contain_nebula__usergroup('slip') }
+
+      it { is_expected.to contain_file('/etc/sudoers.d/slip-catprocio') }
     end
   end
 end

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -73,6 +73,8 @@ describe 'nebula::role::webhost::htvm' do
       # not specified explicitly - realized through Nebula::Usergroup[htprod]
       it { is_expected.to contain_user('htingest') }
       it { is_expected.to contain_user('htweb') }
+
+      it { is_expected.to contain_nebula__cpan('Prometheus::Tiny::Shared') }
     end
   end
 end


### PR DESCRIPTION
Before, this was only installed for web servers (i.e. places with imgsrv) but effectively any place that uses HT perl code (including e.g. for slip) could call functions that need the library.