### PR TITLE
prometheus firewall temp fixup

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -243,17 +243,24 @@ class nebula::profile::prometheus (
         tag   => "${::datacenter}_prometheus_public_ipmi_exporter",
         dport => 9290,
       ;
+    }
+
+    @@firewall {
+      default:
+        proto  => 'tcp',
+        source => $address,
+        state  => 'NEW',
+        action => 'accept',
+      ;
 
       "010 prometheus public node exporter firewall6 ${::hostname} ${address}":
         tag    => "firewall6-${::datacenter}_prometheus_public_node_exporter",
         dport  => 9100,
-        action => 'accept',
       ;
 
       "010 prometheus public ipmi exporter firewall6 ${::hostname} ${address}":
         tag    => "firewall6-${::datacenter}_prometheus_public_ipmi_exporter",
         dport  => 9290,
-        action => 'accept',
       ;
     }
   }


### PR DESCRIPTION
We were setting both action and jump on the same exported resource because 'action' override doesn't clear the 'jump' default.