### PR TITLE
update unattended_upgrades

### DIFF
--- a/manifests/profile/unattended_upgrades.pp
+++ b/manifests/profile/unattended_upgrades.pp
@@ -3,5 +3,14 @@
 # BSD License. See LICENSE.txt for details.
 
 class nebula::profile::unattended_upgrades {
-  include unattended_upgrades
+  class { 'unattended_upgrades':
+    extra_origins => [
+      'origin=Puppetlabs,codename=${distro_codename},label=Puppetlabs',
+    ],
+    only_on_ac_power => false,
+  }
+
+  file { '/etc/apt/apt.conf.d/51unattended-upgrades-extra':
+    content => 'Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";'
+  }
 }

--- a/spec/classes/profile/unattended_upgrades_spec.rb
+++ b/spec/classes/profile/unattended_upgrades_spec.rb
@@ -12,7 +12,8 @@ describe 'nebula::profile::unattended_upgrades' do
 
       it { is_expected.to compile }
       it { is_expected.to contain_class('apt') }
-      it { is_expected.to contain_class('unattended_upgrades') }
+      it { is_expected.to contain_class('unattended_upgrades').with(only_on_ac_power: false) }
+      it { is_expected.to contain_file('/etc/apt/apt.conf.d/51unattended-upgrades-extra') }
     end
   end
 end


### PR DESCRIPTION
- disable AC power check: useless, only generates log spam
- add Puppetlabs source

Does not add `profile::unattended_upgrades` to any roles that don't already have it. Anything roles that should obviously get it? This can also be an additional PR.

edit: Also suppress metered connection check. See `/var/log/unattended-upgrades/unattended-upgrades.log` if you're interested in the output we're eliminating here.