### PR TITLE
HathiTrust DEV-1350: /var/log/babel for web apps

### DIFF
--- a/manifests/profile/hathitrust/babel_logs.pp
+++ b/manifests/profile/hathitrust/babel_logs.pp
@@ -1,0 +1,34 @@
+# Copyright (c) 2024 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::hathitrust::babel_logs
+#
+# Configure a log directory and Grafana Alloy for shipping logs from babel
+# applications to loki
+#
+# @example
+#   include nebula::profile::hathitrust::babel_logs
+class nebula::profile::hathitrust::babel_logs (
+  String $log_path = '/var/log/babel',
+  String $log_owner = 'nobody',
+  String $log_group = 'nogroup',
+) {
+
+  file { $log_path:
+    ensure => 'directory',
+    owner  => $log_owner,
+    group  => $log_group,
+    mode   => '0644'
+  }
+
+  file { '/etc/alloy/babel.alloy':
+    ensure  => 'file',
+    content => template('nebula/profile/hathitrust/babel_logs/alloy.erb'),
+  }
+
+  file { '/etc/logrotate.d/babel':
+    ensure  => 'file',
+    content => template('nebula/profile/hathitrust/babel_logs/logrotate.erb'),
+  }
+}

--- a/manifests/role/webhost/htvm.pp
+++ b/manifests/role/webhost/htvm.pp
@@ -21,6 +21,7 @@ class nebula::role::webhost::htvm (
   include nebula::profile::hathitrust::dependencies
   include nebula::profile::hathitrust::perl
   include nebula::profile::hathitrust::php
+  include nebula::profile::hathitrust::babel_logs
 
   class { 'nebula::profile::hathitrust::imgsrv':
     sdrview  => 'full'

--- a/spec/classes/profile/hathitrust/babel_logs_spec.rb
+++ b/spec/classes/profile/hathitrust/babel_logs_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require 'spec_helper'
+
+require_relative '../../../support/contexts/with_htvm_setup'
+
+describe 'nebula::profile::hathitrust::babel_logs' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      it { is_expected.to compile }
+
+      it { is_expected.to contain_file('/var/log/babel').with_owner('nobody') }
+      it { is_expected.to contain_file('/etc/alloy/babel.alloy').with_content(%r(/var/log/babel)) }
+      it { is_expected.to contain_file('/etc/logrotate.d/babel').with_content(%r(/var/log/babel)) }
+    end
+  end
+end

--- a/templates/profile/hathitrust/babel_logs/alloy.erb
+++ b/templates/profile/hathitrust/babel_logs/alloy.erb
@@ -1,0 +1,15 @@
+local.file_match "babel_logs" {
+  path_targets = [
+  {__path__ = "<%= @log_path %>/*.log"},
+  ]
+}
+
+loki.source.file "babel_logs_files" {
+  targets    = local.file_match.babel_logs.targets
+  forward_to = [loki.process.service__babel.receiver]
+}
+
+loki.process "service__babel" {
+  stage.static_labels {values = {"service" = "babel"}}
+  forward_to = [loki.process.hostname.receiver]
+}

--- a/templates/profile/hathitrust/babel_logs/logrotate.erb
+++ b/templates/profile/hathitrust/babel_logs/logrotate.erb
@@ -1,0 +1,11 @@
+<%= @log_path %>/*.log {
+        daily
+        missingok
+        rotate 7
+        dateext
+        dateyesterday
+        compress
+        delaycompress
+        notifempty
+        create 644 <%= @log_owner %> <%= @log_group %>
+}


### PR DESCRIPTION
Currently, the HathiTrust web applications log to NFS, which is suboptimal for many reasons -- processes have to write to individual files rather than being able to share a log file, and logs can't easily be collected from there and sent to retention or query systems (filebeat, loki).

This:

* creates /var/log/babel and makes it writable by the web server
* adds a logrotate config to ensure logs are rotated (similar to apache logs)
* adds an alloy config to send these logs to loki

I have been testing this configuration on dev-1.babel.hathitrust.org and the alloy config appears to work; the logrotate config may still have some errors (will check next Monday.)

Once the logrotate config is proven to work as expected, this should be safe to merge at any time; once it is merged, we can deploy the corresponding change for the web applications.