### PR TITLE
Add machine_cert profile for client certificates for quod

### DIFF
--- a/manifests/profile/machine_cert.pp
+++ b/manifests/profile/machine_cert.pp
@@ -12,10 +12,10 @@
 #
 # @example
 #   include nebula::profile::machine_cert
-class nebula::profile::machine_cert () {
-  $certname = $trusted['certname'];
-  $client_cert = "/etc/ssl/private/${certname}.pem";
-
+class nebula::profile::machine_cert (
+  String $certname = $trusted['certname'],
+  String $client_cert = "/etc/ssl/private/${certname}.pem"
+) {
   concat { $client_cert:
     ensure => 'present',
     mode   => '0600',

--- a/manifests/profile/machine_cert.pp
+++ b/manifests/profile/machine_cert.pp
@@ -1,0 +1,36 @@
+# Copyright (c) 2024 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::machine_cert
+#
+# Manage a combined cert + key pem file to use as a client certificate.
+#
+# Take the puppet-issued certificate and combine into conventional Debian
+# directory (/etc/ssl/private), using the machine name as the filename base
+# and giving it a .pem extension.
+#
+# @example
+#   include nebula::profile::machine_cert
+class nebula::profile::machine_cert () {
+  $certname = $trusted['certname'];
+  $client_cert = "/etc/ssl/private/${certname}.pem";
+
+  concat { $client_cert:
+    ensure => 'present',
+    mode   => '0600',
+    owner  => 'root',
+  }
+
+  concat::fragment { 'client cert':
+    target => $client_cert,
+    source => "/etc/puppetlabs/puppet/ssl/certs/${certname}.pem",
+    order  =>  1
+  }
+
+  concat::fragment { 'client key':
+    target => $client_cert,
+    source => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
+    order  =>  2
+  }
+}

--- a/manifests/role/app_host/quod_prod.pp
+++ b/manifests/role/app_host/quod_prod.pp
@@ -14,6 +14,7 @@ class nebula::role::app_host::quod_prod {
   include nebula::profile::afs
   include nebula::profile::users
   include nebula::profile::tsm
+  include nebula::profile::machine_cert
   include nebula::profile::quod::prod::perl
   include nebula::profile::quod::prod::haproxy
   include nebula::profile::networking::firewall::http

--- a/manifests/role/app_host/quod_prod.pp
+++ b/manifests/role/app_host/quod_prod.pp
@@ -14,8 +14,13 @@ class nebula::role::app_host::quod_prod {
   include nebula::profile::afs
   include nebula::profile::users
   include nebula::profile::tsm
-  include nebula::profile::machine_cert
   include nebula::profile::quod::prod::perl
   include nebula::profile::quod::prod::haproxy
   include nebula::profile::networking::firewall::http
+
+  # We put the machine certificate in a statically named file because the rdist
+  # config is static and it would be more difficult to refer it by hostname.
+  class { 'nebula::profile::machine_cert':
+    client_cert => '/etc/ssl/private/machine-cert-quod.lib.pem',
+  }
 }


### PR DESCRIPTION
This creates the file the same way as the apps_lib profile does, except as a discrete profile. We then include it in role::quod_prod to enable client certificates with reverse proxies there.