### PR TITLE
rm legacy facts

### DIFF
--- a/manifests/haproxy/binding.pp
+++ b/manifests/haproxy/binding.pp
@@ -19,12 +19,12 @@
 # @param ipaddress The ip address HAproxy should use to reach the node
 #
 # @example
-#   @@nebula::haproxy::binding { '${::hostname} myservice':
+#   @@nebula::haproxy::binding { '${::networking['hostname']} myservice':
 #     service       => 'myservice',
 #     https_offload => 'false',
 #     datacenter    => $::datacenter,
-#     hostname      => $::hostname,
-#     ipaddress     => $::ipaddress
+#     hostname      => $::networking['hostname'],
+#     ipaddress     => $::networking['ip']
 #  }
 define nebula::haproxy::binding(
   String $service,

--- a/manifests/profile/apache/standalone_app_host.pp
+++ b/manifests/profile/apache/standalone_app_host.pp
@@ -10,7 +10,7 @@
 #   include nebula::profile::apache::standalone_app_host
 
 class nebula::profile::apache::standalone_app_host (
-  $ssl_cn = $::fqdn
+  $ssl_cn = $::networking['fqdn']
 ) {
 
   class { 'nebula::profile::ssl_keypair':

--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -16,7 +16,7 @@ class nebula::profile::apt (
   Optional[Hash] $local_repo = undef,
 ) {
 
-  if($facts['os']['family'] == 'Debian') {
+  if($::os['family'] == 'Debian') {
     package { 'aptitude': }
 
     # Ensure that apt knows to never ever install recommended packages
@@ -55,7 +55,7 @@ class nebula::profile::apt (
     if $local_repo {
       apt::source { 'local':
         *            => $local_repo,
-        release      => $::lsbdistcodename,
+        release      => $::os['distro']['codename'],
         repos        => 'main',
         architecture => $::os['architecture'],
       }
@@ -64,7 +64,7 @@ class nebula::profile::apt (
     if $facts['dmi'] and ($facts['dmi']['manufacturer'] == 'HP' or $facts['dmi']['manufacturer'] == 'HPE') {
       apt::source { 'hp':
         location => 'http://downloads.linux.hpe.com/SDR/repo/mcp/debian',
-        release  => "${::lsbdistcodename}/current",
+        release  => "${::os['distro']['codename']}/current",
         repos    => 'non-free',
         key      => {
           'name'   => 'hpe.asc',
@@ -93,11 +93,11 @@ class nebula::profile::apt (
     file { '/etc/apt/trusted.gpg': ensure => absent }
   }
 
-  if($::operatingsystem == 'Debian') {
+  if($::os['name'] == 'Debian') {
     # TODO: port to DEB822
     # TODO: remove non-free where we're not using it
     # TODO: remove branches when we're off buster, bullseye
-    $repos = $::lsbdistcodename ? {
+    $repos = $::os['distro']['codename'] ? {
       'bookworm' => "main contrib non-free non-free-firmware",
       default    => "main contrib non-free",
     }
@@ -106,9 +106,9 @@ class nebula::profile::apt (
       repos    => $repos,
     }
 
-    $security_release = $::lsbdistcodename ? {
-      'buster'  => "${::lsbdistcodename}/updates",
-      default   => "${::lsbdistcodename}-security",
+    $security_release = $::os['distro']['codename'] ? {
+      'buster'  => "${::os['distro']['codename']}/updates",
+      default   => "${::os['distro']['codename']}-security",
     }
 
     apt::source { 'security':
@@ -125,30 +125,30 @@ class nebula::profile::apt (
 
     apt::source { 'updates':
       location => $mirror,
-      release  => "${::lsbdistcodename}-updates",
+      release  => "${::os['distro']['codename']}-updates",
       repos    => $repos,
     }
 
     apt::source { 'adoptium':
       location => 'https://packages.adoptium.net/artifactory/deb/',
-      release  => $::lsbdistcodename,
+      release  => $::os['distro']['codename'],
       repos    => 'main',
       key      => {
         'name'   => 'adoptium.asc',
         'source' => 'puppet:///modules/nebula/apt/keyrings/adoptium.asc',
       }
     }
-  } elsif($::operatingsystem == 'Ubuntu') {
+  } elsif($::os['name'] == 'Ubuntu') {
     # port to DEB822 before upgrade to 24.04
     apt::source {
       default:
         location => $ubuntu_mirror,
         repos    => 'main restricted universe',
       ;
-      'main'     : release => $::lsbdistcodename;
-      'updates'  : release => "${::lsbdistcodename}-updates";
-      'backports': release => "${::lsbdistcodename}-backports";
-      'security' : release => "${::lsbdistcodename}-security";
+      'main'     : release => $::os['distro']['codename'];
+      'updates'  : release => "${::os['distro']['codename']}-updates";
+      'backports': release => "${::os['distro']['codename']}-backports";
+      'security' : release => "${::os['distro']['codename']}-security";
     }
 
     package { 'landscape-common': ensure => purged }

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -24,7 +24,7 @@ class nebula::profile::base (
     enable => true,
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     package { 'dselect': }
     package { 'ifenslave': }
     package { 'vlan': }

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -41,11 +41,11 @@ class nebula::profile::base (
     }
 
     file { '/etc/hostname':
-      content => "${$facts['fqdn']}\n",
-      notify  => Exec["/bin/hostname ${$facts['fqdn']}"],
+      content => "${::networking['fqdn']}\n",
+      notify  => Exec["/bin/hostname ${::networking['fqdn']}"],
     }
 
-    exec { "/bin/hostname ${$facts['fqdn']}":
+    exec { "/bin/hostname ${::networking['fqdn']}":
       refreshonly => true,
     }
   }

--- a/manifests/profile/base/motd.pp
+++ b/manifests/profile/base/motd.pp
@@ -8,12 +8,12 @@ class nebula::profile::base::motd (
   String  $contact_email,
   String  $sysadmin_dept,
 ) {
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     file { '/etc/motd':
       content => template('nebula/profile/base/motd.erb'),
     }
 
-    if($::operatingsystem == 'Ubuntu') {
+    if($::os['name'] == 'Ubuntu') {
       # delete a lot of useless motd content so it's not a half page long
       file { '/etc/update-motd.d/10-help-text': ensure => absent }
       file { '/etc/update-motd.d/50-motd-news': ensure => absent }

--- a/manifests/profile/containerd.pp
+++ b/manifests/profile/containerd.pp
@@ -13,8 +13,8 @@ class nebula::profile::containerd {
 
   apt::source { 'docker':
     location     => 'https://download.docker.com/linux/debian',
-    architecture => $facts['os']['architecture'],
-    release      => $::lsbdistcodename,
+    architecture => $::os['architecture'],
+    release      => $::os['distro']['codename'],
     repos        => 'stable',
     key          => {
       name   => 'docker.asc',

--- a/manifests/profile/exim4.pp
+++ b/manifests/profile/exim4.pp
@@ -33,7 +33,7 @@ class nebula::profile::exim4 (
   }
 
   file { '/etc/mailname':
-    content => "${::fqdn}\n",
+    content => "${::networking['fqdn']}\n",
     notify  => Exec['update exim4 config'],
   }
 

--- a/manifests/profile/fulcrum/base.pp
+++ b/manifests/profile/fulcrum/base.pp
@@ -16,9 +16,9 @@ class nebula::profile::fulcrum::base (
     ip           => '127.0.0.1',
   }
 
-  host { $::hostname:
-    host_aliases => [$::fqdn],
-    ip           => $::ipaddress,
+  host { $::networking['hostname']:
+    host_aliases => [$::networking['fqdn']],
+    ip           => $::networking['ip'],
   }
 
   host { 'ip6-localhost':

--- a/manifests/profile/fulcrum/nginx.pp
+++ b/manifests/profile/fulcrum/nginx.pp
@@ -6,7 +6,7 @@
 # SSL certificates with Let's Encrypt.
 class nebula::profile::fulcrum::nginx (
   Integer $port = 3000,
-  String $server_name = $::fqdn,
+  String $server_name = $::networking['fqdn'],
   String $webroot = '/var/www/acme',
 ) {
   class { 'nginx':

--- a/manifests/profile/github_pull_account.pp
+++ b/manifests/profile/github_pull_account.pp
@@ -29,7 +29,7 @@ class nebula::profile::github_pull_account (
   exec { "create ${git_homedir}/.ssh/id_ecdsa":
     creates => "${git_homedir}/.ssh/id_ecdsa",
     user    => $git_username,
-    command => "/usr/bin/ssh-keygen -t ecdsa -N '' -C '${::hostname}' -f ${git_homedir}/.ssh/id_ecdsa",
+    command => "/usr/bin/ssh-keygen -t ecdsa -N '' -C '${::networking['hostname']}' -f ${git_homedir}/.ssh/id_ecdsa",
     require => File["${git_homedir}/.ssh"],
   }
 

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -110,15 +110,15 @@ class nebula::profile::haproxy(
     order   => '01'
   }
 
-  @@concat_fragment { "keepalived node ip ${::hostname}":
+  @@concat_fragment { "keepalived node ip ${::networking['hostname']}":
     target  => '/etc/keepalived/keepalived.conf',
-    content => "    ${::ipaddress}\n",
+    content => "    ${::networking['ip']}\n",
     tag     => "keepalived-haproxy-ip-${::datacenter}",
     order   => '02'
   }
 
   # don't collect our own IP address, just the other haproxy nodes here
-  Concat_fragment <<| tag == "keepalived-haproxy-ip-${::datacenter}" and title != "keepalived node ip ${::hostname}" |>>
+  Concat_fragment <<| tag == "keepalived-haproxy-ip-${::datacenter}" and title != "keepalived node ip ${::networking['hostname']}" |>>
 
   concat_fragment { 'keepalived postamble':
     target  => '/etc/keepalived/keepalived.conf',
@@ -134,10 +134,10 @@ class nebula::profile::haproxy(
     content => template('nebula/profile/haproxy/keepalived/sysctl.conf.erb'),
   }
 
-  @@firewall { "200 HTTP: HAProxy ${::hostname}":
+  @@firewall { "200 HTTP: HAProxy ${::networking['hostname']}":
     proto  => 'tcp',
     dport  => [80, 443],
-    source => $::ipaddress,
+    source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
     tag    => "${::datacenter}_haproxy"

--- a/manifests/profile/hathitrust/cron/mdp_misc.pp
+++ b/manifests/profile/hathitrust/cron/mdp_misc.pp
@@ -38,7 +38,7 @@ class nebula::profile::hathitrust::cron::mdp_misc (
     'manage mbook sessions':
       minute      => $mdp_sessions_minute,
       environment => $sdr_environment + ["MAILTO=''"],
-      command     => "${home}/scripts/managembookssessions.pl -m clean -a 120 2>&1 || /usr/bin/mail -s '${::hostname} managembooksessions error' ${mail_recipient}";
+      command     => "${home}/scripts/managembookssessions.pl -m clean -a 120 2>&1 || /usr/bin/mail -s '${::networking['hostname']} managembooksessions error' ${mail_recipient}";
 
     'manage exclusivity expiration':
       minute  => $mdp_sessions_minute,
@@ -48,7 +48,7 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       minute      => 01,
       hour        => 00,
       environment => $sdr_environment + ["MAILTO=''"],
-      command     => "${sdr_root}/pt/scripts/harvest_proxy_downloads.pl 2>&1 || /usr/bin/mail -s '${::hostname} harvest_proxy_downloads problems' ${mail_recipient}";
+      command     => "${sdr_root}/pt/scripts/harvest_proxy_downloads.pl 2>&1 || /usr/bin/mail -s '${::networking['hostname']} harvest_proxy_downloads problems' ${mail_recipient}";
 
     # Build up translation maps. Collection codes are pulled from the HT
     # database, and lists of languages and formats are pulled right out of the the solr data.

--- a/manifests/profile/hathitrust/hosts.pp
+++ b/manifests/profile/hathitrust/hosts.pp
@@ -22,9 +22,9 @@ class nebula::profile::hathitrust::hosts(
     ip => '127.0.0.1'
   }
 
-  host { $::hostname:
-    host_aliases => [$::fqdn],
-    ip           => $::ipaddress
+  host { $::networking['hostname']:
+    host_aliases => [$::networking['fqdn']],
+    ip           => $::networking['ip']
   }
 
   host { 'ip6-localhost':

--- a/manifests/profile/hathitrust/ingest_hosts.pp
+++ b/manifests/profile/hathitrust/ingest_hosts.pp
@@ -20,9 +20,9 @@ class nebula::profile::hathitrust::ingest_hosts(
   String $solr_vufind_failover
 ) {
 
-  host { $::hostname:
-    host_aliases => [$::fqdn],
-    ip           => $::ipaddress
+  host { $::networking['hostname']:
+    host_aliases => [$::networking['fqdn']],
+    ip           => $::networking['ip']
   }
 
   host { 'mysql-sdr':

--- a/manifests/profile/http_fileserver.pp
+++ b/manifests/profile/http_fileserver.pp
@@ -33,7 +33,7 @@ class nebula::profile::http_fileserver (
   }
 
   @nebula::taghosts::tag { 'apache': }
-  $letsencrypt_directory = $::letsencrypt_directory[$::fqdn]
+  $letsencrypt_directory = $::letsencrypt_directory[$::networking['fqdn']]
   if $letsencrypt_directory {
     class { 'apache':
       docroot           => '/srv/www',
@@ -54,16 +54,16 @@ class nebula::profile::http_fileserver (
     }
   }
 
-  apache::vhost { "${::fqdn} http":
-    servername => $::fqdn,
+  apache::vhost { "${::networking['fqdn']} http":
+    servername => $::networking['fqdn'],
     port       => 80,
     docroot    => '/var/local/http',
     require    => File['/var/local/http']
   }
 
-  nebula::cert { $::fqdn:
+  nebula::cert { $::networking['fqdn']:
     webroot => '/var/local/http',
-    require => Apache::Vhost["${::fqdn} http"]
+    require => Apache::Vhost["${::networking['fqdn']} http"]
   }
 
   include nebula::profile::networking::firewall::http_datacenters

--- a/manifests/profile/https_to_port.pp
+++ b/manifests/profile/https_to_port.pp
@@ -15,7 +15,7 @@
 #   to land (defaults to `/var/www`)
 class nebula::profile::https_to_port (
   Integer $port,
-  String $server_name = $::fqdn,
+  String $server_name = $::networking['fqdn'],
   String $webroot = '/var/www',
 ) {
   include nginx

--- a/manifests/profile/known_host_public_keys.pp
+++ b/manifests/profile/known_host_public_keys.pp
@@ -17,10 +17,10 @@ class nebula::profile::known_host_public_keys {
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 
-    @@concat_fragment { "known host ${::fqdn} ${name}":
+    @@concat_fragment { "known host ${::networking['fqdn']} ${name}":
       tag     => 'known_host_public_keys',
       target  => '/etc/ssh/ssh_known_hosts',
-      content => "${::fqdn} ${type} ${key}\n",
+      content => "${::networking['fqdn']} ${type} ${key}\n",
     }
   }
 }

--- a/manifests/profile/kubernetes/destination_port/api.pp
+++ b/manifests/profile/kubernetes/destination_port/api.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::api {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes api ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes api ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/api.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:6443 check check-ssl verify none\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:6443 check check-ssl verify none\n",
     tag     => "${cluster_name}_haproxy_kubernetes_api",
   }
 }

--- a/manifests/profile/kubernetes/destination_port/etcd.pp
+++ b/manifests/profile/kubernetes/destination_port/etcd.pp
@@ -5,14 +5,14 @@
 class nebula::profile::kubernetes::destination_port::etcd {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes etcd ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes etcd ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/etcd.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:2379 check\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:2379 check\n",
     tag     => "${cluster_name}_haproxy_kubernetes_etcd",
   }
 
-  @@concat_fragment { "prometheus etcd service ${::hostname}":
+  @@concat_fragment { "prometheus etcd service ${::networking['hostname']}":
     tag     => "${::datacenter}_prometheus_etcd_service_list",
     target  => '/etc/prometheus/etcd.yml',
     content => template('nebula/profile/prometheus/exporter/etcd/target.yaml.erb')

--- a/manifests/profile/kubernetes/destination_port/gelf_tcp.pp
+++ b/manifests/profile/kubernetes/destination_port/gelf_tcp.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::gelf_tcp {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes gelf tcp ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes gelf tcp ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/gelf_tcp.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:32201 check\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:32201 check\n",
     tag     => "${cluster_name}_haproxy_kubernetes_gelf_tcp",
   }
 }

--- a/manifests/profile/kubernetes/destination_port/http.pp
+++ b/manifests/profile/kubernetes/destination_port/http.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::http {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes http ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes http ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/http.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:30080 check send-proxy\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:30080 check send-proxy\n",
     tag     => "${cluster_name}_haproxy_kubernetes_http",
   }
 }

--- a/manifests/profile/kubernetes/destination_port/https.pp
+++ b/manifests/profile/kubernetes/destination_port/https.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::https {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes https ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes https ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/https.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:30443 check send-proxy\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:30443 check send-proxy\n",
     tag     => "${cluster_name}_haproxy_kubernetes_https",
   }
 }

--- a/manifests/profile/kubernetes/destination_port/https_alt.pp
+++ b/manifests/profile/kubernetes/destination_port/https_alt.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::https_alt {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes https alt ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes https alt ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/https_alt.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:31443 check\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:31443 check\n",
     tag     => "${cluster_name}_haproxy_kubernetes_https_alt",
   }
 }

--- a/manifests/profile/kubernetes/destination_port/prometheus.pp
+++ b/manifests/profile/kubernetes/destination_port/prometheus.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::destination_port::prometheus {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "haproxy kubernetes prometheus ${::hostname}":
+  @@concat_fragment { "haproxy kubernetes prometheus ${::networking['hostname']}":
     target  => '/etc/haproxy/services.d/prometheus.cfg',
     order   => '02',
-    content => "  server ${::hostname} ${::ipaddress}:443 check send-proxy\n",
+    content => "  server ${::networking['hostname']} ${::networking['ip']}:443 check send-proxy\n",
     tag     => "${cluster_name}_haproxy_kubernetes_prometheus",
   }
 }

--- a/manifests/profile/kubernetes/dns_client.pp
+++ b/manifests/profile/kubernetes/dns_client.pp
@@ -8,7 +8,7 @@ class nebula::profile::kubernetes::dns_client {
   $private_domain = $cluster['private_domain']
   $router_address = $cluster['router_address']
 
-  @@concat_fragment { "/etc/hosts ipv4 ${::ipaddress}":
+  @@concat_fragment { "/etc/hosts ipv4 ${::networking['ip']}":
     tag     => "${cluster_name}_etc_hosts_ip4_hostname",
     target  => '/etc/hosts',
     order   => '04',
@@ -23,10 +23,10 @@ class nebula::profile::kubernetes::dns_client {
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 
-    @@concat_fragment { "known ${cluster_name} host ${::hostname} ${name}":
+    @@concat_fragment { "known ${cluster_name} host ${::networking['hostname']} ${name}":
       tag     => "${cluster_name}_known_host_public_keys",
       target  => '/etc/ssh/ssh_known_hosts',
-      content => "${::hostname} ${type} ${key}\n",
+      content => "${::networking['hostname']} ${type} ${key}\n",
     }
   }
 }

--- a/manifests/profile/kubernetes/keepalived.pp
+++ b/manifests/profile/kubernetes/keepalived.pp
@@ -24,16 +24,16 @@ class nebula::profile::kubernetes::keepalived (
     content => template('nebula/profile/kubernetes/keepalived/keepalived_01.erb'),
   }
 
-  @@concat_fragment { "keepalived ${::hostname}":
+  @@concat_fragment { "keepalived ${::networking['hostname']}":
     target  => '/etc/keepalived/keepalived.conf',
     order   => '02',
-    content => "    ${::ipaddress}\n",
+    content => "    ${::networking['ip']}\n",
     tag     => "${cluster_name}_keepalived",
   }
 
   # Don't collect own IP address, but otherwise get everyone else in
   # this cluster.
-  Concat_fragment <<| tag == "${cluster_name}_keepalived" and title != "keepalived ${::hostname}" |>>
+  Concat_fragment <<| tag == "${cluster_name}_keepalived" and title != "keepalived ${::networking['hostname']}" |>>
 
   concat_fragment { 'keepalived postamble':
     target  => '/etc/keepalived/keepalived.conf',
@@ -63,7 +63,7 @@ class nebula::profile::kubernetes::keepalived (
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 
-    @@concat_fragment { "known host ${control_dns} ${::fqdn} ${name}":
+    @@concat_fragment { "known host ${control_dns} ${::networking['fqdn']} ${name}":
       tag     => 'known_host_public_keys',
       target  => '/etc/ssh/ssh_known_hosts',
       content => "${control_dns} ${type} ${key}\n",

--- a/manifests/profile/kubernetes/register_for_keys/controller.pp
+++ b/manifests/profile/kubernetes/register_for_keys/controller.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::register_for_keys::controller {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "cluster pki for ${::hostname}":
+  @@concat_fragment { "cluster pki for ${::networking['hostname']}":
     tag     => "${cluster_name}_pki_generation",
     target  => '/var/local/generate_pki.sh',
     order   => '02',
-    content => "KUBE_CONTROLLERS=(\"\${KUBE_CONTROLLERS[@]}\" \"${::hostname}/${::ipaddress}\")\n",
+    content => "KUBE_CONTROLLERS=(\"\${KUBE_CONTROLLERS[@]}\" \"${::networking['hostname']}/${::networking['ip']}\")\n",
   }
 }

--- a/manifests/profile/kubernetes/register_for_keys/etcd.pp
+++ b/manifests/profile/kubernetes/register_for_keys/etcd.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::register_for_keys::etcd {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "cluster pki for ${::hostname}":
+  @@concat_fragment { "cluster pki for ${::networking['hostname']}":
     tag     => "${cluster_name}_pki_generation",
     target  => '/var/local/generate_pki.sh',
     order   => '02',
-    content => "ETCD_NODES=(\"\${ETCD_NODES[@]}\" \"${::hostname}/${::ipaddress}\")\n",
+    content => "ETCD_NODES=(\"\${ETCD_NODES[@]}\" \"${::networking['hostname']}/${::networking['ip']}\")\n",
   }
 }

--- a/manifests/profile/kubernetes/register_for_keys/worker.pp
+++ b/manifests/profile/kubernetes/register_for_keys/worker.pp
@@ -5,10 +5,10 @@
 class nebula::profile::kubernetes::register_for_keys::worker {
   $cluster_name = lookup('nebula::profile::kubernetes::cluster')
 
-  @@concat_fragment { "cluster pki for ${::hostname}":
+  @@concat_fragment { "cluster pki for ${::networking['hostname']}":
     tag     => "${cluster_name}_pki_generation",
     target  => '/var/local/generate_pki.sh',
     order   => '02',
-    content => "KUBE_WORKERS=(\"\${KUBE_WORKERS[@]}\" \"${::hostname}/${::ipaddress}\")\n",
+    content => "KUBE_WORKERS=(\"\${KUBE_WORKERS[@]}\" \"${::networking['hostname']}/${::networking['ip']}\")\n",
   }
 }

--- a/manifests/profile/networking/private.pp
+++ b/manifests/profile/networking/private.pp
@@ -19,14 +19,14 @@ class nebula::profile::networking::private (
 ) {
 
   if !$interface and $::os['family'] == 'Debian' and $facts['is_virtual']
-    and 'ens4' in $facts['networking']['interfaces'] {
+    and 'ens4' in $::networking['interfaces'] {
     $real_interface = 'ens4'
   } else {
     $real_interface = $interface
   }
 
   if $real_interface {
-    $address = sprintf($address_template,split($facts['networking']['ip'],'\.')[-1])
+    $address = sprintf($address_template,split($::networking['ip'],'\.')[-1])
 
     file { '/etc/network/interfaces.d/private':
       content      => template('nebula/profile/networking/private.erb'),

--- a/manifests/profile/networking/private.pp
+++ b/manifests/profile/networking/private.pp
@@ -18,7 +18,7 @@ class nebula::profile::networking::private (
   Optional[String] $interface = undef,
 ) {
 
-  if !$interface and $facts['os']['family'] == 'Debian' and $facts['is_virtual']
+  if !$interface and $::os['family'] == 'Debian' and $facts['is_virtual']
     and 'ens4' in $facts['networking']['interfaces'] {
     $real_interface = 'ens4'
   } else {

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -24,7 +24,7 @@ class nebula::profile::nodejs (
     apt::source { 'nodesource.com':
       comment       => 'Nodesource apt source for recent nodejs',
       location      => "https://deb.nodesource.com/node_${version}.x",
-      release       => $::lsbdistcodename,
+      release       => $::os['distro']['codename'],
       repos         => 'main',
       notify_update => true,
       key           => {

--- a/manifests/profile/php73.pp
+++ b/manifests/profile/php73.pp
@@ -14,7 +14,7 @@ class nebula::profile::php73 (
       name   => 'php-community-sury.org.gpg',
       source => 'https://packages.sury.org/php/apt.gpg'
     },
-    release      => $::lsbdistcodename,
+    release      => $::os['distro']['codename'],
     repos        => 'main',
     architecture => $::os['architecture'],
   }

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -25,7 +25,7 @@ class nebula::profile::prometheus (
   String $pushgateway_version = 'latest',
 ) {
   include nebula::profile::docker
-  $hostname = $::hostname
+  $hostname = $::networking['hostname']
 
   docker::run { 'prometheus':
     image            => "prom/prometheus:${version}",
@@ -126,11 +126,11 @@ class nebula::profile::prometheus (
   }
 
   file { '/etc/prometheus/tls/client.crt':
-    source => "puppet:///ssl-certs/prometheus-pki/${::fqdn}.crt",
+    source => "puppet:///ssl-certs/prometheus-pki/${::networking['fqdn']}.crt",
   }
 
   file { '/etc/prometheus/tls/client.key':
-    source => "puppet:///ssl-certs/prometheus-pki/${::fqdn}.key",
+    source => "puppet:///ssl-certs/prometheus-pki/${::networking['fqdn']}.key",
   }
 
   file { '/opt/prometheus':
@@ -159,7 +159,7 @@ class nebula::profile::prometheus (
       server_tokens        => 'off',
     }
     nginx::resource::server { 'https-forwarder':
-      server_name       => [$::fqdn],
+      server_name       => [$::networking['fqdn']],
       listen_options    => 'proxy_protocol default_server',
       listen_port       => 443,
       proxy             => 'http://localhost:9090',
@@ -187,7 +187,7 @@ class nebula::profile::prometheus (
     }
 
     default: {
-      $all_public_addresses = [$::ipaddress]
+      $all_public_addresses = [$::networking['ip']]
       $all_private_addresses = []
     }
   }
@@ -221,12 +221,12 @@ class nebula::profile::prometheus (
         jump   => 'accept',
       ;
 
-      "010 prometheus public node exporter ${::hostname} ${address}":
+      "010 prometheus public node exporter ${::networking['hostname']} ${address}":
         tag   => "${::datacenter}_prometheus_public_node_exporter",
         dport => 9100,
       ;
 
-      "010 prometheus public ipmi exporter ${::hostname} ${address}":
+      "010 prometheus public ipmi exporter ${::networking['hostname']} ${address}":
         tag   => "${::datacenter}_prometheus_public_ipmi_exporter",
         dport => 9290,
       ;
@@ -242,32 +242,32 @@ class nebula::profile::prometheus (
         jump   => 'accept',
       ;
 
-      "010 prometheus private node exporter ${::hostname} ${address}":
+      "010 prometheus private node exporter ${::networking['hostname']} ${address}":
         tag   => "${::datacenter}_prometheus_private_node_exporter",
         dport => 9100,
       ;
 
-      "010 prometheus private ipmi exporter ${::hostname} ${address}":
+      "010 prometheus private ipmi exporter ${::networking['hostname']} ${address}":
         tag   => "${::datacenter}_prometheus_private_ipmi_exporter",
         dport => 9290,
       ;
     }
   }
 
-  @@firewall { "010 prometheus haproxy exporter ${::hostname}":
+  @@firewall { "010 prometheus haproxy exporter ${::networking['hostname']}":
     tag    => "${::datacenter}_prometheus_haproxy_exporter",
     proto  => 'tcp',
     dport  => 9101,
-    source => $::ipaddress,
+    source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
   }
 
-  @@firewall { "010 prometheus mysql exporter ${::hostname}":
+  @@firewall { "010 prometheus mysql exporter ${::networking['hostname']}":
     tag    => "${::datacenter}_prometheus_mysql_exporter",
     proto  => 'tcp',
     dport  => 9104,
-    source => $::ipaddress,
+    source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
   }

--- a/manifests/profile/prometheus/exporter/haproxy.pp
+++ b/manifests/profile/prometheus/exporter/haproxy.pp
@@ -26,7 +26,7 @@ class nebula::profile::prometheus::exporter::haproxy (
   }
 
 
-  @@concat_fragment { "prometheus haproxy service ${::hostname}":
+  @@concat_fragment { "prometheus haproxy service ${::networking['hostname']}":
     tag     => "${::datacenter}_prometheus_haproxy_service_list",
     target  => '/etc/prometheus/haproxy.yml',
     content => template('nebula/profile/prometheus/exporter/haproxy/target.yaml.erb')

--- a/manifests/profile/prometheus/exporter/ipmi.pp
+++ b/manifests/profile/prometheus/exporter/ipmi.pp
@@ -39,7 +39,7 @@ class nebula::profile::prometheus::exporter::ipmi (
       Firewall <<| tag == "${::datacenter}_prometheus_public_ipmi_exporter" |>>
     }
 
-    @@concat_fragment { "prometheus ipmi scrape config ${::hostname}":
+    @@concat_fragment { "prometheus ipmi scrape config ${::networking['hostname']}":
       tag     => "${::datacenter}_prometheus_ipmi_exporter",
       target  => '/etc/prometheus/ipmi.yml',
       order   => '02',

--- a/manifests/profile/prometheus/exporter/mysql.pp
+++ b/manifests/profile/prometheus/exporter/mysql.pp
@@ -24,7 +24,7 @@ class nebula::profile::prometheus::exporter::mysql ()
     content => template('nebula/profile/prometheus/exporter/mysql/defaults.sh.erb')
   }
 
-  @@concat_fragment { "prometheus mysql service ${::hostname}":
+  @@concat_fragment { "prometheus mysql service ${::networking['hostname']}":
     tag     => "${::datacenter}_prometheus_mysql_service_list",
     target  => '/etc/prometheus/mysql.yml',
     content => template('nebula/profile/prometheus/exporter/mysql/target.yaml.erb')

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -107,10 +107,10 @@ class nebula::profile::prometheus::exporter::node (
   $role = lookup_role()
   $datacenter = $::datacenter
 
-  if $::domain == lookup('umich::default_domain', default_value => 'prometheus-node-exporter.default.invalid') {
-    $hostname = $::hostname
+  if $::networking['domain'] == lookup('umich::default_domain', default_value => 'prometheus-node-exporter.default.invalid') {
+    $hostname = $::networking['hostname']
   } else {
-    $hostname = $::fqdn
+    $hostname = $::networking['fqdn']
   }
 
   if $datacenter in $covered_datacenters {
@@ -127,8 +127,8 @@ class nebula::profile::prometheus::exporter::node (
 
     default: {
       # If the public/private fact isn't working, fall back to assuming
-      # that the legacy `$::ipaddress` fact is public.
-      $all_public_addresses = [$::ipaddress]
+      # that the legacy `$::networking['ip']` fact is public.
+      $all_public_addresses = [$::networking['ip']]
       $all_private_addresses = []
     }
   }
@@ -149,7 +149,7 @@ class nebula::profile::prometheus::exporter::node (
 
   $ipaddress = $ipaddresses[0]
   $ipaddresses.each |$address| {
-    @@firewall { "300 pushgateway ${::hostname} ${address}":
+    @@firewall { "300 pushgateway ${::networking['hostname']} ${address}":
       tag    => "${monitoring_datacenter}_pushgateway_node",
       proto  => 'tcp',
       dport  => 9091,
@@ -180,7 +180,7 @@ class nebula::profile::prometheus::exporter::node (
     content => template('nebula/profile/prometheus/exporter/node/pushgateway_advanced.sh.erb'),
   }
 
-  @@concat_fragment { "prometheus node service ${::hostname}":
+  @@concat_fragment { "prometheus node service ${::networking['hostname']}":
     tag     => "${monitoring_datacenter}_prometheus_node_service_list",
     target  => '/etc/prometheus/nodes.yml',
     content => template('nebula/profile/prometheus/exporter/node/target.yaml.erb'),

--- a/manifests/profile/quod/prod/haproxy.pp
+++ b/manifests/profile/quod/prod/haproxy.pp
@@ -7,11 +7,11 @@
 # @example
 #   include nebula::profile::quod::prod::haproxy
 class nebula::profile::quod::prod::haproxy {
-  @@nebula::haproxy::binding { "${::hostname} quod":
+  @@nebula::haproxy::binding { "${::networking['hostname']} quod":
     service       => 'quod',
     https_offload => true,
     datacenter    => $::datacenter,
-    hostname      => $::hostname,
-    ipaddress     => $::ipaddress;
+    hostname      => $::networking['hostname'],
+    ipaddress     => $::networking['ip'];
   }
 }

--- a/manifests/profile/taghosts/tags.pp
+++ b/manifests/profile/taghosts/tags.pp
@@ -75,8 +75,8 @@ class nebula::profile::taghosts::tags (
     }
   }
 
-  if $facts['os']['family'] == 'Debian' {
-    $os_name = $facts['os']['name'] ? {
+  if $::os['family'] == 'Debian' {
+    $os_name = $::os['name'] ? {
       'Ubuntu' => 'ubuntu',
       default  => 'debian',
     }
@@ -85,7 +85,7 @@ class nebula::profile::taghosts::tags (
       order => '004',
     }
 
-    nebula::taghosts::tag { $facts['os']['distro']['codename']:
+    nebula::taghosts::tag { $::os['distro']['codename']:
       order => '005',
     }
   }

--- a/manifests/profile/taghosts/tags.pp
+++ b/manifests/profile/taghosts/tags.pp
@@ -15,14 +15,14 @@ class nebula::profile::taghosts::tags (
 
   # Each line starts with the fqdn, a tab, and the tag "puppet" to show
   # this host's tags are managed by puppet.
-  @@concat::fragment { "taghosts ${::fqdn} 000":
+  @@concat::fragment { "taghosts ${::networking['fqdn']} 000":
     tag     => 'taghosts',
     target  => '/var/lib/ae/active-servers',
-    content => "${::fqdn}\tpuppet",
+    content => "${::networking['fqdn']}\tpuppet",
   }
 
   # Each line ends with a newline.
-  @@concat::fragment { "taghosts ${::fqdn} 999":
+  @@concat::fragment { "taghosts ${::networking['fqdn']} 999":
     tag     => 'taghosts',
     target  => '/var/lib/ae/active-servers',
     content => "\n",

--- a/manifests/profile/vmhost/host.pp
+++ b/manifests/profile/vmhost/host.pp
@@ -91,7 +91,7 @@ class nebula::profile::vmhost::host (
     }
   }
 
-  if($::operatingsystem == 'Ubuntu') {
+  if($::os['name'] == 'Ubuntu') {
     package { 'command-not-found': ensure => purged }
     package { 'python3-commandnotfound': ensure => purged }
   }

--- a/manifests/profile/www_lib/cron.pp
+++ b/manifests/profile/www_lib/cron.pp
@@ -25,7 +25,7 @@ class nebula::profile::www_lib::cron (
     'staff.lib parse':
       hour    => 3,
       minute  => 30,
-      command => "/usr/bin/perl /www/staff.lib/web/sites/staff.lib.umich.edu/local/dashboard/parse.pl > /www/staff.lib/web/sites/staff.lib.umich.edu/local/dashboard/logs/${::hostname}-parse.log 2>&1",
+      command => "/usr/bin/perl /www/staff.lib/web/sites/staff.lib.umich.edu/local/dashboard/parse.pl > /www/staff.lib/web/sites/staff.lib.umich.edu/local/dashboard/logs/${::networking['hostname']}-parse.log 2>&1",
     ;
 
     'Proactively scan the log files for suspcious activity':

--- a/manifests/profile/www_lib/php.pp
+++ b/manifests/profile/www_lib/php.pp
@@ -19,7 +19,7 @@ class nebula::profile::www_lib::php (
       name   => 'php-community-sury.org.gpg',
       source => 'https://packages.sury.org/php/apt.gpg'
     },
-    release      => $::lsbdistcodename,
+    release      => $::os['distro']['codename'],
     repos        => 'main',
     architecture => $::os['architecture'],
   }

--- a/manifests/profile/www_lib/register_for_load_balancing.pp
+++ b/manifests/profile/www_lib/register_for_load_balancing.pp
@@ -6,11 +6,11 @@ class nebula::profile::www_lib::register_for_load_balancing (
   Array[String] $services = [],
 ) {
   $services.each |$service| {
-    @@nebula::haproxy::binding { "${::hostname} ${service}":
+    @@nebula::haproxy::binding { "${::networking['hostname']} ${service}":
       service       => $service,
       datacenter    => $::datacenter,
-      hostname      => $::hostname,
-      ipaddress     => $::ipaddress,
+      hostname      => $::networking['hostname'],
+      ipaddress     => $::networking['ip'],
       https_offload => false,
     }
   }

--- a/manifests/profile/www_lib/vhosts/default.pp
+++ b/manifests/profile/www_lib/vhosts/default.pp
@@ -33,7 +33,7 @@ class nebula::profile::www_lib::vhosts::default (
   nebula::apache::www_lib_vhost { '000-default-ssl':
     ssl         => true,
     ssl_cn      => $ssl_cn,
-    servername  => $::fqdn,
+    servername  => $::networking['fqdn'],
     directories => [ $nebula::profile::apache::monitoring::location ],
     aliases     => [ $nebula::profile::apache::monitoring::scriptalias ],
     docroot     => false,

--- a/manifests/role/aws.pp
+++ b/manifests/role/aws.pp
@@ -20,7 +20,7 @@ class nebula::role::aws (
 
   include nebula::profile::aws::filesystem
 
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     include nebula::profile::exim4
     include nebula::profile::ntp
     class { 'nebula::profile::networking':

--- a/manifests/role/hathitrust.pp
+++ b/manifests/role/hathitrust.pp
@@ -18,7 +18,7 @@ class nebula::role::hathitrust (
     internal_routing => $internal_routing,
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     include nebula::profile::krb5
     if $afs {
       include nebula::profile::afs

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -9,7 +9,7 @@
 class nebula::role::minimum (
   String $internal_routing = '',
 ) {
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     include nebula::profile::base
     include nebula::profile::prometheus::exporter::node
     include nebula::profile::authorized_keys

--- a/manifests/role/umich.pp
+++ b/manifests/role/umich.pp
@@ -17,7 +17,7 @@ class nebula::role::umich (
     internal_routing => $internal_routing,
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     include nebula::profile::duo
     include nebula::profile::exim4
     include nebula::profile::grub

--- a/manifests/role/umich_mailserver.pp
+++ b/manifests/role/umich_mailserver.pp
@@ -17,7 +17,7 @@ class nebula::role::umich_mailserver (
     internal_routing => $internal_routing,
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $::os['family'] == 'Debian' {
     include nebula::profile::duo
     include nebula::profile::postfix
     include nebula::profile::grub

--- a/manifests/role/webhost/htvm/prod.pp
+++ b/manifests/role/webhost/htvm/prod.pp
@@ -10,12 +10,12 @@ class nebula::role::webhost::htvm::prod {
   include nebula::role::webhost::htvm
   include nebula::profile::hathitrust::apache::logs
 
-  @@nebula::haproxy::binding { "${::hostname} hathitrust":
+  @@nebula::haproxy::binding { "${::networking['hostname']} hathitrust":
     service       => 'hathitrust',
     https_offload => false,
     datacenter    => $::datacenter,
-    hostname      => $::hostname,
-    ipaddress     => $::ipaddress
+    hostname      => $::networking['hostname'],
+    ipaddress     => $::networking['ip']
   }
 
   @nebula::taghosts::tag { 'prod': }

--- a/manifests/taghosts/tag.pp
+++ b/manifests/taghosts/tag.pp
@@ -5,7 +5,7 @@
 define nebula::taghosts::tag (
   String $order = '100',
 ) {
-  @@concat::fragment { "taghosts ${::fqdn} ${order} ${title}":
+  @@concat::fragment { "taghosts ${::networking['fqdn']} ${order} ${title}":
     tag     => 'taghosts',
     target  => '/var/lib/ae/active-servers',
     content => " ${title}",

--- a/manifests/unison/client.pp
+++ b/manifests/unison/client.pp
@@ -34,10 +34,10 @@ define nebula::unison::client (
     require    => Package[unison]
   }
 
-  @@firewall { "200 Unison: ${title} ${::hostname}":
+  @@firewall { "200 Unison: ${title} ${::networking['hostname']}":
     proto  => 'tcp',
     dport  => [$port],
-    source => $::ipaddress,
+    source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
     tag    =>  "unison-client-${title}"

--- a/manifests/unison/server.pp
+++ b/manifests/unison/server.pp
@@ -25,7 +25,7 @@ define nebula::unison::server (
   }
 
   @@nebula::unison::client { $title:
-    server      => $::fqdn,
+    server      => $::networking['fqdn'],
     port        => $port,
     root        => $root,
     paths       => $paths,

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -16,9 +16,10 @@ describe 'nebula::profile::haproxy' do
           networking: {
             ip: my_ip,
             primary: 'eth0',
+            hostname: 'thisnode',
           },
-          ipaddress: my_ip,
-          hostname: 'thisnode',
+          ipaddress: 'INVALID_DO_NOT_USE',
+          hostname: 'INVALID_DO_NOT_USE',
         )
       end
 

--- a/spec/classes/profile/hathitrust/hosts_spec.rb
+++ b/spec/classes/profile/hathitrust/hosts_spec.rb
@@ -27,10 +27,15 @@ describe 'nebula::profile::hathitrust::hosts' do
       end
 
       let(:facts) do
-        os_facts.merge(
-          ipaddress: my_ip,
-          hostname: hostname,
-          fqdn: fqdn,
+        os_facts.deep_merge(
+          ipaddress: 'INVALID_DO_NOT_USE',
+          hostname: 'INVALID_DO_NOT_USE',
+          fqdn: 'INVALID_DO_NOT_USE',
+          networking: {
+            'ip' => my_ip,
+            'hostname' => hostname,
+            'fqdn' => fqdn,
+          },
         )
       end
 

--- a/spec/classes/profile/known_host_public_keys_spec.rb
+++ b/spec/classes/profile/known_host_public_keys_spec.rb
@@ -13,8 +13,10 @@ describe 'nebula::profile::known_host_public_keys' do
       context 'with fqdn of example.invalid and some ssh public keys' do
         let(:facts) do
           {
-            'fqdn' => 'example.invalid',
-            'ssh' => {
+            networking: {
+              'fqdn' => 'example.invalid',
+            },
+            ssh: {
               'ecdsa' => {
                 'type' => 'ecdsa-sha2-nistp256',
                 'key' => 'ecdsa_key',

--- a/spec/classes/profile/kubernetes/dns_client_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_client_spec.rb
@@ -10,24 +10,28 @@ describe 'nebula::profile::kubernetes::dns_client' do
     context "on #{os}" do
       let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
       let(:facts) do
-        os_facts.merge(
-          'networking' => {
+        my_facts = os_facts.deep_merge(
+          networking: {
             'interfaces' => {
               'ens4' => {
                 'ip' => '10.123.234.5',
               },
             },
+            'ip' => '10.123.234.5',
+            'primary' => 'ens4',
           },
         )
+        my_facts[:networking]['interfaces'].delete('eth0')
+        my_facts
       end
 
       it { is_expected.to compile }
 
       it do
-        expect(exported_resources).to contain_concat_fragment("/etc/hosts ipv4 #{facts[:ipaddress]}")
+        expect(exported_resources).to contain_concat_fragment("/etc/hosts ipv4 #{facts[:networking]['ip']}")
           .with_target('/etc/hosts')
           .with_order('04')
-          .with_content("#{facts[:ipaddress]} #{facts[:fqdn]} #{facts[:hostname]}\n")
+          .with_content("#{facts[:networking]['ip']} #{facts[:fqdn]} #{facts[:hostname]}\n")
       end
 
       it do

--- a/spec/classes/profile/kubernetes/keepalived_spec.rb
+++ b/spec/classes/profile/kubernetes/keepalived_spec.rb
@@ -108,8 +108,9 @@ describe 'nebula::profile::kubernetes::keepalived' do
       context 'with fqdn of default.invalid and an ssh-rsa public key' do
         let(:facts) do
           {
-            'fqdn' => 'default.invalid',
-            'ssh' => {
+            fqdn: 'INVALID_DO_NOT_USE',
+            networking: { 'fqdn' => 'default.invalid' },
+            ssh: {
               'rsa' => {
                 'type' => 'ssh-rsa',
                 'key' => 'abc123',

--- a/spec/classes/profile/quod/prod/haproxy_spec.rb
+++ b/spec/classes/profile/quod/prod/haproxy_spec.rb
@@ -7,7 +7,14 @@ require 'spec_helper'
 describe 'nebula::profile::quod::prod::haproxy' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(hostname: 'thisnode', datacenter: 'somedc') }
+      let(:facts) do
+        os_facts.deep_merge(
+          datacenter: 'somedc',
+          networking: {
+            'hostname' => 'thisnode',
+          },
+        )
+      end
 
       it { is_expected.to compile }
 

--- a/spec/classes/role/deb_server_spec.rb
+++ b/spec/classes/role/deb_server_spec.rb
@@ -12,7 +12,7 @@ describe 'nebula::role::deb_server' do
     context "on #{os}" do
       include_context 'with mocked query for nodes in other datacenters'
 
-      let(:facts) { os_facts.merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
+      let(:facts) { os_facts.deep_merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
       let(:hiera_config) { 'spec/fixtures/hiera/deb_server_config.yaml' }
 
       it { is_expected.to compile }

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -11,7 +11,7 @@ describe 'nebula::role::webhost::htvm' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context 'with setup for htvm node', os_facts
-
+      # binding.irb
       it { is_expected.to compile }
 
       it do
@@ -40,10 +40,10 @@ describe 'nebula::role::webhost::htvm' do
 
       context 'with ens4' do
         let(:facts) do
-          os_facts.merge(
+          os_facts.deep_merge(
             networking: {
-              ip: '1.2.3.123',
-              interfaces: { 'ens4' => {} },
+              'ip' => '1.2.3.123',
+              'interfaces' => { 'ens4' => {} },
             },
             is_virtual: true,
           )

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -13,15 +13,19 @@ require 'spec_helper'
       context "on #{os}" do
         let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
         let(:facts) do
-          os_facts.merge(
-            'networking' => {
+          my_facts = os_facts.deep_merge(
+            networking: {
               'interfaces' => {
                 'ens4' => {
                   'ip' => '10.123.234.5',
                 },
               },
+              'ip' => '10.123.234.5',
+              'primary' => 'ens4',
             },
           )
+          my_facts[:networking]['interfaces'].delete('eth0')
+          my_facts
         end
 
         it { is_expected.to contain_class('Nebula::Profile::Ntp') }
@@ -40,15 +44,19 @@ end
       context "on #{os}" do
         let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
         let(:facts) do
-          os_facts.merge(
-            'networking' => {
+          my_facts = os_facts.deep_merge(
+            networking: {
               'interfaces' => {
                 'ens4' => {
                   'ip' => '10.123.234.5',
                 },
               },
+              'ip' => '10.123.234.5',
+              'primary' => 'ens4',
             },
           )
+          my_facts[:networking]['interfaces'].delete('eth0')
+          my_facts
         end
 
         it { is_expected.to contain_class('Nebula::Profile::Ntp') }
@@ -89,27 +97,27 @@ end
         case role
         when 'etcd'
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
               .with_tag('first_cluster_pki_generation')
               .with_target('/var/local/generate_pki.sh')
               .with_order('02')
-              .with_content("ETCD_NODES=(\"${ETCD_NODES[@]}\" \"#{facts[:hostname]}/#{facts[:ipaddress]}\")\n")
+              .with_content("ETCD_NODES=(\"${ETCD_NODES[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
           end
         when 'controller'
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
               .with_tag('first_cluster_pki_generation')
               .with_target('/var/local/generate_pki.sh')
               .with_order('02')
-              .with_content("KUBE_CONTROLLERS=(\"${KUBE_CONTROLLERS[@]}\" \"#{facts[:hostname]}/#{facts[:ipaddress]}\")\n")
+              .with_content("KUBE_CONTROLLERS=(\"${KUBE_CONTROLLERS[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
           end
         when 'worker'
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
               .with_tag('first_cluster_pki_generation')
               .with_target('/var/local/generate_pki.sh')
               .with_order('02')
-              .with_content("KUBE_WORKERS=(\"${KUBE_WORKERS[@]}\" \"#{facts[:hostname]}/#{facts[:ipaddress]}\")\n")
+              .with_content("KUBE_WORKERS=(\"${KUBE_WORKERS[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
           end
 
           it { is_expected.to contain_package('lvm2') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,3 +82,23 @@ end
 def allow_call(dbl)
   allow(dbl).to receive(:call)
 end
+
+class Hash
+  # deep_merge copied with minor adaptation from:
+  # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/deep_mergeable.rb
+  def deep_merge(other, &block)
+    dup.deep_merge!(other, &block)
+  end
+
+  def deep_merge!(other, &block)
+    merge!(other) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge(other_val, &block)
+      elsif block_given?
+        block.call(key, this_val, other_val)
+      else
+        other_val
+      end
+    end
+  end
+end

--- a/spec/support/contexts/with_htvm_setup.rb
+++ b/spec/support/contexts/with_htvm_setup.rb
@@ -5,10 +5,9 @@ require 'faker'
 
 RSpec.shared_context 'with setup for htvm node' do |os_facts|
   let(:facts) do
-    os_facts.merge(
-      hostname: 'thisnode',
+    os_facts.deep_merge(
       datacenter: 'somedc',
-      networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} },
+      networking: { 'ip' => Faker::Internet.ip_v4_address, 'interfaces' => {}, 'hostname' => 'thisnode' },
     )
   end
   let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }

--- a/templates/profile/kubernetes/dns/hosts_04_ipv4_hostname.erb
+++ b/templates/profile/kubernetes/dns/hosts_04_ipv4_hostname.erb
@@ -1,1 +1,1 @@
-<%= @ipaddress %> <%= @fqdn %> <%= @hostname %>
+<%= @facts['networking']['ip'] %> <%= @facts['networking']['fqdn'] %> <%= @facts['networking']['hostname'] %>


### PR DESCRIPTION
- remove legacy facts to support puppet 8
- fix tests that now need the `networking` fact mocked correctly