### PR TITLE
node 18

### DIFF
--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -17,7 +17,7 @@
 #     version => '14',
 #   }
 class nebula::profile::nodejs (
-  $version = '10',
+  $version = '18',
 ) {
   include nebula::profile::apt
 


### PR DESCRIPTION
On Debian 12 node 18 is the default and node 12 is the oldest version supported by the nodesource apt repo.

We should set node version in the config repo if any version older than 18 is needed.

It's worth noting that currently setting a version here lower than the debian default doesn't actually work (i.e. even though we were setting 10 here, all debian 11 hosts have node 12 or newer)