### PR TITLE
add firewall resource imports

### DIFF
--- a/manifests/profile/networking/firewall/http.pp
+++ b/manifests/profile/networking/firewall/http.pp
@@ -14,7 +14,7 @@
 # @example
 #   include nebula::profile::networking::firewall::http
 class nebula::profile::networking::firewall::http () {
-  Firewall <<| tag == 'haproxy' |>>
+  Firewall <<| tag == 'firewall6-haproxy' |>>
 }
 
 

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -182,6 +182,8 @@ class nebula::profile::prometheus (
 
   # Delete this once nothing is importing it. It's only here for the
   # sake of hosts that aren't in production.
+  # Referenced in branches: fulcrum_demo, tdx_7298538
+  # ** intentionally retains puppetlabs/firewall v6.0.0 semantics **
   @@firewall { "010 prometheus legacy node exporter ${::hostname}":
     tag    => "${::datacenter}_prometheus_node_exporter",
     proto  => 'tcp',
@@ -284,8 +286,26 @@ class nebula::profile::prometheus (
     action => 'accept',
   }
 
+  @@firewall { "010 prometheus firewall6 haproxy exporter ${::hostname}":
+    tag    => "firewall6-${::datacenter}_prometheus_haproxy_exporter",
+    proto  => 'tcp',
+    dport  => 9101,
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
+  }
+
   @@firewall { "010 prometheus mysql exporter ${::hostname}":
     tag    => "${::datacenter}_prometheus_mysql_exporter",
+    proto  => 'tcp',
+    dport  => 9104,
+    source => $::ipaddress,
+    state  => 'NEW',
+    action => 'accept',
+  }
+
+  @@firewall { "010 prometheus firewall6 mysql exporter ${::hostname}":
+    tag    => "firewall6-${::datacenter}_prometheus_mysql_exporter",
     proto  => 'tcp',
     dport  => 9104,
     source => $::ipaddress,

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -313,5 +313,5 @@ class nebula::profile::prometheus (
     action => 'accept',
   }
 
-  Firewall <<| tag == "${::datacenter}_pushgateway_node" |>>
+  Firewall <<| tag == "firewall6-${::datacenter}_pushgateway_node" |>>
 }

--- a/manifests/profile/prometheus/exporter/haproxy.pp
+++ b/manifests/profile/prometheus/exporter/haproxy.pp
@@ -32,6 +32,6 @@ class nebula::profile::prometheus::exporter::haproxy (
     content => template('nebula/profile/prometheus/exporter/haproxy/target.yaml.erb')
   }
 
-  Firewall <<| tag == "${::datacenter}_prometheus_haproxy_exporter" |>>
+  Firewall <<| tag == "firewall6-${::datacenter}_prometheus_haproxy_exporter" |>>
 
 }

--- a/manifests/profile/prometheus/exporter/ipmi.pp
+++ b/manifests/profile/prometheus/exporter/ipmi.pp
@@ -33,10 +33,10 @@ class nebula::profile::prometheus::exporter::ipmi (
       fail('Host cannot be scraped without a public or private IP address')
     } elsif $all_private_addresses != [] {
       $ipaddress = $all_private_addresses[0]
-      Firewall <<| tag == "${::datacenter}_prometheus_private_ipmi_exporter" |>>
+      Firewall <<| tag == "firewall6-${::datacenter}_prometheus_private_ipmi_exporter" |>>
     } else {
       $ipaddress = $all_public_addresses[0]
-      Firewall <<| tag == "${::datacenter}_prometheus_public_ipmi_exporter" |>>
+      Firewall <<| tag == "firewall6-${::datacenter}_prometheus_public_ipmi_exporter" |>>
     }
 
     @@concat_fragment { "prometheus ipmi scrape config ${::hostname}":

--- a/manifests/profile/prometheus/exporter/mysql.pp
+++ b/manifests/profile/prometheus/exporter/mysql.pp
@@ -30,7 +30,7 @@ class nebula::profile::prometheus::exporter::mysql ()
     content => template('nebula/profile/prometheus/exporter/mysql/target.yaml.erb')
   }
 
-  Firewall <<| tag == "${::datacenter}_prometheus_mysql_exporter" |>>
+  Firewall <<| tag == "firewall6-${::datacenter}_prometheus_mysql_exporter" |>>
 
   $role = lookup_role()
 

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -139,11 +139,11 @@ class nebula::profile::prometheus::exporter::node (
     fail("${datacenter} host cannot be scraped by ${monitoring_datacenter} prometheus server without a public IP address")
   } elsif $all_private_addresses != [] and $monitoring_datacenter == $datacenter {
     $ipaddresses = $all_private_addresses
-    Firewall <<| tag == "${monitoring_datacenter}_prometheus_private_node_exporter" |>>
+    Firewall <<| tag == "firewall6-${monitoring_datacenter}_prometheus_private_node_exporter" |>>
     Concat_fragment <<| title == "02 pushgateway advanced private url ${monitoring_datacenter}" |>>
   } else {
     $ipaddresses = $all_public_addresses
-    Firewall <<| tag == "${monitoring_datacenter}_prometheus_public_node_exporter" |>>
+    Firewall <<| tag == "firewall6-${monitoring_datacenter}_prometheus_public_node_exporter" |>>
     Concat_fragment <<| title == "02 pushgateway advanced public url ${monitoring_datacenter}" |>>
   }
 

--- a/manifests/unison/server.pp
+++ b/manifests/unison/server.pp
@@ -33,6 +33,6 @@ define nebula::unison::server (
     filesystems => $filesystems
   }
 
-  Firewall <<| tag == "unison-client-${title}" |>>
+  Firewall <<| tag == "firewall6-unison-client-${title}" |>>
 
 }


### PR DESCRIPTION
- add `firewall6-` prefix to each import of firewall exported resource
- add `firewall6-` prefixed version of `haproxy` and `mysql` prometheus exporter `@@firewall` resources (missed in #737)
- comment clarifying the status of "prometheus legacy node exporter" resource