### PR TITLE
Revert "disable management of puppetdb"

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -36,6 +36,8 @@ fixtures:
     mount_core:          {"repo": "puppetlabs/mount_core",      "ref": "1.3.0" }
     mysql:               {"repo": "puppetlabs/mysql",           "ref": "16.0.0"}
     ntp:                 {"repo": "puppetlabs/ntp",             "ref": "10.1.0"}
+    postgresql:          {"repo": "puppetlabs/postgresql",      "ref": "10.3.0"}
+    puppetdb:            {"repo": "puppetlabs/puppetdb",        "ref": "8.1.0" }
     reboot:              {"repo": "puppetlabs/reboot",          "ref": "5.0.0" }
     sshkeys_core:        {"repo": "puppetlabs/sshkeys_core",    "ref": "2.5.0" }
     stdlib:              {"repo": "puppetlabs/stdlib",          "ref": "9.6.0" }

--- a/manifests/profile/puppet/db.pp
+++ b/manifests/profile/puppet/db.pp
@@ -7,8 +7,8 @@
 # @example
 #   include nebula::profile::puppet::db
 class nebula::profile::puppet::db {
-  #class { 'puppetdb':
-  #  disable_cleartext => true,
-  #  manage_firewall   => false,
-  #}
+  class { 'puppetdb':
+    disable_cleartext => true,
+    manage_firewall   => false,
+  }
 }

--- a/manifests/profile/puppet/master_with_db.pp
+++ b/manifests/profile/puppet/master_with_db.pp
@@ -9,9 +9,9 @@
 class nebula::profile::puppet::master_with_db (
   String $puppetdb_server = lookup('nebula::puppetdb'),
 ) {
-#  class { 'puppetdb::master::config':
-#    puppetdb_server         => $puppetdb_server,
-#    manage_report_processor => true,
-#    enable_reports          => true,
-#  }
+  class { 'puppetdb::master::config':
+    puppetdb_server         => $puppetdb_server,
+    manage_report_processor => true,
+    enable_reports          => true,
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,8 @@
     {"name": "puppetlabs/mount_core",      "version_requirement": ">= 1.3.0  < 2.0.0" },
     {"name": "puppetlabs/mysql",           "version_requirement": ">= 16.0.0 < 17.0.0"},
     {"name": "puppetlabs/ntp",             "version_requirement": ">= 10.1.0 < 11.0.0"},
+    {"name": "puppetlabs/postgresql",      "version_requirement": ">= 10.3.0 < 11.0.0"},
+    {"name": "puppetlabs/puppetdb",        "version_requirement": ">= 8.1.0  < 9.0.0" },
     {"name": "puppetlabs/reboot",          "version_requirement": ">= 5.0.0  < 6.0.0" },
     {"name": "puppetlabs/sshkeys_core",    "version_requirement": ">= 2.5.0  < 3.0.0" },
     {"name": "puppetlabs/stdlib",          "version_requirement": ">= 9.6.0  < 10.0.0"},

--- a/spec/classes/profile/puppet/db_spec.rb
+++ b/spec/classes/profile/puppet/db_spec.rb
@@ -10,7 +10,7 @@ describe 'nebula::profile::puppet::db' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      xit do
+      it do
         expect(subject).to contain_class('puppetdb').with(
           disable_cleartext: true,
           manage_firewall: false,

--- a/spec/classes/profile/puppet/master_with_db_spec.rb
+++ b/spec/classes/profile/puppet/master_with_db_spec.rb
@@ -10,7 +10,7 @@ describe 'nebula::profile::puppet::master_with_db' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      xit do
+      it do
         expect(subject).to contain_class('puppetdb::master::config').with(
           puppetdb_server: 'puppetdb.default.invalid',
           manage_report_processor: true,
@@ -21,7 +21,7 @@ describe 'nebula::profile::puppet::master_with_db' do
       context 'when given a puppetdb_server of db.puppet.gov' do
         let(:params) { { puppetdb_server: 'db.puppet.gov' } }
 
-        xit do
+        it do
           expect(subject).to contain_class('puppetdb::master::config')
             .with_puppetdb_server('db.puppet.gov')
         end


### PR DESCRIPTION
This reverts commit 8e3f8dec182483404a49c014e27b954dbd8f2889.

Since we upgraded puppet firewall, the dependency conflicts should finally be resolved and allow us to use the puppetdb module again.