### PR TITLE
use firewall v8 semantics for exported resources

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -136,7 +136,7 @@ class nebula::profile::haproxy(
     source => $::ipaddress,
     state  => 'NEW',
     jump   => 'accept',
-    tag    => 'haproxy'
+    tag    => "${::datacenter}_haproxy"
   }
 
   @@firewall { "200 HTTP firewall6: HAProxy ${::hostname}":

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -135,7 +135,7 @@ class nebula::profile::haproxy(
     dport  => [80, 443],
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
     tag    => 'haproxy'
   }
 

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -231,7 +231,7 @@ class nebula::profile::prometheus (
         proto  => 'tcp',
         source => $address,
         state  => 'NEW',
-        action => 'accept',
+        jump   => 'accept',
       ;
 
       "010 prometheus public node exporter ${::hostname} ${address}":
@@ -247,11 +247,13 @@ class nebula::profile::prometheus (
       "010 prometheus public node exporter firewall6 ${::hostname} ${address}":
         tag    => "firewall6-${::datacenter}_prometheus_public_node_exporter",
         dport  => 9100,
+        action => 'accept',
       ;
 
       "010 prometheus public ipmi exporter firewall6 ${::hostname} ${address}":
         tag    => "firewall6-${::datacenter}_prometheus_public_ipmi_exporter",
         dport  => 9290,
+        action => 'accept',
       ;
     }
   }
@@ -262,7 +264,7 @@ class nebula::profile::prometheus (
         proto  => 'tcp',
         source => $address,
         state  => 'NEW',
-        action => 'accept',
+        jump   => 'accept',
       ;
 
       "010 prometheus private node exporter ${::hostname} ${address}":
@@ -302,7 +304,7 @@ class nebula::profile::prometheus (
     dport  => 9101,
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   @@firewall { "010 prometheus firewall6 haproxy exporter ${::hostname}":
@@ -320,7 +322,7 @@ class nebula::profile::prometheus (
     dport  => 9104,
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
   }
 
   @@firewall { "010 prometheus firewall6 mysql exporter ${::hostname}":

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -155,7 +155,7 @@ class nebula::profile::prometheus::exporter::node (
       dport  => 9091,
       source => $address,
       state  => 'NEW',
-      action => 'accept',
+      jump   => 'accept',
     }
 
     @@firewall { "300 pushgateway firewall6 ${::hostname} ${address}":

--- a/manifests/unison/client.pp
+++ b/manifests/unison/client.pp
@@ -39,7 +39,7 @@ define nebula::unison::client (
     dport  => [$port],
     source => $::ipaddress,
     state  => 'NEW',
-    action => 'accept',
+    jump   => 'accept',
     tag    =>  "unison-client-${title}"
   }
 

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -306,7 +306,7 @@ describe 'nebula::profile::haproxy' do
       it 'exports a firewall resource tagged haproxy' do
         expect(exported_resources).to contain_firewall('200 HTTP: HAProxy thisnode').with(
           source: my_ip,
-          tag: 'haproxy',
+          tag: 'somedc_haproxy',
         )
       end
 

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -117,7 +117,7 @@ describe 'nebula::profile::prometheus::exporter::node' do
           .with_dport(9091)
           .with_source(facts[:ipaddress])
           .with_state('NEW')
-          .with_action('accept')
+          .with_jump('accept')
       end
 
       context 'with both public and private mlibrary_ip_addresses' do

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -189,7 +189,7 @@ describe 'nebula::profile::prometheus' do
             .with_dport(port)
             .with_source(facts[:ipaddress])
             .with_state('NEW')
-            .with_action('accept')
+            .with_jump('accept')
         end
       end
 
@@ -346,7 +346,7 @@ describe 'nebula::profile::prometheus' do
                 .with_dport(port)
                 .with_source(ip_address)
                 .with_state('NEW')
-                .with_action('accept')
+                .with_jump('accept')
             end
           end
         end


### PR DESCRIPTION
`s/action/state/`, but only for exported resources, and only for the non-prefixed-tag version.

Not yet actually collecting the firewall v8 resources, just adding them so they are present when we upgrade the firewall module.