### PR TITLE
HathiTrust DEV-1318: limit access to metrics endpoint

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -13,6 +13,7 @@ class nebula::profile::hathitrust::apache::babel (
   String $sdremail,
   Hash $default_access,
   Array[String] $haproxy_ips,
+  Array[String] $prometheus_ips,
   Hash $ssl_params,
   String $prefix,
   String $domain,
@@ -46,6 +47,11 @@ class nebula::profile::hathitrust::apache::babel (
   $monitor_requires = {
     enforce  => 'any',
     requires => [ 'local' ] + $haproxy_ips.map |String $ip| { "ip ${ip}" }
+  }
+
+  $metrics_requires = {
+    enforce => 'any',
+    requires => [ 'local' ] + $prometheus_ips.map |String $ip| { "ip ${ip}" }
   }
 
   class { 'nebula::profile::monitor_pl':
@@ -120,7 +126,7 @@ class nebula::profile::hathitrust::apache::babel (
       "ASSERTION_EMAIL ${sdremail}",
       "PTSEARCH_SOLR ${ptsearch_solr}",
       "PTSEARCH_SOLR_BASIC_AUTH ${ptsearch_solr_basic_auth}",
-      "USE_CATPROCIO 1"
+      'USE_CATPROCIO 1'
     ] + if($prod_crms_instance) {
       ['CRMS_INSTANCE production']
     } else{ [] },
@@ -322,6 +328,11 @@ class nebula::profile::hathitrust::apache::babel (
         provider => 'location',
         path     => '/monitor',
         require  => $monitor_requires
+      },
+      {
+        provider => 'location',
+        path     => '/cgi/imgsrv/metrics',
+        require  => $metrics_requires
       },
       {
         provider              => 'location',

--- a/spec/fixtures/hiera/hathitrust.yaml
+++ b/spec/fixtures/hiera/hathitrust.yaml
@@ -15,6 +15,9 @@ nebula::profile::hathitrust::apache::babel::dex_endpoint: 'https://dex.default.i
 nebula::profile::hathitrust::apache::matomo::matomo_endpoint: 'https://matomo.default.invalid:3000/'
 nebula::profile::hathitrust::apache::babel::ptsearch_solr: 'http://ptsearch.default.invalid:8983'
 nebula::profile::hathitrust::apache::babel::ptsearch_solr_basic_auth: 'ZmFrZV91c2VyOmZha2VfcGFzc3dvcmQ='
+nebula::profile::hathitrust::apache::babel::prometheus_ips:
+  - '6.7.8.9'
+  - '10.11.12.13'
 
 nebula::profile::hathitrust::hosts::mysql_sdr: '10.1.2.4'
 nebula::profile::hathitrust::hosts::mysql_htdev: '2.2.2.2'


### PR DESCRIPTION
The metrics endpoint doesn't need to be public, and won't get consistent data coming from it anyway. This limits it to a provided set of IP addresses. While we could try to collect IPs for the prometheus role and the kubernetes gateway, it wasn't immediately clear how to collect the floating IP that the kubernetes gateway uses, so this defers to a set of allowed IP addresses listed in lensoftruth.