### PR TITLE
update puppet/letsencrypt module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,8 +19,7 @@ fixtures:
     rbenv:               {"repo": "jdowning/rbenv",             "ref": "3.1.0" }
     archive:             {"repo": "puppet/archive",             "ref": "7.1.0" }
     kmod:                {"repo": "puppet/kmod",                "ref": "4.0.1" }
-    # TODO: Puppet 8 requires version 11.  11 requires lens changes. https://forge.puppet.com/modules/puppet/letsencrypt/changelog
-    letsencrypt:         {"repo": "puppet/letsencrypt",         "ref": "10.1.0"} 
+    letsencrypt:         {"repo": "puppet/letsencrypt",         "ref": "11.1.0"}
     logrotate:           {"repo": "puppet/logrotate",           "ref": "7.1.0" }
     nginx:               {"repo": "puppet/nginx",               "ref": "6.0.1" }
     php:                 {"repo": "puppet/php",                 "ref": "10.2.0"}

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     {"name": "jdowning/rbenv",             "version_requirement": ">= 3.1.0  < 4.0.0" },
     {"name": "puppet/archive",             "version_requirement": ">= 7.1.0  < 8.0.0" },
     {"name": "puppet/kmod",                "version_requirement": ">= 4.0.1  < 5.0.0" },
-    {"name": "puppet/letsencrypt",         "version_requirement": ">= 10.1.0 < 11.0.0"},
+    {"name": "puppet/letsencrypt",         "version_requirement": ">= 11.1.0 < 12.0.0"},
     {"name": "puppet/logrotate",           "version_requirement": ">= 7.1.0  < 8.0.0" },
     {"name": "puppet/nginx",               "version_requirement": ">= 6.0.1  < 7.0.0" },
     {"name": "puppet/php",                 "version_requirement": ">= 10.2.0 < 11.0.0"},


### PR DESCRIPTION
We're only using letsencrypt directly in manifests/cert.pp. There, `$title` is automatically used as the first domain. IOW, the "breaking" change to [puppet/letsencrypt](https://github.com/mlibrary/nebula/blob/production/manifests/cert.pp) only enforces a choice that @daaang made when initially writing our use of in nebula.