### PR TITLE
duplicate firewall exported resources

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -139,6 +139,15 @@ class nebula::profile::haproxy(
     tag    => 'haproxy'
   }
 
+  @@firewall { "200 HTTP firewall6: HAProxy ${::hostname}":
+    proto  => 'tcp',
+    dport  => [80, 443],
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
+    tag    => 'firewall6-haproxy'
+  }
+
   # HAProxy should listen for kubernetes connections.
   nebula::exposed_port { '200 kubectl':
     port  => 6443,

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -241,6 +241,16 @@ class nebula::profile::prometheus (
         tag    => "${::datacenter}_prometheus_public_ipmi_exporter",
         dport  => 9290,
       ;
+
+      "010 prometheus public node exporter firewall6 ${::hostname} ${address}":
+        tag    => "firewall6-${::datacenter}_prometheus_public_node_exporter",
+        dport  => 9100,
+      ;
+
+      "010 prometheus public ipmi exporter firewall6 ${::hostname} ${address}":
+        tag    => "firewall6-${::datacenter}_prometheus_public_ipmi_exporter",
+        dport  => 9290,
+      ;
     }
   }
 

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -157,6 +157,15 @@ class nebula::profile::prometheus::exporter::node (
       state  => 'NEW',
       action => 'accept',
     }
+
+    @@firewall { "300 pushgateway firewall6 ${::hostname} ${address}":
+      tag    => "firewall6-${monitoring_datacenter}_pushgateway_node",
+      proto  => 'tcp',
+      dport  => 9091,
+      source => $address,
+      state  => 'NEW',
+      action => 'accept',
+    }
   }
 
   ensure_packages(['curl', 'jq'])

--- a/manifests/unison/client.pp
+++ b/manifests/unison/client.pp
@@ -43,4 +43,12 @@ define nebula::unison::client (
     tag    =>  "unison-client-${title}"
   }
 
+  @@firewall { "200 Unison firewall6: ${title} ${::hostname}":
+    proto  => 'tcp',
+    dport  => [$port],
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
+    tag    =>  "firewall6-unison-client-${title}"
+  }
 }


### PR DESCRIPTION
Add a duplicate of every `@@firewall` resource with 'firewall6-*' prefix to prepare for upgrading firewall module.