### PR TITLE
upgrade firewall module to 8.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -30,7 +30,7 @@ fixtures:
     cron_core:           {"repo": "puppetlabs/cron_core",       "ref": "1.3.0" }
     docker:              {"repo": "puppetlabs/docker",          "ref": "10.0.1" }
     # TODO: Upgrading to 7 requires nuking PuppetDB. https://forge.puppet.com/modules/puppetlabs/firewall/8.0.3/changelog
-    firewall:            {"repo": "puppetlabs/firewall",        "ref": "6.0.0" }
+    firewall:            {"repo": "puppetlabs/firewall",        "ref": "8.0.0" }
     host_core:           {"repo": "puppetlabs/host_core",       "ref": "1.3.0" }
     inifile:             {"repo": "puppetlabs/inifile",         "ref": "6.1.1" }
     lvm:                 {"repo": "puppetlabs/lvm",             "ref": "2.3.0" }

--- a/manifests/exposed_port.pp
+++ b/manifests/exposed_port.pp
@@ -66,7 +66,7 @@ define nebula::exposed_port(
       dport  => $port,
       source => $cidr['block'],
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 }

--- a/manifests/firewall_allow.pp
+++ b/manifests/firewall_allow.pp
@@ -76,7 +76,7 @@ define nebula::firewall_allow (
       dport  => $port,
       source => $cidr,
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 }

--- a/manifests/profile/fulcrum/nginx.pp
+++ b/manifests/profile/fulcrum/nginx.pp
@@ -197,6 +197,6 @@ class nebula::profile::fulcrum::nginx (
     proto  => 'tcp',
     dport  => 443,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 }

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -135,7 +135,7 @@ class nebula::profile::haproxy(
     dport  => [80, 443],
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
     tag    => 'haproxy'
   }
 

--- a/manifests/profile/hathitrust/rsync.pp
+++ b/manifests/profile/hathitrust/rsync.pp
@@ -48,7 +48,7 @@ class nebula::profile::hathitrust::rsync (
         dport  => 873,
         source => $user['ip'],
         state  => 'NEW',
-        action => 'accept'
+        jump   => 'accept'
       }
     }
   }

--- a/manifests/profile/hathitrust/secure_rsync.pp
+++ b/manifests/profile/hathitrust/secure_rsync.pp
@@ -69,7 +69,7 @@ class nebula::profile::hathitrust::secure_rsync (
       source    => $network['block'],
       src_range => $network['range'],
       state     => 'NEW',
-      action    => 'accept',
+      jump      => 'accept',
     }
   }
 }

