### PR TITLE
Restart filebeat when rotating HAProxy logs

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -148,4 +148,14 @@ class nebula::profile::haproxy(
     content => template('nebula/profile/haproxy/stats_frontend.cfg.erb'),
   }
 
+  logrotate::rule { 'haproxy':
+    path         => '/var/log/haproxy.log',
+    rotate_every => 'day',
+    rotate       => 5,
+    missingok    => true,
+    ifempty      => false,
+    compress     => true,
+    postrotate   => ['/usr/lib/rsyslog/rsyslog-rotate', '/bin/systemctl restart filebeat'],
+  }
+
 }

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -312,6 +312,18 @@ describe 'nebula::profile::haproxy' do
           is_expected.to contain_file('/usr/local/bin/set_weights.rb')
         end
       end
+
+      describe 'log rotation' do
+        let(:rotate_logs) { contain_logrotate__rule("haproxy") }
+
+        it { is_expected.to rotate_logs.with_path("/var/log/haproxy.log") }
+        it { is_expected.to rotate_logs.with_rotate_every("day") }
+        it { is_expected.to rotate_logs.with_rotate(5) }
+        it { is_expected.to rotate_logs.with_missingok(true) }
+        it { is_expected.to rotate_logs.with_ifempty(false) }
+        it { is_expected.to rotate_logs.with_compress(true) }
+        it { is_expected.to rotate_logs.with_postrotate(["/usr/lib/rsyslog/rsyslog-rotate", "/bin/systemctl restart filebeat"]) }
+      end
     end
   end
 end


### PR DESCRIPTION
The current contents of /etc/logrotate.d/haproxy are:

    /var/log/haproxy.log {
        daily
        rotate 5
        missingok
        notifempty
        compress
        postrotate
            /usr/lib/rsyslog/rsyslog-rotate
        endscript
    }

So most of this is translating from the existing logrotate config to expressing that as a puppet resource. But also, I'm adding a filebeat restart because filebeat is holding files open and filling up disks.