### PR TITLE
Allow htprod to sudo to stop/start/restart imgsrv

### DIFF
--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -33,4 +33,12 @@ class nebula::role::webhost::htvm::test {
   include nebula::role::webhost::htvm
   include nebula::profile::hathitrust::apache::test
 
+  file { '/etc/sudoers.d/htprod-systemctl-imgsrv':
+    ensure  => 'present',
+    content => @("SUDOERS")
+      %htprod  ALL=(root) NOPASSWD: /bin/journalctl
+      %htprod  ALL=(root) NOPASSWD: /bin/systemctl start imgsrv,/bin/systemctl stop imgsrv,/bin/systemctl restart imgsrv,/bin/systemctl status imgsrv
+    | SUDOERS
+  }
+
 }


### PR DESCRIPTION
This is similar to the sudoers already in place on beeftea-1/2 for managing solr there.

When working on developing/testing imgsrv, it's very useful to be able to manually restart it, especially if it ends up in a strange state.