### PR TITLE
Fix vim settings (mostly for root)

### DIFF
--- a/manifests/profile/vim.pp
+++ b/manifests/profile/vim.pp
@@ -15,4 +15,11 @@ class nebula::profile::vim {
     content => template('nebula/profile/vim/vimrc.vim.erb'),
     require => Package['vim'],
   }
+
+  # Write an empty /root/.vimrc to prevent vim from automatically
+  # loading /usr/share/vim/vim*/defaults.vim
+  file { '/root/.vimrc':
+    ensure => 'file',
+    mode   => '0644',
+  }
 }

--- a/templates/profile/vim/vimrc.vim.erb
+++ b/templates/profile/vim/vimrc.vim.erb
@@ -23,7 +23,7 @@ syntax on
 
 " If using a dark background within the editing area and syntax highlighting
 " turn on this option as well
-set background=dark
+"set background=dark
 
 " Uncomment the following to have Vim jump to the last position when
 " reopening a file


### PR DESCRIPTION
- don't set bg=dark, vim automatically sets bg based on termcap
- create empty /root/.vimrc
  - w/o .vimrc vim loads defaults from /usr/share/vim/vim82/defaults.vim
  - defaults.vim sets mouse=a, overriding /etc/vim/vimrc