### PR TITLE
Support rolling deployment of Cloudflare WAF

### DIFF
--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -74,9 +74,12 @@ describe 'nebula::haproxy::service' do
               errorfile 400 /etc/haproxy/errors/hsts400.http
               default_backend svc1-dc1-https-back
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
+              acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
+              acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
               http-request deny if blocked-ip
               http-request set-header X-Forwarded-Proto https
               http-request set-header X-Client-IP %ci
+              http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
             HAPROXY
           )
         end
@@ -292,9 +295,12 @@ describe 'nebula::haproxy::service' do
               stats uri /haproxy?stats
               default_backend svc1-dc1-http-back
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
+              acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
+              acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
               http-request deny if blocked-ip
               http-request set-header X-Forwarded-Proto http
               http-request set-header X-Client-IP %ci
+              http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
             HAPROXY
           )
         end

--- a/templates/profile/haproxy/frontend.erb
+++ b/templates/profile/haproxy/frontend.erb
@@ -26,12 +26,12 @@ use_backend <%= @service_prefix %>-back-exempt if <%= exemption_condition %>
 <% end -%>
 default_backend <%= @service_prefix %>-back
 acl blocked-ip src -f <%= @badrobots %>
+acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
+acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
 http-request deny if blocked-ip
 http-request set-header X-Forwarded-Proto <%= @protocol %>
-<% if @cloudflare_protected -%>
-acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
-http-request deny unless cloudflare_proxied
-http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)]
-<% else -%>
 http-request set-header X-Client-IP %ci
+http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
+<% if @cloudflare_protected -%>
+http-request deny unless cloudflare_proxied
 <% end -%>


### PR DESCRIPTION
By separating the connecting IP handling from the access restriction, we allow a period where direct and proxied clients can access a service. After we are satisfied that all DNS propagation is complete, we can then restrict to proxied clients only.

The strategy here involves unconditionally checking the source IP and whether the CF-Connecting-IP header is supplied. We unconditionally set the X-Client-IP to the source. Then, we conditionally overwrite it with the supplied header value, if and only if its is supplied and the source is a Cloudflare proxy server. The access restriction is only enforced when the service's cloudflare_protected property is true.