### PR TITLE
logrotate for /var/log/babel on ingest machines, again

### DIFF
--- a/manifests/profile/hathitrust/babel_logs.pp
+++ b/manifests/profile/hathitrust/babel_logs.pp
@@ -22,8 +22,12 @@ class nebula::profile::hathitrust::babel_logs (
     mode   => '0644'
   }
 
+  include nebula::profile::loki
+
   file { '/etc/alloy/babel.alloy':
     ensure  => 'file',
+    require => Package['alloy'],
+    notify  => Service['alloy'],
     content => template('nebula/profile/hathitrust/babel_logs/alloy.erb'),
   }
 

--- a/manifests/role/hathitrust/ingest_indexing.pp
+++ b/manifests/role/hathitrust/ingest_indexing.pp
@@ -34,5 +34,10 @@ class nebula::role::hathitrust::ingest_indexing () {
 
   include nebula::profile::ruby
 
+  class { 'nebula::profile::hathitrust::babel_logs':
+    log_owner => 'slip',
+    log_group => 'htprod'
+  }
+
   nebula::usergroup { 'htingest': }
 }

--- a/spec/classes/profile/hathitrust/babel_logs_spec.rb
+++ b/spec/classes/profile/hathitrust/babel_logs_spec.rb
@@ -8,8 +8,10 @@ require 'spec_helper'
 require_relative '../../../support/contexts/with_htvm_setup'
 
 describe 'nebula::profile::hathitrust::babel_logs' do
-  on_supported_os.each do |os, _os_facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      let(:facts) { os_facts }
+
       it { is_expected.to compile }
 
       it { is_expected.to contain_file('/var/log/babel').with_owner('nobody') }

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -30,6 +30,8 @@ describe 'nebula::role::hathitrust::ingest_indexing' do
       # not specified explicitly - realized through Nebula::Usergroup[htingest]
       it { is_expected.to contain_user('htingest') }
       it { is_expected.not_to contain_user('htweb') }
+
+      it { is_expected.to contain_file('/etc/logrotate.d/babel') }
     end
   end
 end


### PR DESCRIPTION
This is https://github.com/mlibrary/nebula/pull/759, with the addition of explicitly `include nebula::profile::loki` in `babel_logs.pp`. Assuming you wanted alloy on these hosts, that will fix the puppet failure (puppet wouldn't write the alloy drop-in because `/etc/alloy` didn't exist, because the `alloy` package wasn't installed).