### PR TITLE
disable HashKnownHosts

### DIFF
--- a/templates/profile/networking/ssh_config.erb
+++ b/templates/profile/networking/ssh_config.erb
@@ -1,7 +1,6 @@
 # Managed by puppet (nebula/profile/base/ssh_config.erb)
 Host *
     SendEnv LANG LC_*
-    HashKnownHosts yes
     GSSAPIAuthentication yes
     GSSAPIDelegateCredentials yes
     GSSAPITrustDNS yes


### PR DESCRIPTION
Unclear why we ever set this. Default is `no`. Provides no security benefit and makes removing outdated fingerprints a pain.