### PR TITLE
update nodejs to 22 for ht test vm

### DIFF
--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -27,7 +27,7 @@ class nebula::role::webhost::htvm::test {
   ])
 
   class { 'nebula::profile::nodejs':
-    version => '18',
+    version => '22',
   }
 
   include nebula::role::webhost::htvm


### PR DESCRIPTION
Node 18 is supported through April. Would like to bump this version before then if possible. If this is complicated I'm happy to wait or add support for upgrading one host at a time.