### PR TITLE
Only alert on OOM-kill if a lot of memory is freed

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -41,7 +41,7 @@ groups:
   - alert: HostOomKillDetected
     annotations:
       summary: 'Linux node {{$labels.hostname}} OOM-killed a process'
-    expr: 'increase(node_vmstat_oom_kill[5m]) > 0'
+    expr: 'increase(node_vmstat_oom_kill[5m]) > 0 and max_over_time(node_memory_MemAvailable_bytes[5m]) / min_over_time(node_memory_MemAvailable_bytes[5m]) > 2'
     for: 0m
     labels:
       severity: ticket


### PR DESCRIPTION
Specifically, to start, only if the amount of available memory has doubled during the same period that something got OOM-killed.

So:

1.  On OOM-kill, if we go from 100Mi free to 1Gi free, we get an alert.
2.  On OOM-kill, if we go from 20Gi free to 50Gi free, we get an alert.
3.  On OOM-kill, if we go from 20Gi free to 22Gi free, no alert.
4.  On OOM-kill, if we go from 100Mi free to 150Mi free, no alert.

The purpose here is that, since adding monitoring for kubernetes worker nodes, we've learned that kubernetes (or really, containerd with the systemd cgroup driver) uses the kernel's OOM killer when containers overstep their resource allocations. This has resulted in a lot of alerts that, for the purposes of hardware monitoring, we don't need to see.

Rather than ignore all worker nodes' OOM killers, we are opting to add a condition to only alert us if the OOM kill made a significant change to the existing memory landscape of the host.

For starters, "available memory doubled" is how we're defining "significant change to the existing memory landscape."