### PR TITLE
add ipmi puppet module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,6 +17,7 @@ fixtures:
       repo: "https://github.com/mlibrary/puppetlabs-apache"
   forge_modules:
     rbenv:               {"repo": "jdowning/rbenv",             "ref": "3.0.0" }
+    ipmi:                {"repo": "jhoblitt/ipmi",              "ref": "6.1.0" }
     archive:             {"repo": "puppet/archive",             "ref": "7.1.0" }
     kmod:                {"repo": "puppet/kmod",                "ref": "4.0.1" }
     # TODO: Puppet 8 requires version 11.  11 requires lens changes. https://forge.puppet.com/modules/puppet/letsencrypt/changelog

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -60,5 +60,9 @@ class nebula::profile::base (
 
   if $facts['dmi'] and ($facts['dmi']['manufacturer'] == 'HP' or $facts['dmi']['manufacturer'] == 'HPE') {
     include nebula::profile::base::hp
+    include nebula::profile::base::ipmi
+  }
+  if $facts['dmi'] and ($facts['dmi']['manufacturer'] == 'Dell Inc.') {
+    include nebula::profile::base::ipmi
   }
 }

--- a/manifests/profile/base/ipmi.pp
+++ b/manifests/profile/base/ipmi.pp
@@ -1,0 +1,16 @@
+# nebula::profile::base::ipmi
+#
+# add IPMI facts to puppetdb
+# TODO: export resource for drac/ilo ip, hostname
+# TODO: add ipmi configuration (manage users, etc)
+#
+# @example
+#   include nebula::profile::base::impi
+class nebula::profile::base::ipmi
+{
+  class { 'ipmi':
+    service_ensure         => 'stopped',
+    ipmievd_service_ensure => 'stopped',
+    watchdog               => false,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,7 @@
   "issues_url": "https://github.com/mlibrary/nebula/issues",
   "dependencies": [
     {"name": "jdowning/rbenv",             "version_requirement": ">= 3.0.0  < 4.0.0" },
+    {"name": "jhoblitt/ipmi",              "version_requirement": ">= 6.1.0  < 7.0.0" },
     {"name": "puppet/archive",             "version_requirement": ">= 7.1.0  < 8.0.0" },
     {"name": "puppet/kmod",                "version_requirement": ">= 4.0.1  < 5.0.0" },
     {"name": "puppet/letsencrypt",         "version_requirement": ">= 10.1.0 < 11.0.0"},

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -122,6 +122,8 @@ describe 'nebula::profile::base' do
             file: '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
           )
         end
+
+        # it { is_expected.to is_expected.to contain_class('ipmi') }
       end
 
       context 'on an HPE machine' do
@@ -142,6 +144,7 @@ describe 'nebula::profile::base' do
         end
 
         it { is_expected.to contain_package('ssacli') }
+        it { is_expected.to contain_class('ipmi') }
       end
 
       context 'on an Dell machine' do
@@ -151,6 +154,7 @@ describe 'nebula::profile::base' do
 
         it { is_expected.not_to contain_kmod__blacklist('hpwdt') }
         it { is_expected.not_to contain_kmod__blacklist('acpi_power_meter') }
+        it { is_expected.to contain_class('ipmi') }
       end
 
       it { is_expected.not_to contain_package('i40e-dkms') }


### PR DESCRIPTION
* Install module on all bare metal (hp/dell) hosts

* jhoblitt/ipmi installs packages that are needed for local querying of the ilo/drac (interactively, as well as via puppet)
* This should immediately make several useful facts available, such as ilo/drac IP, firmware version, etc
* This is intended to serve as a base for later adding the management cards to /etc/hosts on bastions