### PR TITLE
Revert "Add logrotate for /var/log/babel on ingest machines"

### DIFF
--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -34,10 +34,5 @@ class nebula::role::hathitrust::ingest_indexing () {
 
   include nebula::profile::ruby
 
-  class { 'nebula::profile::hathitrust::babel_logs':
-    log_owner => 'slip',
-    log_group => 'htprod'
-  }
-
   nebula::usergroup { 'htingest': }
 }

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -30,8 +30,6 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
       # not specified explicitly - realized through Nebula::Usergroup[htingest]
       it { is_expected.to contain_user('htingest') }
       it { is_expected.not_to contain_user('htweb') }
-
-      it { is_expected.to contain_file('/etc/logrotate.d/babel') }
     end
   end
 end


### PR DESCRIPTION
Reverts mlibrary/nebula#759

Puppet fails because this doesn't `include nebula::profile::loki`, and thus alloy is missing.