### PR TITLE
Use Cloudflare headers to set X-Client-IP

### DIFF
--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -72,11 +72,11 @@ describe 'nebula::haproxy::service' do
               stats uri /haproxy?stats
               http-response set-header "Strict-Transport-Security" "max-age=31536000"
               errorfile 400 /etc/haproxy/errors/hsts400.http
-              http-request set-header X-Client-IP %ci
-              http-request set-header X-Forwarded-Proto https
               default_backend svc1-dc1-https-back
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
               http-request deny if blocked-ip
+              http-request set-header X-Forwarded-Proto https
+              http-request set-header X-Client-IP %ci
             HAPROXY
           )
         end
@@ -290,11 +290,11 @@ describe 'nebula::haproxy::service' do
               frontend svc1-dc1-http-front
               bind 1.2.3.4:80
               stats uri /haproxy?stats
-              http-request set-header X-Client-IP %ci
-              http-request set-header X-Forwarded-Proto http
               default_backend svc1-dc1-http-back
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
               http-request deny if blocked-ip
+              http-request set-header X-Forwarded-Proto http
+              http-request set-header X-Client-IP %ci
             HAPROXY
           )
         end
@@ -336,6 +336,13 @@ describe 'nebula::haproxy::service' do
               content: %r{http-request deny unless cloudflare_proxied},
             )
           end
+
+          it 'forwards the CF-Connecting-IP as X-Client-IP' do
+            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+              target: service_config,
+              content: %r{http-request set-header X-Client-IP %\[req.hdr\(CF-Connecting-IP\)\]},
+            )
+          end
         end
 
         context 'without the cloudflare_protected setting' do
@@ -345,6 +352,13 @@ describe 'nebula::haproxy::service' do
             expect(subject).not_to contain_concat_fragment('svc1-dc1-http frontend').with(
               target: service_config,
               content: %r{http-request deny unless cloudflare_proxied},
+            )
+          end
+
+          it 'sets the originating client IP as X-Client-IP' do
+            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+              target: service_config,
+              content: %r{http-request set-header X-Client-IP %ci},
             )
           end
         end

--- a/templates/profile/haproxy/frontend.erb
+++ b/templates/profile/haproxy/frontend.erb
@@ -15,8 +15,6 @@ stats uri /haproxy?stats
 http-response set-header "Strict-Transport-Security" "max-age=31536000"
 errorfile 400 /etc/haproxy/errors/hsts400.http
 <% end -%>
-http-request set-header X-Client-IP %ci
-http-request set-header X-Forwarded-Proto <%= @protocol %>
 <% @nonempty_whitelists.each do |whitelist,_| -%>
 acl whitelist_<%= whitelist %> <%= whitelist %> -n -f /etc/haproxy/<%= @service %>_whitelist_<%= whitelist %>.txt
 <% end -%>
@@ -29,7 +27,11 @@ use_backend <%= @service_prefix %>-back-exempt if <%= exemption_condition %>
 default_backend <%= @service_prefix %>-back
 acl blocked-ip src -f <%= @badrobots %>
 http-request deny if blocked-ip
+http-request set-header X-Forwarded-Proto <%= @protocol %>
 <% if @cloudflare_protected -%>
 acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
 http-request deny unless cloudflare_proxied
+http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)]
+<% else -%>
+http-request set-header X-Client-IP %ci
 <% end -%>


### PR DESCRIPTION
When a service is directly exposed, we set the X-Client-IP to the connecting IP address. When proxying through Cloudflare, the originating IP address is set in the CF-Connecting-IP header, which we should use for the value instead.

This change also conducts a minor reordering of the template to keep the forwarded protocol next to the client IP header directive. This reordering is cosmetic only; the routing/access decisions are unchanged.