### PR TITLE
Rename GenericMetricsExporterDown, add LightsOutDeviceDown

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -59,10 +59,17 @@ groups:
     for: 30m
     labels:
       severity: page
-  - alert: PrometheusExporterDown
+  - alert: GenericMetricsExporterDown
     annotations:
-      summary: '{{$labels.hostname}} {{$labels.job}} exporter isn''t responding to Prometheus.'
-    expr: 'up{job!="node"} == 0'
+      summary: '{{$labels.datacenter}} {{$labels.hostname}} {{$labels.job}} exporter isn''t responding to Prometheus.'
+    expr: 'up{job!="node",job!="ipmi"} == 0'
+    for: 30m
+    labels:
+      severity: page
+  - alert: LightsOutDeviceDown
+    annotations:
+      summary: '{{$labels.instance}} isn''t responding to Prometheus (via {{$labels.via}})'
+    expr: 'up{job=="ipmi"} == 0'
     for: 30m
     labels:
       severity: page


### PR DESCRIPTION
Add datacenter to GenericMetricsExporterDown since not everything necessarily has a hostname (ipmi is an example of this). I can think of no reason to alter the period or severity of ipmi alerts specifically, but it should be useful to take advantage of its particular labels.