### PR TITLE
Add php-bcmath to support the readership map

### DIFF
--- a/manifests/profile/php73.pp
+++ b/manifests/profile/php73.pp
@@ -28,6 +28,7 @@ class nebula::profile::php73 (
       #  'php-pear',
       'php7.3-redis',
       'php7.3-xdebug',
+      'php7.3-bcmath',
       'php7.3-cli',
       'php7.3-common',
       'php7.3-curl',


### PR DESCRIPTION
The app was updated from Universal Analytics to GA4, and that requires the bcmath extension. It is packaged in Debian repositories as well as the php-community/sury repositories. The app is actually using PHP 8.2, but I am adding it here as some record keeping.