### PR TITLE
Remove unnecessary firewall opening for private SSH

### DIFF
--- a/manifests/profile/networking/firewall/ssh.pp
+++ b/manifests/profile/networking/firewall/ssh.pp
@@ -13,11 +13,4 @@ class nebula::profile::networking::firewall::ssh {
     port  => 22,
     block => 'umich::networks::all_trusted_machines',
   }
-
-  if ! is_publicly_accessible() {
-    nebula::exposed_port { '100 Legacy Private SSH':
-      port  => 22,
-      block => 'umich::networks::private_bastion_hosts',
-    }
-  }
 }

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -46,13 +46,6 @@ describe 'nebula::profile::networking::firewall::ssh' do
             block: 'umich::networks::all_trusted_machines',
           )
         end
-
-        it do
-          expect(subject).to contain_nebula__exposed_port('100 Legacy Private SSH').with(
-            port: 22,
-            block: 'umich::networks::private_bastion_hosts',
-          )
-        end
       end
     end
   end


### PR DESCRIPTION
This was from back before we had private NAT working right. Nothing that uses it needs it (it's been superceded by the `private_ssh` profile), and it never really worked anyway.