### PR TITLE
Handle Cloudflare worker request info

### DIFF
--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -76,10 +76,13 @@ describe 'nebula::haproxy::service' do
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
               acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
               acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
+              acl cloudflare_worker req.hdr(CF-Worker) -m found
               http-request deny if blocked-ip
               http-request set-header X-Forwarded-Proto https
               http-request set-header X-Client-IP %ci
               http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
+              http-request set-header X-Client-IP 240.36.0.103 if cloudflare_proxied cloudflare_worker
+              http-request replace-header User-Agent (.*) "Cloudflare Worker (%[req.hdr(CF-Worker)]) - \\1" if cloudflare_proxied cloudflare_worker
             HAPROXY
           )
         end
@@ -297,10 +300,13 @@ describe 'nebula::haproxy::service' do
               acl blocked-ip src -f /etc/haproxy/global_badrobots.txt
               acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
               acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
+              acl cloudflare_worker req.hdr(CF-Worker) -m found
               http-request deny if blocked-ip
               http-request set-header X-Forwarded-Proto http
               http-request set-header X-Client-IP %ci
               http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
+              http-request set-header X-Client-IP 240.36.0.103 if cloudflare_proxied cloudflare_worker
+              http-request replace-header User-Agent (.*) "Cloudflare Worker (%[req.hdr(CF-Worker)]) - \\1" if cloudflare_proxied cloudflare_worker
             HAPROXY
           )
         end

--- a/templates/profile/haproxy/frontend.erb
+++ b/templates/profile/haproxy/frontend.erb
@@ -28,10 +28,13 @@ default_backend <%= @service_prefix %>-back
 acl blocked-ip src -f <%= @badrobots %>
 acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt
 acl cloudflare_connecting_ip req.hdr(CF-Connecting-IP) -m found
+acl cloudflare_worker req.hdr(CF-Worker) -m found
 http-request deny if blocked-ip
 http-request set-header X-Forwarded-Proto <%= @protocol %>
 http-request set-header X-Client-IP %ci
 http-request set-header X-Client-IP %[req.hdr(CF-Connecting-IP)] if cloudflare_proxied cloudflare_connecting_ip
+http-request set-header X-Client-IP 240.36.0.103 if cloudflare_proxied cloudflare_worker
+http-request replace-header User-Agent (.*) "Cloudflare Worker (%[req.hdr(CF-Worker)]) - \1" if cloudflare_proxied cloudflare_worker
 <% if @cloudflare_protected -%>
 http-request deny unless cloudflare_proxied
 <% end -%>


### PR DESCRIPTION
Our strategy here is to identify proxied requests that also carry the CF-Worker header. These requests include a special source address in IPv6 form, so we approximate it as an IPv4 address in the reserved "Class E" block, similar to their psuedo-IPv4 approach. We also augment the User-Agent to identify the specific worker. A separate header may ultimately be better, but this approach is transparently logged, for some convenience.

The magic address Cloudflare uses is 2a06:98c0:3600::103, and we map it statically to 240.36.0.103 to have vague similarity.