### PR TITLE
Switch mod_remoteip parameters to use upstream names

### DIFF
--- a/manifests/profile/apache.pp
+++ b/manifests/profile/apache.pp
@@ -59,8 +59,8 @@ class nebula::profile::apache (
   }
 
   class { 'apache::mod::remoteip':
-    header    => 'X-Client-IP',
-    proxy_ips => $haproxy_ips
+    header         => 'X-Client-IP',
+    internal_proxy => $haproxy_ips
   }
 
   apache::custom_config { 'badrobots':

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -119,8 +119,8 @@ class nebula::profile::hathitrust::apache (
   class { 'apache::mod::shib': }
 
   class { 'apache::mod::remoteip':
-    header    => 'X-Client-IP',
-    proxy_ips => $haproxy_ips
+    header         => 'X-Client-IP',
+    internal_proxy => $haproxy_ips
   }
 
   class { 'nebula::profile::ssl_keypair':


### PR DESCRIPTION
The puppetlabs/apache module has deprecated the proxy_ips parameter we have been using, in favor of more specific parameter names that align with the actual Apache/mod_remoteip directives. These are RemoteIPTrustedProxy and RemoteIPInternalProxy, respectively.

Each of these behaves the same, except that "trusted" proxies are designed to refer to external proxies. Client IPs reported from these within ARIN-designated private networks are rejected (not promoted from header to request attribute), since they would be invalid (non-internet addresses reported on internet requests). An "internal" proxy is allowed to report any address as the client IP.

Internally, the module was mapping to "internal" when proxy_ips was specified. Our HAProxy servers are appropriate for this designation, so this commit switches to the explicit parameter name, internal_proxy.