### PR TITLE
add debian non-free-firmware section for bookworm

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -94,10 +94,16 @@ class nebula::profile::apt (
   }
 
   if($::operatingsystem == 'Debian') {
-    # port to DEB822 before upgrade to Debian 12
+    # TODO: port to DEB822
+    # TODO: remove non-free where we're not using it
+    # TODO: remove branches when we're off buster, bullseye
+    $repos = $::lsbdistcodename ? {
+      'bookworm' => "main contrib non-free non-free-firmware",
+      default    => "main contrib non-free",
+    }
     apt::source { 'main':
       location => $mirror,
-      repos    => 'main contrib non-free',
+      repos    => $repos,
     }
 
     $security_release = $::lsbdistcodename ? {
@@ -108,7 +114,7 @@ class nebula::profile::apt (
     apt::source { 'security':
       location => 'http://security.debian.org/debian-security',
       release  => $security_release,
-      repos    => 'main contrib non-free',
+      repos    => $repos,
     }
 
     unless empty($::installed_backports) {
@@ -120,7 +126,7 @@ class nebula::profile::apt (
     apt::source { 'updates':
       location => $mirror,
       release  => "${::lsbdistcodename}-updates",
-      repos    => 'main contrib non-free',
+      repos    => $repos,
     }
 
     apt::source { 'adoptium':

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -34,11 +34,25 @@ describe 'nebula::profile::apt' do
         it do
           expect(subject).to contain_apt__source('main').with(
             location: 'http://ftp.us.debian.org/debian/',
-            repos: 'main contrib non-free',
+            repos: case os
+                   when 'debian-12-x86_64'
+                     'main contrib non-free non-free-firmware'
+                   else
+                     'main contrib non-free'
+                   end,
           )
         end
 
-        it { is_expected.to contain_apt__source('security').with_repos('main contrib non-free') }
+        it do
+          expect(subject).to contain_apt__source('security').with(
+            repos: case os
+                   when 'debian-12-x86_64'
+                     'main contrib non-free non-free-firmware'
+                   else
+                     'main contrib non-free'
+                   end,
+          )
+        end
 
         it do
           expect(subject).to contain_apt__source('security').with_release(
@@ -94,7 +108,12 @@ describe 'nebula::profile::apt' do
           expect(subject).to contain_apt__source('updates').with(
             location: 'http://ftp.us.debian.org/debian/',
             release: "#{facts[:lsbdistcodename]}-updates",
-            repos: 'main contrib non-free',
+            repos: case os
+                   when 'debian-12-x86_64'
+                     'main contrib non-free non-free-firmware'
+                   else
+                     'main contrib non-free'
+                   end,
           )
         end
 


### PR DESCRIPTION
To make it easier to disable most non-free packages, bookworm split the non-free section into non-free and non-free-firmware. We have packages from both of these sections on some hosts. Adding non-free-firmware for bookworm maintains the status-quo.