### PR TITLE
Add php-bcmath to default production PHP

### DIFF
--- a/manifests/profile/www_lib/php.pp
+++ b/manifests/profile/www_lib/php.pp
@@ -49,6 +49,7 @@ class nebula::profile::www_lib::php (
       "php${default_php_version}-msgpack",
       "php${default_php_version}-redis",
       "php${default_php_version}-xdebug",
+      "php${default_php_version}-bcmath",
       "php${default_php_version}-curl",
       "php${default_php_version}-gd",
       "php${default_php_version}-ldap",


### PR DESCRIPTION
The campus readership map is planned for an update soon, and will depend on php-bcmath to support Google Analytics 4. This follows the addition in development. At present, this materializes as php8.1-bcmath.