### PR TITLE
Restrict Cloudflare protected HAProxy services to published IP ranges

### DIFF
--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -45,6 +45,10 @@
 # @param dynamic_weight_smoothing This value is added to the weight for each
 # backend server regardless of server load to help "smooth" the effect of the weighting
 #
+# @param cloudflare_protected This service is protected by Cloudflare's WAF / bot / DDoS
+#   service, so restrict all requests to Cloudflare's IP ranges. For now, we are only
+#   considering IPv4 and the list is kept at: /etc/haproxy/cloudflare-ipv4.txt
+#
 # @param check_timeout_milliseconds How long to wait for http status
 # checks; defaults to 5 seconds
 #
@@ -74,6 +78,7 @@ define nebula::haproxy::service(
   Boolean          $custom_503 = false,
   Boolean          $dynamic_weighting = false,
   Integer          $dynamic_weight_smoothing = 2,
+  Boolean          $cloudflare_protected = false,
   String           $badrobots = '/etc/haproxy/global_badrobots.txt',
   Optional[Integer] $check_timeout_milliseconds = undef
 ) {
@@ -205,6 +210,28 @@ define nebula::haproxy::service(
       order   => '07'
     }
 
+  }
+
+  if $cloudflare_protected {
+    file { '/etc/haproxy/cloudflare-ipv4.txt':
+      content => @(EOT)
+        173.245.48.0/20
+        103.21.244.0/22
+        103.22.200.0/22
+        103.31.4.0/22
+        141.101.64.0/18
+        108.162.192.0/18
+        190.93.240.0/20
+        188.114.96.0/20
+        197.234.240.0/22
+        198.41.128.0/17
+        162.158.0.0/15
+        104.16.0.0/13
+        104.24.0.0/14
+        172.64.0.0/13
+        131.0.72.0/22
+      |EOT
+    }
   }
 
   if $cert_source {

--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -212,28 +212,6 @@ define nebula::haproxy::service(
 
   }
 
-  if $cloudflare_protected {
-    file { '/etc/haproxy/cloudflare-ipv4.txt':
-      content => @(EOT)
-        173.245.48.0/20
-        103.21.244.0/22
-        103.22.200.0/22
-        103.31.4.0/22
-        141.101.64.0/18
-        108.162.192.0/18
-        190.93.240.0/20
-        188.114.96.0/20
-        197.234.240.0/22
-        198.41.128.0/17
-        162.158.0.0/15
-        104.16.0.0/13
-        104.24.0.0/14
-        172.64.0.0/13
-        131.0.72.0/22
-      |EOT
-    }
-  }
-
   if $cert_source {
     file { "/etc/ssl/private/${service}":
       ensure  => 'directory',

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -37,6 +37,10 @@ class nebula::profile::haproxy(
       content => $global_badrobots;
   }
 
+  file { '/etc/haproxy/cloudflare-ipv4.txt':
+    source => 'https://www.cloudflare.com/ips-v4',
+  }
+
   file { '/etc/ssl/private' :
     ensure => 'directory',
     mode   => '0700',

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -149,6 +149,13 @@ describe 'nebula::profile::haproxy' do
         end
       end
 
+      describe 'Cloudflare proxy IP ranges' do
+        it 'saves Cloudflare trusted ranges in /etc/haproxy' do
+          expect(subject).to contain_file('/etc/haproxy/cloudflare-ipv4.txt')
+            .with_source('https://www.cloudflare.com/ips-v4')
+        end
+      end
+
       describe 'global_badrobots.txt file' do
         it 'lists ips to block' do
           expect(subject).to contain_file('/etc/haproxy/global_badrobots.txt').with_content("1.2.3.0/24\n5.6.7.8\n")

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -323,8 +323,6 @@ describe 'nebula::haproxy::service' do
         context 'with the cloudflare_protected setting' do
           let(:params) { super().merge(cloudflare_protected: true) }
 
-          it { is_expected.to contain_file('/etc/haproxy/cloudflare-ipv4.txt') }
-
           it do
             expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
               target: service_config,

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -317,6 +317,41 @@ describe 'nebula::haproxy::service' do
         end
       end
 
+      describe 'Cloudflare proxy ACL' do
+        let(:service_config) { '/etc/haproxy/services.d/svc1-http.cfg' }
+
+        context 'with the cloudflare_protected setting' do
+          let(:params) { super().merge(cloudflare_protected: true) }
+
+          it { is_expected.to contain_file('/etc/haproxy/cloudflare-ipv4.txt') }
+
+          it do
+            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+              target: service_config,
+              content: %r{acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt},
+            )
+          end
+
+          it do
+            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+              target: service_config,
+              content: %r{http-request deny unless cloudflare_proxied},
+            )
+          end
+        end
+
+        context 'without the cloudflare_protected setting' do
+          let(:params) { super().merge(cloudflare_protected: false) }
+
+          it do
+            expect(subject).not_to contain_concat_fragment('svc1-dc1-http frontend').with(
+              target: service_config,
+              content: %r{http-request deny unless cloudflare_proxied},
+            )
+          end
+        end
+      end
+
       describe 'ssl certs' do
         let(:dest) { '/etc/ssl/private/svc1' }
 

--- a/templates/profile/haproxy/frontend.erb
+++ b/templates/profile/haproxy/frontend.erb
@@ -29,3 +29,7 @@ use_backend <%= @service_prefix %>-back-exempt if <%= exemption_condition %>
 default_backend <%= @service_prefix %>-back
 acl blocked-ip src -f <%= @badrobots %>
 http-request deny if blocked-ip
+<% if @cloudflare_protected -%>
+acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
+http-request deny unless cloudflare_proxied
+<% end -%>


### PR DESCRIPTION
The Cloudflare WAF setup requires that you restrict your service to only their proxy IP ranges. This change extends our HAProxy service definition to accommodate this by using a new ACL and an http-request rule when the service has the "cloudflare_protected" flag.

This is not the only design option, but we have not yet needed to extend our services with arbitrary rules, so it did not seem to be the time to do that.

We source the IP ranges directly from Cloudflare. See: https://www.cloudflare.com/ips/