### PR TITLE
Configure ssh client not to store host keys for floating hostnames

### DIFF
--- a/manifests/profile/bolt.pp
+++ b/manifests/profile/bolt.pp
@@ -46,4 +46,18 @@ class nebula::profile::bolt {
       Package["git"],
     ]
   }
+
+  lookup("nebula::profile::kubernetes::clusters", default_value => {}).each |$id, $cluster| {
+    $host = $cluster["control_dns"]
+
+    concat_fragment { "configure ssh client for ${id}":
+      target  => '/etc/ssh/ssh_config',
+      order   => '10',
+      content => @("SSH_CONFIG")
+        Host ${host}
+        UserKnownHostsFile /dev/null
+        LogLevel ERROR
+        | SSH_CONFIG
+    }
+  }
 }


### PR DESCRIPTION
Some of our hosts are redundant with keepalived in a primary/backup pattern, and we sometimes want to use them as jump hosts with ssh.

Usually ssh will proxy through the primary host, but in those rare moments where the backup is claiming the IP address, we still want to connect, even though the backup host has different ssh host keys.

Even when /etc/ssh/ssh_known_hosts is managed, the ssh client will also store keys in the user's known_hosts file, resulting in the possibility of failed ssh connections while e.g. in the middle of a reboot.

We can't configure ssh not to save the host keys, but we can configure it to write them to /dev/null. We also set the log level to ERROR because otherwise every single connection will yell that this is the first time it's seen this server and it's saving the host keys in /dev/null.