### PR TITLE
Restart filebeat after rotating apache logs

### DIFF
--- a/templates/profile/apache/logrotate.d/apache2.erb
+++ b/templates/profile/apache/logrotate.d/apache2.erb
@@ -14,6 +14,7 @@
 	postrotate
                 if /etc/init.d/apache2 status > /dev/null ; then \
                     /etc/init.d/apache2 reload > /dev/null; \
+                    /bin/systemctl restart filebeat > /dev/null; \
                 fi;
 	endscript
 	prerotate


### PR DESCRIPTION
This is to prevent filebeat from keeping an open file handle on rotated apache log files. 