### PR TITLE
Run filebeat on new bastion hosts

### DIFF
--- a/manifests/role/bastion.pp
+++ b/manifests/role/bastion.pp
@@ -8,6 +8,7 @@ class nebula::role::bastion {
   include nebula::profile::bolt
   include nebula::profile::root_ssh_private_keys
   include nebula::profile::interactive
+  include nebula::profile::elastic::filebeat::configs::ulib
 
   # These three are effectively the requirements for getting user login
   # with kerberos and duo.


### PR DESCRIPTION
Alternative approaches which could better reflect what we want:

1.  We could base the bastion role on umich/hathitrust instead of minimum.
2.  We could add filebeat to the minimum role.