### PR TITLE
Fix path for startup_imgsrv

### DIFF
--- a/templates/profile/hathitrust/imgsrv/startup_imgsrv.erb
+++ b/templates/profile/hathitrust/imgsrv/startup_imgsrv.erb
@@ -14,7 +14,7 @@ SCRIPT=$SDRROOT/imgsrv/cgi/imgsrv
 export SDRROOT SDRDATAROOT SDR_VIEW
 
 /usr/bin/plackup -I $SDRROOT/plack-lib -E production \
-       -R $SCRIPT.psgi,$SCRIPT,$SDRROOT/imgsrv/bin/rsync.timestamp -s FCGI \
+       -R $SCRIPT.psgi,$SCRIPT,$SDRROOT/bin/rsync.timestamp -s FCGI \
        --manager=FCGI::ProcManager::HT --nproc $NPROC\
        --listen $BIND $SCRIPT.psgi &
 


### PR DESCRIPTION
Trivial change to watch the correct path for restarting imgsrv (see https://hathitrust.atlassian.net/browse/DEV-1317, https://github.com/hathitrust/babel/blob/main/bin/rsync.app.timestamp)

I don't love that these things are coupled, and maybe we should be deploying startup_imgsrv as part of babel, but right now this needs to be fixed here.