### PR TITLE
Add ruby management to mgetit_log role

### DIFF
--- a/manifests/role/mgetit_log.pp
+++ b/manifests/role/mgetit_log.pp
@@ -11,4 +11,5 @@ class nebula::role::mgetit_log {
   include nebula::profile::elastic::filebeat::prospectors::mgetit
   include nebula::profile::nodejs
   include nebula::profile::php73
+  include nebula::profile::ruby
 }


### PR DESCRIPTION
The role has always needed ruby, but we were forced to manage ruby manually on malt long ago due to torquebox dependencies. Those dependencies are log gone. This change will bring malt under puppet ruby management. Revisiting the mgetit_log role or malt's role is out of scope and not worth attention at this time.