--- a/manifests/profile/kubernetes/dns_server.pp
+++ b/manifests/profile/kubernetes/dns_server.pp
@@ -76,7 +76,7 @@ class nebula::profile::kubernetes::dns_server {
       dport  => 53,
       source => $node_cidr,
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     ;
 
     '200 Nameserver (TCP)':

--- a/manifests/profile/kubernetes/haproxy.pp
+++ b/manifests/profile/kubernetes/haproxy.pp
@@ -52,7 +52,7 @@ class nebula::profile::kubernetes::haproxy {
     default:
       proto  => 'tcp',
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     ;
 
     '200 private api':

--- a/manifests/profile/kubernetes/kubelet.pp
+++ b/manifests/profile/kubernetes/kubelet.pp
@@ -53,7 +53,7 @@ class nebula::profile::kubernetes::kubelet (
       proto  => 'tcp',
       source => $node_cidr,
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     ;
 
     '200 Cluster ssh':

--- a/manifests/profile/kubernetes/router.pp
+++ b/manifests/profile/kubernetes/router.pp
@@ -20,7 +20,7 @@ class nebula::profile::kubernetes::router {
   firewall { '001 Do not NAT internal requests':
     table       => 'nat',
     chain       => 'POSTROUTING',
-    action      => 'accept',
+    jump        => 'accept',
     proto       => 'all',
     source      => $node_cidr,
     destination => $node_cidr,

--- a/manifests/profile/letsencrypt.pp
+++ b/manifests/profile/letsencrypt.pp
@@ -22,6 +22,6 @@ class nebula::profile::letsencrypt (
     proto  => 'tcp',
     dport  => 80,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 }

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -144,7 +144,7 @@ class nebula::profile::networking::firewall (
   $firewall_defaults = {
     proto  => 'tcp',
     state  => 'NEW',
-    action => 'accept'
+    jump   => 'accept'
   }
 
   create_resources(firewall,$rules,$firewall_defaults)
@@ -154,18 +154,18 @@ class nebula::profile::networking::firewall (
   firewall { '001 accept related established rules':
     proto  => 'all',
     state  => ['RELATED', 'ESTABLISHED'],
-    action => 'accept',
+    jump   => 'accept',
   }
 
   firewall { '001 accept all to lo interface':
     proto   => 'all',
     iniface => 'lo',
-    action  => 'accept',
+    jump    => 'accept',
   }
 
   firewall { '999 drop all':
     proto  => 'all',
-    action => 'drop',
+    jump   => 'drop',
     before => undef,
   }
 
@@ -173,22 +173,22 @@ class nebula::profile::networking::firewall (
   firewall { '001 accept related established rules (v6)':
     proto    => 'all',
     state    => ['RELATED', 'ESTABLISHED'],
-    action   => 'accept',
-    provider => 'ip6tables',
+    jump     => 'accept',
+    protocol => 'ip6tables',
   }
 
   firewall { '001 accept all to lo interface (v6)':
     proto    => 'all',
     iniface  => 'lo',
-    action   => 'accept',
-    provider => 'ip6tables',
+    jump     => 'accept',
+    protocol => 'ip6tables',
   }
 
   firewall { '999 drop all (v6)':
     proto    => 'all',
-    action   => 'drop',
+    jump     => 'drop',
     before   => undef,
-    provider => 'ip6tables',
+    protocol => 'ip6tables',
   }
 
 }

--- a/manifests/profile/networking/firewall/http_datacenters.pp
+++ b/manifests/profile/networking/firewall/http_datacenters.pp
@@ -16,7 +16,7 @@ class nebula::profile::networking::firewall::http_datacenters (
     proto  => 'tcp',
     dport  => [80, 443],
     state  => 'NEW',
-    action => 'accept'
+    jump   => 'accept'
   }
 
   $networks.flatten.each |$network| {

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -188,7 +188,7 @@ class nebula::profile::prometheus (
     dport  => 9100,
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   case $facts["mlibrary_ip_addresses"] {
@@ -229,7 +229,7 @@ class nebula::profile::prometheus (
         proto  => 'tcp',
         source => $address,
         state  => 'NEW',
-        action => 'accept',
+        jump   => 'accept',
       ;
 
       "010 prometheus public node exporter ${::hostname} ${address}":
@@ -250,7 +250,7 @@ class nebula::profile::prometheus (
         proto  => 'tcp',
         source => $address,
         state  => 'NEW',
-        action => 'accept',
+        jump   => 'accept',
       ;
 
       "010 prometheus private node exporter ${::hostname} ${address}":
@@ -271,7 +271,7 @@ class nebula::profile::prometheus (
     dport  => 9101,
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   @@firewall { "010 prometheus mysql exporter ${::hostname}":
@@ -280,7 +280,7 @@ class nebula::profile::prometheus (
     dport  => 9104,
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   Firewall <<| tag == "${::datacenter}_pushgateway_node" |>>

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -155,7 +155,7 @@ class nebula::profile::prometheus::exporter::node (
       dport  => 9091,
       source => $address,
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 

--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -13,7 +13,7 @@ class nebula::role::webhost::htvm::test {
       dport  => [80,443],
       source => $network['block'],
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     }
   }
 

--- a/manifests/unison/client.pp
+++ b/manifests/unison/client.pp
@@ -39,7 +39,7 @@ define nebula::unison::client (
     dport  => [$port],
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
     tag    =>  "unison-client-${title}"
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     {"name": "puppetlabs/concat",          "version_requirement": ">= 9.0.2  < 10.0.0"},
     {"name": "puppetlabs/cron_core",       "version_requirement": ">= 1.3.0  < 2.0.0" },
     {"name": "puppetlabs/docker",          "version_requirement": ">= 10.0.1 < 11.0.0"},
-    {"name": "puppetlabs/firewall",        "version_requirement": "6.0.0"},
+    {"name": "puppetlabs/firewall",        "version_requirement": ">= 8.0.0  < 9.0.0" },
     {"name": "puppetlabs/host_core",       "version_requirement": ">= 1.3.0  < 2.0.0" },
     {"name": "puppetlabs/inifile",         "version_requirement": ">= 6.1.1  < 7.0.0" },
     {"name": "puppetlabs/lvm",             "version_requirement": ">= 2.3.0  < 3.0.0" },

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -36,7 +36,7 @@ describe 'nebula::profile::kubernetes::dns_server' do
               .with_dport(53)
               .with_source('172.28.0.0/14')
               .with_state('NEW')
-              .with_action('accept')
+              .with_jump('accept')
           end
         end
 

--- a/spec/classes/profile/kubernetes/haproxy_spec.rb
+++ b/spec/classes/profile/kubernetes/haproxy_spec.rb
@@ -66,7 +66,7 @@ describe 'nebula::profile::kubernetes::haproxy' do
                 is_expected.to contain_firewall("200 public #{service}")
                   .with_proto('tcp')
                   .with_state('NEW')
-                  .with_action('accept')
+                  .with_jump('accept')
                   .with_dport(port)
                   .without_source
               end
@@ -81,7 +81,7 @@ describe 'nebula::profile::kubernetes::haproxy' do
                 is_expected.to contain_firewall("200 private #{service}")
                   .with_proto('tcp')
                   .with_state('NEW')
-                  .with_action('accept')
+                  .with_jump('accept')
                   .with_dport(port)
                   .with_source('172.28.0.0/14')
               end

--- a/spec/classes/profile/kubernetes/kubelet_spec.rb
+++ b/spec/classes/profile/kubernetes/kubelet_spec.rb
@@ -102,7 +102,7 @@ describe 'nebula::profile::kubernetes::kubelet' do
               .with_dport(ports)
               .with_source('172.28.0.0/14')
               .with_state('NEW')
-              .with_action('accept')
+              .with_jump('accept')
           end
         end
       end

--- a/spec/classes/profile/kubernetes/router_spec.rb
+++ b/spec/classes/profile/kubernetes/router_spec.rb
@@ -23,7 +23,7 @@ describe 'nebula::profile::kubernetes::router' do
         is_expected.to contain_firewall('001 Do not NAT internal requests')
           .with_table('nat')
           .with_chain('POSTROUTING')
-          .with_action('accept')
+          .with_jump('accept')
           .with_proto('all')
           .with_source('172.28.0.0/14')
           .with_destination('172.28.0.0/14')

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -16,7 +16,7 @@ describe 'nebula::profile::networking::firewall' do
         is_expected.to contain_firewall('001 accept related established rules').with(
           proto: 'all',
           state: %w[RELATED ESTABLISHED],
-          action: 'accept',
+          jump: 'accept',
         )
       end
 
@@ -24,8 +24,8 @@ describe 'nebula::profile::networking::firewall' do
         is_expected.to contain_firewall('001 accept related established rules (v6)').with(
           proto: 'all',
           state: %w[RELATED ESTABLISHED],
-          action: 'accept',
-          provider: 'ip6tables',
+          jump: 'accept',
+          protocol: 'ip6tables',
         )
       end
 
@@ -33,7 +33,7 @@ describe 'nebula::profile::networking::firewall' do
         is_expected.to contain_firewall('001 accept all to lo interface').with(
           proto: 'all',
           iniface: 'lo',
-          action: 'accept',
+          jump: 'accept',
         )
       end
 
@@ -41,8 +41,8 @@ describe 'nebula::profile::networking::firewall' do
         is_expected.to contain_firewall('001 accept all to lo interface (v6)').with(
           proto: 'all',
           iniface: 'lo',
-          action: 'accept',
-          provider: 'ip6tables',
+          jump: 'accept',
+          protocol: 'ip6tables',
         )
       end
 
@@ -53,7 +53,7 @@ describe 'nebula::profile::networking::firewall' do
           dport: %w[8081 8082],
           source: '10.2.3.4',
           state: 'NEW',
-          action: 'accept',
+          jump: 'accept',
         )
       end
 
@@ -63,7 +63,7 @@ describe 'nebula::profile::networking::firewall' do
           dport: 123,
           source: '10.4.5.6',
           state: 'NEW',
-          action: 'accept',
+          jump: 'accept',
         )
       end
 
@@ -77,7 +77,7 @@ describe 'nebula::profile::networking::firewall' do
           toports: '1234',
         )
         is_expected.not_to contain_firewall('900 port forwarding: an advanced rule').with(
-          action: 'accept',
+          jump: 'accept',
           state: 'NEW',
         )
       end
@@ -85,15 +85,15 @@ describe 'nebula::profile::networking::firewall' do
       it do
         is_expected.to contain_firewall('999 drop all').with(
           proto: 'all',
-          action: 'drop',
+          jump: 'drop',
         )
       end
 
       it do
         is_expected.to contain_firewall('999 drop all (v6)').with(
           proto: 'all',
-          action: 'drop',
-          provider: 'ip6tables',
+          jump: 'drop',
+          protocol: 'ip6tables',
         )
       end
 

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -117,7 +117,7 @@ describe 'nebula::profile::prometheus::exporter::node' do
           .with_dport(9091)
           .with_source(facts[:ipaddress])
           .with_state('NEW')
-          .with_action('accept')
+          .with_jump('accept')
       end
 
       context 'with both public and private mlibrary_ip_addresses' do

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -189,7 +189,7 @@ describe 'nebula::profile::prometheus' do
             .with_dport(port)
             .with_source(facts[:ipaddress])
             .with_state('NEW')
-            .with_action('accept')
+            .with_jump('accept')
         end
       end
 
@@ -200,7 +200,7 @@ describe 'nebula::profile::prometheus' do
           .with_dport(9100)
           .with_source(facts[:ipaddress])
           .with_state('NEW')
-          .with_action('accept')
+          .with_jump('accept')
       end
 
       context 'with no mlibrary_ip_addresses fact' do
@@ -346,7 +346,7 @@ describe 'nebula::profile::prometheus' do
                 .with_dport(port)
                 .with_source(ip_address)
                 .with_state('NEW')
-                .with_action('accept')
+                .with_jump('accept')
             end
           end
         end

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -28,7 +28,7 @@ describe 'nebula::cert' do
             .with_proto('tcp')
             .with_dport(80)
             .with_state('NEW')
-            .with_action('accept')
+            .with_jump('accept')
         end
 
         context 'and with additional_domains set to sub.example.invalid' do

--- a/spec/defines/exposed_port_spec.rb
+++ b/spec/defines/exposed_port_spec.rb
@@ -23,7 +23,7 @@ describe 'nebula::exposed_port' do
             dport: 22,
             source: '10.0.0.0/16',
             state: 'NEW',
-            action: 'accept',
+            jump: 'accept',
           )
         end
 

--- a/spec/defines/firewall_allow_spec.rb
+++ b/spec/defines/firewall_allow_spec.rb
@@ -23,7 +23,7 @@ describe 'nebula::firewall_allow' do
             dport: 1234,
             source: '10.0.0.0/32',
             state: 'NEW',
-            action: 'accept',
+            jump: 'accept',
           )
         end
 
@@ -59,7 +59,7 @@ describe 'nebula::firewall_allow' do
             dport: [123, 456, 789],
             source: '10.255.255.255/32',
             state: 'NEW',
-            action: 'accept',
+            jump: 'accept',
           )
         end
       end


### PR DESCRIPTION
To support firewall >= 7.0.0
s/jump/action/, s/provider/protocol/
see https://github.com/puppetlabs/puppetlabs-firewall?tab=readme-ov-file#migration-path-to-v700