### PR TITLE
standardrb, puppet-lint

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,7 @@
 --no-puppet_url_without_modules-check
 --no-strict_indent-check
 --no-trailing_comma-check
+--no-lookup_in_parameter-check
+--no-parameter_documentation-check
+--no-parameter_types-check
+--no-params_empty_string_assignment-check

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,2 +1,4 @@
 --relative
 --no-puppet_url_without_modules-check
+--no-strict_indent-check
+--no-trailing_comma-check

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,9 @@
+---
+ignore:
+  - Gemfile
+  - Puppetfile
+  - Rakefile
+  - modules/**/*
+  - spec/fixtures/**/*
+  - spec/spec_helper.rb
+  - vendor/**/*

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,6 +23,10 @@ Rakefile:
     # We sometimes refer to non-nebula puppet fileserver paths.
     # This check will make breaking changes on lint_fix task.
     - puppet_url_without_modules
+    # likes to add useless indents in heredocs and never pass its own tests
+    - strict_indent
+    # likes to crash when "fixing" files
+    - trailing_comma
 spec/default_facts.yml:
   extra_facts:
     ec2_tag_role: nebula::role::aws

--- a/.sync.yml
+++ b/.sync.yml
@@ -17,6 +17,7 @@ Gemfile:
         version: '>= 5.0'
       - gem: pdk
         version: '>= 3.3.0'
+      - gem: standard
 Rakefile:
   extra_disabled_lint_checks:
     # We sometimes refer to non-nebula puppet fileserver paths.

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development do
   gem "faker",                                   require: false
   gem "librarian-puppet", '>= 5.0',              require: false
   gem "pdk", '>= 3.3.0',                         require: false
+  gem "standard",                                require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,45 @@
-Puppet Nebula
-=============
+# Puppet Nebula
 
-# Development
+## Development
 
-1. git clone
-2. `docker compose build`
-3. `docker compose run spec_prep`
-4. `docker compose run specs`
+### with locally installed ruby
 
-or:
+```sh
+# ensure you're using the correct ruby (higher versions will _probably_ work)
+% cat .ruby-version
+3.2
+% ruby -v
+ruby 3.2.6
 
-```bash
+# bundle
+bundle
+
+# run all tests
+bundle exec rake parallel_spec
+
+# run any single test
+bundle exec rake spec_prep
+bundle exec rspec specs/path/to/a_spec.rb
+
+# lint
+bundle exec standardrb # lint .rb files
+bundle exec rake lint # lint .pp files
+
+# puppet module dependencies
+bundle exec rake outdated
+bundle exec rake librarian
+
+# update gems, pdk
+vi .sync.yml
+pdk update
+```
+
+### with `docker compose`
+```sh
+docker compose build
+docker compose run spec_prep
+docker compose run specs
+# or…
 docker compose run specs bundle exec rspec specs/path/to/a_spec.rb
 docker compose run specs bundle exec rake spec_standalone
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,5 @@ require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_puppet_url_without_modules')
+PuppetLint.configuration.send('disable_strict_indent')
+PuppetLint.configuration.send('disable_trailing_comma')

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     command:
     - /bin/bash
     - '-c'
-    - 'bundle exec rubocop ''spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'' && bundle exec rake syntax lint && bundle exec rake metadata_lint'
+    - 'bundle exec standardrb && bundle exec rake syntax lint && bundle exec rake metadata_lint'
 
   librarian:
     build: .

--- a/lib/facter/installed_backports.rb
+++ b/lib/facter/installed_backports.rb
@@ -3,7 +3,7 @@
 Facter.add(:installed_backports) do
   setcode do
     Facter::Core::Execution.execute(
-      "dpkg -l | awk '/^.i .*~bpo/ { print $2 }'",
-    ).strip.split("\n").map { |package| package.sub(%r{:amd64$}, '') }
+      "dpkg -l | awk '/^.i .*~bpo/ { print $2 }'"
+    ).strip.split("\n").map { |package| package.sub(%r{:amd64$}, "") }
   end
 end

--- a/lib/facter/network_cards.rb
+++ b/lib/facter/network_cards.rb
@@ -3,7 +3,7 @@
 Facter.add(:network_cards) do
   setcode do
     Facter::Core::Execution.execute(
-      "lspci | grep Ethernet | cut -f 3 -d ':'",
+      "lspci | grep Ethernet | cut -f 3 -d ':'"
     ).strip.split("\n")
   end
 end

--- a/lib/facter/prometheus_errors_total.rb
+++ b/lib/facter/prometheus_errors_total.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'yaml'
+require "yaml"
 
 # This will read the Prometheus node exporter's log and look for errors.
 # The result seen by puppet is nothing more than an integer which it can
@@ -11,7 +11,7 @@ require 'yaml'
 # are for.
 Facter.add(:prometheus_errors_total) do
   setcode do
-    log_path = '/var/log/prometheus-node-exporter.log'
+    log_path = "/var/log/prometheus-node-exporter.log"
     error_count = %r{(?<=error gathering metrics: )\d*(?= error)}
 
     if File.size? log_path

--- a/lib/facter/ruby_versions.rb
+++ b/lib/facter/ruby_versions.rb
@@ -2,9 +2,9 @@
 
 Facter.add(:ruby_versions) do
   setcode do
-    if File.exist?('/etc/profile.d/rbenv.sh')
+    if File.exist?("/etc/profile.d/rbenv.sh")
       Facter::Core::Execution.execute(
-        '/bin/bash -c "source /etc/profile.d/rbenv.sh; rbenv versions --bare --skip-aliases"',
+        '/bin/bash -c "source /etc/profile.d/rbenv.sh; rbenv versions --bare --skip-aliases"'
       ).strip.split("\n")
     else
       []

--- a/lib/facter/two_syncs_ago.rb
+++ b/lib/facter/two_syncs_ago.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'yaml'
+require "yaml"
 
 # This will put the contents of puppet's summary of its last run into a
 # facter fact. It does no analysis: it only reads the yaml and takes the
@@ -16,8 +16,8 @@ require 'yaml'
 # purpose is only for quick and simple error detection.
 Facter.add(:two_syncs_ago_summary) do
   setcode do
-    summary_file_path = '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml'
-    if Facter.value(:osfamily) == 'windows'
+    summary_file_path = "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
+    if Facter.value(:osfamily) == "windows"
       summary_file_path = 'C:\ProgramData\PuppetLabs\puppet\cache\state\last_run_summary.yaml'
     end
 

--- a/lib/facter/vm_guests.rb
+++ b/lib/facter/vm_guests.rb
@@ -2,9 +2,9 @@
 
 Facter.add(:vm_guests) do
   setcode do
-    if File.exist?('/usr/bin/virsh')
+    if File.exist?("/usr/bin/virsh")
       Facter::Core::Execution.execute(
-        '/usr/bin/virsh list --name --all',
+        "/usr/bin/virsh list --name --all"
       ).strip.split("\n")
     else
       []

--- a/lib/puppet/functions/fact_for.rb
+++ b/lib/puppet/functions/fact_for.rb
@@ -6,12 +6,12 @@
 
 Puppet::Functions.create_function(:fact_for) do
   dispatch :fact_for do
-    required_param 'String', :node_id
-    required_param 'String', :fact_name
+    required_param "String", :node_id
+    required_param "String", :fact_name
   end
 
   def fact_for(node_id, fact_name)
-    fact_keys = fact_name.split('.')
+    fact_keys = fact_name.split(".")
 
     value = run_query(node_id, fact_keys.shift)
 
@@ -25,11 +25,11 @@ Puppet::Functions.create_function(:fact_for) do
   private
 
   def run_query(node_id, fact_name)
-    call_function('puppetdb_query',
-                  ['from', 'facts',
-                   ['extract', ['value'],
-                    ['and',
-                     ['=', 'certname', node_id],
-                     ['=', 'name', fact_name]]]])[0]['value']
+    call_function("puppetdb_query",
+      ["from", "facts",
+        ["extract", ["value"],
+          ["and",
+            ["=", "certname", node_id],
+            ["=", "name", fact_name]]]])[0]["value"]
   end
 end

--- a/lib/puppet/functions/find_all_files_under.rb
+++ b/lib/puppet/functions/find_all_files_under.rb
@@ -6,8 +6,8 @@
 
 Puppet::Functions.create_function(:find_all_files_under) do
   dispatch :find_all_files_under do
-    required_param 'String', :path
-    return_type 'Array[String]'
+    required_param "String", :path
+    return_type "Array[String]"
   end
 
   def find_all_files_under(path)

--- a/lib/puppet/functions/inverted_hashlist.rb
+++ b/lib/puppet/functions/inverted_hashlist.rb
@@ -6,17 +6,17 @@
 
 Puppet::Functions.create_function(:inverted_hashlist) do
   dispatch :from_lookup do
-    required_param 'String', :lookup_string
-    return_type 'Hash[String, Array[String]]'
+    required_param "String", :lookup_string
+    return_type "Hash[String, Array[String]]"
   end
 
   dispatch :from_hash do
-    required_param 'Hash[String, Array[String]]', :input_hash
-    return_type 'Hash[String, Array[String]]'
+    required_param "Hash[String, Array[String]]", :input_hash
+    return_type "Hash[String, Array[String]]"
   end
 
   def from_lookup(lookup_string)
-    from_hash(call_function('lookup', lookup_string))
+    from_hash(call_function("lookup", lookup_string))
   end
 
   def from_hash(input_hash)

--- a/lib/puppet/functions/ip_from_cidr.rb
+++ b/lib/puppet/functions/ip_from_cidr.rb
@@ -3,13 +3,13 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'ipaddr'
+require "ipaddr"
 
 Puppet::Functions.create_function(:ip_from_cidr) do
   dispatch :run do
-    required_param 'String',  :cidr
-    required_param 'Integer', :index
-    return_type 'String'
+    required_param "String", :cidr
+    required_param "Integer", :index
+    return_type "String"
   end
 
   def run(cidr, index)

--- a/lib/puppet/functions/is_publicly_accessible.rb
+++ b/lib/puppet/functions/is_publicly_accessible.rb
@@ -4,11 +4,11 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-require 'ipaddr'
+require "ipaddr"
 
 Puppet::Functions.create_function(:is_publicly_accessible) do
   dispatch :run do
-    return_type 'Boolean'
+    return_type "Boolean"
   end
 
   def run
@@ -16,11 +16,11 @@ Puppet::Functions.create_function(:is_publicly_accessible) do
   end
 
   def ip_addresses
-    interfaces.values.map { |v| v['ip'] }.delete_if { |ip| ip.nil? }
+    interfaces.values.map { |v| v["ip"] }.delete_if { |ip| ip.nil? }
   end
 
   def interfaces
-    @interfaces ||= closure_scope['facts']['networking']['interfaces']
+    @interfaces ||= closure_scope["facts"]["networking"]["interfaces"]
     @interfaces ||= {}
   end
 
@@ -29,8 +29,8 @@ Puppet::Functions.create_function(:is_publicly_accessible) do
   end
 
   def private_blocks
-    @private_blocks ||= call_function('lookup',
-                                      'umich::networks::private_blocks')
-                        .map { |cidr| IPAddr.new(cidr) }
+    @private_blocks ||= call_function("lookup",
+      "umich::networks::private_blocks")
+      .map { |cidr| IPAddr.new(cidr) }
   end
 end

--- a/lib/puppet/functions/lookup_role.rb
+++ b/lib/puppet/functions/lookup_role.rb
@@ -6,13 +6,13 @@
 
 Puppet::Functions.create_function(:lookup_role) do
   dispatch :run do
-    return_type 'String'
+    return_type "String"
   end
 
   def run
     clear_internals
     case hiera_role
-    when 'nebula::role::aws::auto'
+    when "nebula::role::aws::auto"
       ec2_tag_role
     else
       hiera_role
@@ -25,11 +25,11 @@ Puppet::Functions.create_function(:lookup_role) do
   end
 
   def hiera_role
-    @hiera_role ||= call_function('lookup', 'role')
+    @hiera_role ||= call_function("lookup", "role")
   end
 
   def ec2_tag_role
-    @ec2_tag_role ||= closure_scope['facts']['ec2_tag_role']
+    @ec2_tag_role ||= closure_scope["facts"]["ec2_tag_role"]
     @ec2_tag_role ||= hiera_role
   end
 end

--- a/lib/puppet/functions/nebula/date_is_in_the_future.rb
+++ b/lib/puppet/functions/nebula/date_is_in_the_future.rb
@@ -5,18 +5,18 @@
 # BSD License. See LICENSE.txt for details.
 
 # Return true if the given date is in the future.
-Puppet::Functions.create_function(:'nebula::date_is_in_the_future') do
+Puppet::Functions.create_function(:"nebula::date_is_in_the_future") do
   # @param date Date to check
   # @return [Boolean] whether the given date is in the future
   #
   # @example Check a date in the past
   #   nebula::date_is_in_the_future('1970-01-01') => false
   dispatch :run do
-    required_param 'String', :date
-    return_type 'Boolean'
+    required_param "String", :date
+    return_type "Boolean"
   end
 
   def run(date)
-    Date.strptime(date, '%Y-%m-%d') > Date.today
+    Date.strptime(date, "%Y-%m-%d") > Date.today
   end
 end

--- a/lib/puppet/functions/nebula/get_keys_from_users.rb
+++ b/lib/puppet/functions/nebula/get_keys_from_users.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 
 # Get a list of key hashes from user data.
-Puppet::Functions.create_function(:'nebula::get_keys_from_users') do
+Puppet::Functions.create_function(:"nebula::get_keys_from_users") do
   # Input userdata from a hiera lookup.
   #
   # @param hiera_sudoers Hiera path to lookup
@@ -17,9 +17,9 @@ Puppet::Functions.create_function(:'nebula::get_keys_from_users') do
   # @example Extract from nebula::users::sudoers
   #   nebula::get_keys_from_users('nebula::users::sudoers')
   dispatch :get_from_hiera do
-    required_param 'String', :hiera_sudoers
-    optional_param 'String', :default_host
-    return_type 'Array[Hash[String, String]]'
+    required_param "String", :hiera_sudoers
+    optional_param "String", :default_host
+    return_type "Array[Hash[String, String]]"
   end
 
   # Input userdata directly from a hash.
@@ -41,31 +41,31 @@ Puppet::Functions.create_function(:'nebula::get_keys_from_users') do
   #           'key'     => 'AAAAAAAA',
   #           'comment' => 'username@localhost'}]
   dispatch :get_from_hash do
-    required_param 'Hash[String, Hash]', :sudoers
-    optional_param 'String', :default_host
-    return_type 'Array[Hash[String, String]]'
+    required_param "Hash[String, Hash]", :sudoers
+    optional_param "String", :default_host
+    return_type "Array[Hash[String, String]]"
   end
 
-  def get_from_hiera(hiera_sudoers, default_host = '')
-    get_from_hash(call_function('lookup', hiera_sudoers), default_host)
+  def get_from_hiera(hiera_sudoers, default_host = "")
+    get_from_hash(call_function("lookup", hiera_sudoers), default_host)
   end
 
-  def get_from_hash(sudoers, default_host = '')
+  def get_from_hash(sudoers, default_host = "")
     keys = []
 
     sudoers.each do |username, userdata|
-      host = userdata['host'] || default_host
+      host = userdata["host"] || default_host
 
-      comment = if host == ''
-                  username
-                else
-                  "#{username}@#{host}"
-                end
+      comment = if host == ""
+        username
+      else
+        "#{username}@#{host}"
+      end
 
       keys << {
-        'type'    => userdata['type'],
-        'data'    => userdata['key'].gsub(%r{\s+}, ''),
-        'comment' => comment,
+        "type" => userdata["type"],
+        "data" => userdata["key"].gsub(%r{\s+}, ""),
+        "comment" => comment
       }
     end
 

--- a/lib/puppet/functions/nodes_for_class.rb
+++ b/lib/puppet/functions/nodes_for_class.rb
@@ -6,21 +6,21 @@
 
 Puppet::Functions.create_function(:nodes_for_class) do
   dispatch :nodes_for_class do
-    required_param 'String', :class
-    return_type 'Array[String]'
+    required_param "String", :class
+    return_type "Array[String]"
   end
 
   def nodes_for_class(class_title)
-    call_function('puppetdb_query',
-                  ['from', 'resources',
-                   ['extract', ['certname'],
-                    ['=', 'title', capitalize_each_namespace(class_title)]]])
-      .map { |resource| resource['certname'] }.sort
+    call_function("puppetdb_query",
+      ["from", "resources",
+        ["extract", ["certname"],
+          ["=", "title", capitalize_each_namespace(class_title)]]])
+      .map { |resource| resource["certname"] }.sort
   end
 
   private
 
   def capitalize_each_namespace(resource_name)
-    resource_name.split('::').map { |ns| ns.capitalize }.join('::')
+    resource_name.split("::").map { |ns| ns.capitalize }.join("::")
   end
 end

--- a/lib/puppet/functions/public_ip.rb
+++ b/lib/puppet/functions/public_ip.rb
@@ -6,28 +6,28 @@
 
 Puppet::Functions.create_function(:public_ip) do
   dispatch :run do
-    return_type 'String'
+    return_type "String"
   end
 
   def run
     if aws_node?
-      ec2_metadata['public-ipv4']
+      ec2_metadata["public-ipv4"]
     else
-      facts['networking']['ip']
+      facts["networking"]["ip"]
     end
   end
 
   def aws_node?
-    ec2_metadata.key?('public-ipv4')
+    ec2_metadata.key?("public-ipv4")
   end
 
   def facts
-    closure_scope['facts']
+    closure_scope["facts"]
   end
 
   def ec2_metadata
-    if facts.key? 'ec2_metadata'
-      facts['ec2_metadata']
+    if facts.key? "ec2_metadata"
+      facts["ec2_metadata"]
     else
       {}
     end

--- a/manifests/apache/ssl_keypair.pp
+++ b/manifests/apache/ssl_keypair.pp
@@ -21,5 +21,4 @@ define nebula::apache::ssl_keypair () {
     notify => Class['Apache::Service'],
     source => "puppet:///ssl-certs/${title}.key"
   }
-
 }

--- a/manifests/apache/www_lib_vhost.pp
+++ b/manifests/apache/www_lib_vhost.pp
@@ -55,7 +55,7 @@ define nebula::apache::www_lib_vhost (
   if $setenv {
     $setenv_with_perl = $setenv + 'PERL_USE_UNSAFE_INC 1'
   } else {
-    $setenv_with_perl = [ 'PERL_USE_UNSAFE_INC 1' ]
+    $setenv_with_perl = ['PERL_USE_UNSAFE_INC 1']
   }
 
   if($usertrack) {

--- a/manifests/authzd_user.pp
+++ b/manifests/authzd_user.pp
@@ -6,11 +6,10 @@
 #
 # @example
 #   include nebula::profile::authzd_user()
-define nebula::authzd_user(
+define nebula::authzd_user (
   String $home,
   Hash $key,
   String $gid) {
-
   user { $title:
     gid        => $gid,
     home       => $home,
@@ -19,7 +18,7 @@ define nebula::authzd_user(
   }
 
   nebula::file::ssh_keys { "${home}/.ssh/authorized_keys":
-    keys   => [ $key],
+    keys   => [$key],
     secret => true,
     owner  => $title,
     group  => $gid

--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -35,15 +35,12 @@ define nebula::cert (
   require nebula::profile::letsencrypt
 
   if $webroot == [] {
-
     letsencrypt::certonly { $title:
       domains     => [$title] + $additional_domains,
       manage_cron => true,
       cron_output => 'log',
     }
-
   } else {
-
     if $webroot =~ Array {
       $webroot_paths = $webroot
     } else {
@@ -57,6 +54,5 @@ define nebula::cert (
       plugin        => 'webroot',
       webroot_paths => $webroot_paths,
     }
-
   }
 }

--- a/manifests/cifs_mount.pp
+++ b/manifests/cifs_mount.pp
@@ -21,7 +21,7 @@
 #     gid           => 'somegroup',
 #
 #  }
-define nebula::cifs_mount(
+define nebula::cifs_mount (
   String $remote_target,
   String $uid,
   String $gid,
@@ -35,7 +35,7 @@ define nebula::cifs_mount(
 
   realize File["/etc/default/${user}-credentials"]
 
-  ensure_packages(['cifs-utils'], {'ensure' => 'present'})
+  ensure_packages(['cifs-utils'], { 'ensure' => 'present' })
 
   file { $title:
     ensure => 'directory',
@@ -46,7 +46,6 @@ define nebula::cifs_mount(
     device  => $remote_target,
     options => "credentials=/etc/default/${user}-credentials,uid=${uid},gid=${gid},file_mode=${file_mode},dir_mode=${dir_mode},${extra_options}",
     fstype  => 'cifs',
-    require => Package[cifs-utils]
+    require => Package['cifs-utils']
   }
-
 }

--- a/manifests/exposed_port.pp
+++ b/manifests/exposed_port.pp
@@ -55,7 +55,7 @@
 #     block    => 'one building',
 #     protocol => 'udp',
 #   }
-define nebula::exposed_port(
+define nebula::exposed_port (
   $port,
   String $block,
   String $protocol = 'tcp',

--- a/manifests/file/ssh_keys.pp
+++ b/manifests/file/ssh_keys.pp
@@ -34,7 +34,7 @@
 #         comment => 'user4@host' },
 #     ]
 #   }
-define nebula::file::ssh_keys(
+define nebula::file::ssh_keys (
   Array   $keys = [],
   Boolean $secret = false,
   String  $owner = 'root',

--- a/manifests/haproxy/binding.pp
+++ b/manifests/haproxy/binding.pp
@@ -26,14 +26,13 @@
 #     hostname      => $::networking['hostname'],
 #     ipaddress     => $::networking['ip']
 #  }
-define nebula::haproxy::binding(
+define nebula::haproxy::binding (
   String $service,
   String $hostname,
   String $datacenter,
   String $ipaddress,
   Boolean $https_offload = true,
 ) {
-
   $last_octet = $ipaddress.split('\.')[-1]
   $cookie = "cookie s${last_octet}"
   $track = "track ${service}-${datacenter}-https-back/${hostname}"
@@ -73,5 +72,4 @@ define nebula::haproxy::binding(
   }
 
   realize(Nebula::Haproxy::Service[$service])
-
 }

--- a/manifests/haproxy/service.pp
+++ b/manifests/haproxy/service.pp
@@ -67,7 +67,7 @@
 #     },
 #     custom_503           => true,
 #  }
-define nebula::haproxy::service(
+define nebula::haproxy::service (
   String           $floating_ip,
   Optional[String] $cert_source = undef,
   Optional[String] $throttle_condition = undef,
@@ -82,7 +82,6 @@ define nebula::haproxy::service(
   String           $badrobots = '/etc/haproxy/global_badrobots.txt',
   Optional[Integer] $check_timeout_milliseconds = undef
 ) {
-
   include nebula::profile::haproxy::prereqs
 
   $service = $title
@@ -91,7 +90,7 @@ define nebula::haproxy::service(
 
   if $max_requests_per_sec > 0 {
     file { "/etc/haproxy/errors/${service}429.http":
-      ensure => 'present',
+      ensure => 'file',
       mode   => '0644',
       notify => Service['haproxy'],
       source => "https://${http_files}/errorfiles/${service}429.http"
@@ -100,7 +99,7 @@ define nebula::haproxy::service(
 
   if $custom_503 {
     file { "/etc/haproxy/errors/${service}503.http":
-      ensure => 'present',
+      ensure => 'file',
       mode   => '0644',
       notify => Service['haproxy'],
       source => "https://${http_files}/errorfiles/${service}503.http"
@@ -109,7 +108,7 @@ define nebula::haproxy::service(
 
   if $dynamic_weighting {
     cron { "dynamic weighting for ${service}":
-      command     => "/usr/bin/ruby /usr/local/bin/set_weights.rb ${::datacenter} ${service} > /dev/null 2>&1",
+      command     => "/usr/bin/ruby /usr/local/bin/set_weights.rb ${facts['datacenter']} ${service} > /dev/null 2>&1",
       user        => lookup('nebula::profile::haproxy::monitoring_user')['name'],
       minute      => '*/5',
       environment => ["HAPROXY_SMOOTHING_FACTOR=${dynamic_weight_smoothing}"]
@@ -118,7 +117,7 @@ define nebula::haproxy::service(
 
   $nonempty_whitelists.each |String $whitelist, Array[String] $exemptions| {
     file { "/etc/haproxy/${service}_whitelist_${whitelist}.txt":
-      ensure  => 'present',
+      ensure  => 'file',
       mode    => '0644',
       notify  => Service['haproxy'],
       content => $exemptions.map |$exemption| { "${exemption}\n" }.join('')
@@ -132,13 +131,13 @@ define nebula::haproxy::service(
 
   $protocols.each |$protocol,$protocol_options| {
     $service_cfg = "/etc/haproxy/services.d/${service}-${protocol}.cfg"
-    $service_loc = "${service}-${::datacenter}"
+    $service_loc = "${service}-${facts['datacenter']}"
     $service_prefix = "${service_loc}-${protocol}"
 
     concat { $service_cfg:
       ensure => 'present',
       mode   => '0644',
-      notify =>  Service['haproxy']
+      notify => Service['haproxy']
     }
 
     concat_fragment { "${service_prefix} backend":
@@ -146,7 +145,6 @@ define nebula::haproxy::service(
       content => "backend ${service_prefix}-back\n",
       order   => '01'
     }
-
 
     if($protocol == 'https') {
       concat_fragment { "${service_prefix} check":
@@ -203,13 +201,11 @@ define nebula::haproxy::service(
       Concat_fragment <| tag == "${service_prefix}_exempt_binding" |>
     }
 
-
     concat_fragment { "${service_prefix} frontend":
       target  => $service_cfg,
       content => template('nebula/profile/haproxy/frontend.erb'),
       order   => '07'
     }
-
   }
 
   if $cert_source {
@@ -227,5 +223,4 @@ define nebula::haproxy::service(
       require => Package['haproxy']
     }
   }
-
 }

--- a/manifests/local_storage_volume.pp
+++ b/manifests/local_storage_volume.pp
@@ -13,7 +13,6 @@ define nebula::local_storage_volume (
   String $volume_name,
   Integer $mib_capacity
 ) {
-
   file { "/mnt/local-pvs/mounts/${volume_name}":
     ensure => 'directory'
   }

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -16,7 +16,7 @@
 define nebula::log (
   Array[String] $files,
   String $service = $title,
-){
+) {
   include nebula::profile::loki
 
   file { "/etc/alloy/${service}.alloy":

--- a/manifests/nfs_mount.pp
+++ b/manifests/nfs_mount.pp
@@ -18,13 +18,13 @@
 #     options       => 'ro,auto,hard,intr,nfsvers=3',
 #     monitored     => true
 #  }
-define nebula::nfs_mount(
+define nebula::nfs_mount (
   String $remote_target,
   String $options = 'auto,hard,nfsvers=3',
   Boolean $monitored = true,
   Boolean $private_network = true
 ) {
-  ensure_packages(['nfs-common'], {'ensure' => 'present'})
+  ensure_packages(['nfs-common'], { 'ensure' => 'present' })
 
   file { $title:
     ensure => 'directory',
@@ -35,7 +35,7 @@ define nebula::nfs_mount(
     device  => $remote_target,
     options => $options,
     fstype  => 'nfs',
-    require => Package[nfs-common]
+    require => Package['nfs-common']
   }
 
   if($private_network) {

--- a/manifests/profile/afs.pp
+++ b/manifests/profile/afs.pp
@@ -30,7 +30,6 @@ class nebula::profile::afs (
   Integer $cache_size,
   String  $cell,
 ) {
-
   include nebula::profile::krb5
 
   if nebula::date_is_in_the_future($allow_auto_reboot_until) {
@@ -47,7 +46,7 @@ class nebula::profile::afs (
 
   exec { 'reinstall kernel to enable afs':
     command => '/usr/bin/apt-get -y install --reinstall linux-headers-amd64',
-    creates => "/lib/modules/${::kernelrelease}/updates/dkms/openafs.ko",
+    creates => "/lib/modules/${facts['kernelrelease']}/updates/dkms/openafs.ko",
     timeout => 600,
     require => Package['openafs-modules-dkms'],
   }

--- a/manifests/profile/aleph/perl.pp
+++ b/manifests/profile/aleph/perl.pp
@@ -9,7 +9,6 @@
 # @example
 #   include nebula::profile::aleph::perl
 class nebula::profile::aleph::perl () {
-
   ensure_packages([
     'libjson-perl',
     'libmarc-record-perl',

--- a/manifests/profile/alma_integrations.pp
+++ b/manifests/profile/alma_integrations.pp
@@ -6,7 +6,6 @@
 class nebula::profile::alma_integrations (
   Array[Hash] $ssh_keys = []
 ) {
-
   user { 'alma':
     home       => '/var/local/alma',
     managehome => true,

--- a/manifests/profile/apache.pp
+++ b/manifests/profile/apache.pp
@@ -14,7 +14,6 @@ class nebula::profile::apache (
   String $ssl_key_dir = '/etc/ssl/private',
   Optional[Hash] $log_formats = undef,
 ) {
-
   $haproxy_ips = nodes_for_class('nebula::profile::haproxy').map |String $nodename| {
     fact_for($nodename, 'networking')['ip']
   }

--- a/manifests/profile/apache/auth_openidc.pp
+++ b/manifests/profile/apache/auth_openidc.pp
@@ -26,7 +26,6 @@ class nebula::profile::apache::auth_openidc (
   String $oidc_client_secret,
   String $oidc_crypto,
 ) {
-
   apache::mod { 'auth_openidc':
     package       => 'libapache2-mod-auth-openidc',
   }
@@ -35,11 +34,11 @@ class nebula::profile::apache::auth_openidc (
 
   file { 'auth_openidc.conf':
     ensure  => file,
-    path    => "${::apache::mod_dir}/auth_openidc.conf",
+    path    => "${apache::mod_dir}/auth_openidc.conf",
     mode    => '0700',
     content => template('nebula/profile/apache/auth_openidc.conf.erb'),
-    require => Exec["mkdir ${::apache::mod_dir}"],
-    before  => File[$::apache::mod_dir],
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
     notify  => Class['apache::service'],
   }
 
@@ -49,9 +48,8 @@ class nebula::profile::apache::auth_openidc (
 
   file { '/var/cache/apache2/mod_auth_openidc/oidc-sessions':
     ensure => 'directory',
-    owner  => $::apache::user,
-    group  => $::apache::group,
+    owner  => $apache::user,
+    group  => $apache::group,
     mode   => '0700'
   }
-
 }

--- a/manifests/profile/apache/authz_umichlib.pp
+++ b/manifests/profile/apache/authz_umichlib.pp
@@ -36,7 +36,6 @@ class nebula::profile::apache::authz_umichlib (
   String $oracle_sid = 'orcl',
   Integer $oracle_port = 1521,
 ) {
-
   include apache::mod::dbd
 
   # Note: Packages for modules must be declared in the mod stanzas and
@@ -67,11 +66,11 @@ class nebula::profile::apache::authz_umichlib (
 
   file { 'authz_umichlib.conf':
     ensure  => file,
-    path    => "${::apache::mod_dir}/authz_umichlib.conf",
-    mode    => $::apache::file_mode,
+    path    => "${apache::mod_dir}/authz_umichlib.conf",
+    mode    => $apache::file_mode,
     content => template('nebula/profile/apache/authz_umichlib.conf.erb'),
-    require => Exec["mkdir ${::apache::mod_dir}"],
-    before  => File[$::apache::mod_dir],
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
     notify  => Class['apache::service'],
   }
 

--- a/manifests/profile/apache/monitoring.pp
+++ b/manifests/profile/apache/monitoring.pp
@@ -21,13 +21,12 @@ class nebula::profile::apache::monitoring (
   String $monitor_uri = '/monitor',
   String $monitor_dir = "${cgi_dir}/monitor",
 ) {
-
   $location = {
     provider => 'location',
     path     => $monitor_uri,
     require  => {
       enforce  => 'any',
-      requires => [ 'local' ] + $nebula::profile::apache::haproxy_ips.map |String $ip| { "ip ${ip}" }
+      requires => ['local'] + $nebula::profile::apache::haproxy_ips.map |String $ip| { "ip ${ip}" }
     }
   }
 
@@ -44,5 +43,4 @@ class nebula::profile::apache::monitoring (
     group  => 'root',
     mode   => '0755'
   }
-
 }

--- a/manifests/profile/apache/standalone_app_host.pp
+++ b/manifests/profile/apache/standalone_app_host.pp
@@ -12,7 +12,6 @@
 class nebula::profile::apache::standalone_app_host (
   $ssl_cn = $::networking['fqdn']
 ) {
-
   class { 'nebula::profile::ssl_keypair':
     common_name => $ssl_cn
   }
@@ -46,6 +45,4 @@ class nebula::profile::apache::standalone_app_host (
   include apache::mod::setenvif
 
   apache::listen { ['80','443']: }
-
 }
-

--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -15,8 +15,7 @@ class nebula::profile::apt (
   String $ubuntu_mirror = 'http://us.archive.ubuntu.com/ubuntu',
   Optional[Hash] $local_repo = undef,
 ) {
-
-  if($::os['family'] == 'Debian') {
+  if($facts['os']['family'] == 'Debian') {
     package { 'aptitude': }
 
     # Ensure that apt knows to never ever install recommended packages
@@ -55,16 +54,16 @@ class nebula::profile::apt (
     if $local_repo {
       apt::source { 'local':
         *            => $local_repo,
-        release      => $::os['distro']['codename'],
+        release      => $facts['os']['distro']['codename'],
         repos        => 'main',
-        architecture => $::os['architecture'],
+        architecture => $facts['os']['architecture'],
       }
     }
 
     if $facts['dmi'] and ($facts['dmi']['manufacturer'] == 'HP' or $facts['dmi']['manufacturer'] == 'HPE') {
       apt::source { 'hp':
         location => 'http://downloads.linux.hpe.com/SDR/repo/mcp/debian',
-        release  => "${::os['distro']['codename']}/current",
+        release  => "${facts['os']['distro']['codename']}/current",
         repos    => 'non-free',
         key      => {
           'name'   => 'hpe.asc',
@@ -86,29 +85,29 @@ class nebula::profile::apt (
     # remove this once vm creation no longer adds these files
     tidy { '/etc/apt/trusted.gpg.d/':
       recurse => true,
-      matches => [ 'puppet*.gpg' ],
+      matches => ['puppet*.gpg'],
     }
 
     # not used for os packages, and all added repos should use /etc/apt/keyrings
     file { '/etc/apt/trusted.gpg': ensure => absent }
   }
 
-  if($::os['name'] == 'Debian') {
+  if($facts['os']['name'] == 'Debian') {
     # TODO: port to DEB822
     # TODO: remove non-free where we're not using it
     # TODO: remove branches when we're off buster, bullseye
-    $repos = $::os['distro']['codename'] ? {
-      'bookworm' => "main contrib non-free non-free-firmware",
-      default    => "main contrib non-free",
+    $repos = $facts['os']['distro']['codename'] ? {
+      'bookworm' => 'main contrib non-free non-free-firmware',
+      default    => 'main contrib non-free',
     }
     apt::source { 'main':
       location => $mirror,
       repos    => $repos,
     }
 
-    $security_release = $::os['distro']['codename'] ? {
-      'buster'  => "${::os['distro']['codename']}/updates",
-      default   => "${::os['distro']['codename']}-security",
+    $security_release = $facts['os']['distro']['codename'] ? {
+      'buster'  => "${facts['os']['distro']['codename']}/updates",
+      default   => "${facts['os']['distro']['codename']}-security",
     }
 
     apt::source { 'security':
@@ -117,7 +116,7 @@ class nebula::profile::apt (
       repos    => $repos,
     }
 
-    unless empty($::installed_backports) {
+    unless empty($facts['installed_backports']) {
       class { 'apt::backports':
         location => $mirror,
       }
@@ -125,30 +124,30 @@ class nebula::profile::apt (
 
     apt::source { 'updates':
       location => $mirror,
-      release  => "${::os['distro']['codename']}-updates",
+      release  => "${facts['os']['distro']['codename']}-updates",
       repos    => $repos,
     }
 
     apt::source { 'adoptium':
       location => 'https://packages.adoptium.net/artifactory/deb/',
-      release  => $::os['distro']['codename'],
+      release  => $facts['os']['distro']['codename'],
       repos    => 'main',
       key      => {
         'name'   => 'adoptium.asc',
         'source' => 'puppet:///modules/nebula/apt/keyrings/adoptium.asc',
       }
     }
-  } elsif($::os['name'] == 'Ubuntu') {
+  } elsif($facts['os']['name'] == 'Ubuntu') {
     # port to DEB822 before upgrade to 24.04
     apt::source {
       default:
         location => $ubuntu_mirror,
         repos    => 'main restricted universe',
       ;
-      'main'     : release => $::os['distro']['codename'];
-      'updates'  : release => "${::os['distro']['codename']}-updates";
-      'backports': release => "${::os['distro']['codename']}-backports";
-      'security' : release => "${::os['distro']['codename']}-security";
+      'main'     : release => $facts['os']['distro']['codename'];
+      'updates'  : release => "${facts['os']['distro']['codename']}-updates";
+      'backports': release => "${facts['os']['distro']['codename']}-backports";
+      'security' : release => "${facts['os']['distro']['codename']}-security";
     }
 
     package { 'landscape-common': ensure => purged }

--- a/manifests/profile/aws/filesystem.pp
+++ b/manifests/profile/aws/filesystem.pp
@@ -12,8 +12,7 @@ class nebula::profile::aws::filesystem (
   String $disk = 'xvdb',
   String $device = '/dev/xvdb',
   String $mountpoint = '/l'
-){
-
+) {
   if $facts['disks'][$disk] {
     filesystem { $device:
       ensure  => present,
@@ -34,5 +33,4 @@ class nebula::profile::aws::filesystem (
       fstype => 'ext4'
     }
   }
-
 }

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -24,7 +24,7 @@ class nebula::profile::base (
     enable => true,
   }
 
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     package { 'dselect': }
     package { 'ifenslave': }
     package { 'vlan': }
@@ -56,7 +56,6 @@ class nebula::profile::base (
   }
 
   include nebula::profile::base::stop_mcollective
-
 
   if $facts['dmi'] and ($facts['dmi']['manufacturer'] == 'HP' or $facts['dmi']['manufacturer'] == 'HPE') {
     include nebula::profile::base::hp

--- a/manifests/profile/base/hp.pp
+++ b/manifests/profile/base/hp.pp
@@ -10,11 +10,11 @@
 #   include nebula::profile::base::hp
 class nebula::profile::base::hp {
   kmod::blacklist { 'hpwdt':
-    file =>  '/etc/modprobe.d/hpwdt-blacklist.conf',
+    file => '/etc/modprobe.d/hpwdt-blacklist.conf',
   }
 
   kmod::blacklist { 'acpi_power_meter':
-    file =>  '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
+    file => '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
   }
 
   package { 'ssacli': }
@@ -36,5 +36,4 @@ class nebula::profile::base::hp {
     minute  => '0',
     hour    => '6',
   }
-
 }

--- a/manifests/profile/base/motd.pp
+++ b/manifests/profile/base/motd.pp
@@ -8,12 +8,12 @@ class nebula::profile::base::motd (
   String  $contact_email,
   String  $sysadmin_dept,
 ) {
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     file { '/etc/motd':
       content => template('nebula/profile/base/motd.erb'),
     }
 
-    if($::os['name'] == 'Ubuntu') {
+    if($facts['os']['name'] == 'Ubuntu') {
       # delete a lot of useless motd content so it's not a half page long
       file { '/etc/update-motd.d/10-help-text': ensure => absent }
       file { '/etc/update-motd.d/50-motd-news': ensure => absent }

--- a/manifests/profile/containerd.pp
+++ b/manifests/profile/containerd.pp
@@ -13,8 +13,8 @@ class nebula::profile::containerd {
 
   apt::source { 'docker':
     location     => 'https://download.docker.com/linux/debian',
-    architecture => $::os['architecture'],
-    release      => $::os['distro']['codename'],
+    architecture => $facts['os']['architecture'],
+    release      => $facts['os']['distro']['codename'],
     repos        => 'stable',
     key          => {
       name   => 'docker.asc',

--- a/manifests/profile/deb_signing.pp
+++ b/manifests/profile/deb_signing.pp
@@ -19,7 +19,6 @@ class nebula::profile::deb_signing (
   String $sign_key,
   String $sign_script
 ) {
-
   ensure_packages(['gnupg', 'dpkg-dev', 'pinentry-curses', 'apt-utils'])
 
   file { '/var/local/deb-signing.key':
@@ -37,5 +36,4 @@ class nebula::profile::deb_signing (
     group  => 'dlps',
     mode   => '0750'
   }
-
 }

--- a/manifests/profile/dns/aws.pp
+++ b/manifests/profile/dns/aws.pp
@@ -10,7 +10,6 @@
 # @example
 #   include nebula::profile::dns::aws
 class nebula::profile::dns::aws {
-
   $searchpaths = lookup('nebula::resolv_conf::searchpath')
   $searchpath_str = join($searchpaths, ' ')
 

--- a/manifests/profile/dns/smartconnect.pp
+++ b/manifests/profile/dns/smartconnect.pp
@@ -57,7 +57,7 @@ class nebula::profile::dns::smartconnect (
     ensure  => 'directory',
     owner   => 'root',
     group   => 'bind',
-    require => Package[nebula::profile::dns::smartconnect::bind9]
+    require => Package['nebula::profile::dns::smartconnect::bind9']
   }
 
   file { '/etc/bind/named.conf':

--- a/manifests/profile/elastic.pp
+++ b/manifests/profile/elastic.pp
@@ -36,7 +36,7 @@ class nebula::profile::elastic (
 
   if $logstash_auth_cert != '' {
     file { '/etc/ssl/certs/logstash-forwarder.crt':
-      ensure  => 'present',
+      ensure  => 'file',
       mode    => '0644',
       source  => "puppet://${logstash_auth_cert}",
       require => File['/etc/ssl/certs'],

--- a/manifests/profile/elastic/filebeat.pp
+++ b/manifests/profile/elastic/filebeat.pp
@@ -16,7 +16,7 @@ class nebula::profile::elastic::filebeat {
   }
 
   file { '/etc/filebeat/filebeat.yml':
-    ensure  => 'present',
+    ensure  => 'file',
     mode    => '0644',
     content => template('nebula/profile/elastic/filebeat/filebeat.yml.erb'),
     require => Package['filebeat'],

--- a/manifests/profile/elastic/metricbeat.pp
+++ b/manifests/profile/elastic/metricbeat.pp
@@ -29,7 +29,7 @@ class nebula::profile::elastic::metricbeat (
   }
 
   file { '/etc/metricbeat/metricbeat.yml':
-    ensure  => 'present',
+    ensure  => 'file',
     mode    => '0644',
     content => template('nebula/profile/elastic/metricbeat.yml.erb'),
     require => Package['metricbeat'],

--- a/manifests/profile/fulcrum/base.pp
+++ b/manifests/profile/fulcrum/base.pp
@@ -2,7 +2,6 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-
 # Base profile for a Fulcrum host; sets up networking and app user.
 class nebula::profile::fulcrum::base (
   $uid = 717,

--- a/manifests/profile/fulcrum/nginx.pp
+++ b/manifests/profile/fulcrum/nginx.pp
@@ -19,7 +19,7 @@ class nebula::profile::fulcrum::nginx (
     'nginx-module-headersmore',
   ])
 
-  $letsencrypt_directory = $::letsencrypt_directory[$server_name]
+  $letsencrypt_directory = $facts['letsencrypt_directory'][$server_name]
 
   $networks = lookup('nebula::profile::networking::firewall::http_datacenters::networks')
   $allow = $networks.flatten.map |$network| { $network['block'] }
@@ -161,7 +161,7 @@ class nebula::profile::fulcrum::nginx (
   }
 
   file { '/etc/nginx/modules-enabled':
-    ensure =>  'directory',
+    ensure => 'directory',
   }
 
   file { '/etc/nginx/shib_clear_headers':
@@ -194,9 +194,9 @@ class nebula::profile::fulcrum::nginx (
   include nebula::profile::networking::firewall::http_datacenters
 
   firewall { '200 HTTPS: public':
-    proto  => 'tcp',
-    dport  => 443,
-    state  => 'NEW',
-    jump   => 'accept',
+    proto => 'tcp',
+    dport => 443,
+    state => 'NEW',
+    jump  => 'accept',
   }
 }

--- a/manifests/profile/fulcrum/shibboleth.pp
+++ b/manifests/profile/fulcrum/shibboleth.pp
@@ -74,5 +74,4 @@ class nebula::profile::fulcrum::shibboleth {
     enable  => true,
     require => Service['shibd'],
   }
-
 }

--- a/manifests/profile/grub.pp
+++ b/manifests/profile/grub.pp
@@ -9,8 +9,7 @@
 # @example
 #   include nebula::profile::grub
 class nebula::profile::grub {
-
-  if $::is_virtual and $::virtual == 'kvm' {
+  if $facts['is_virtual'] and $facts['virtual'] == 'kvm' {
     service { 'getty@hvc0':
       ensure     => 'running',
       enable     => true,

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -6,7 +6,7 @@
 #
 # @example
 #   include nebula::profile::haproxy
-class nebula::profile::haproxy(
+class nebula::profile::haproxy (
   Hash $services,
   Hash $monitoring_user,
   Boolean $master = false,
@@ -22,7 +22,7 @@ class nebula::profile::haproxy(
 
   file {
     default:
-      ensure  => 'present',
+      ensure  => 'file',
       mode    => '0644',
       require => Package['haproxy'],
       notify  => Service['haproxy'],
@@ -57,7 +57,7 @@ class nebula::profile::haproxy(
     }
   }
 
-  Nebula::Haproxy::Binding <<| datacenter == $::datacenter |>>
+  Nebula::Haproxy::Binding <<| datacenter == $facts['datacenter'] |>>
 
   nebula::authzd_user { $monitoring_user['name']:
     gid     => 'haproxy',
@@ -80,7 +80,7 @@ class nebula::profile::haproxy(
   }
   $http_files = lookup('nebula::http_files')
   file { '/usr/local/bin/set_weights.rb':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/set_weights.rb"
   }
@@ -98,7 +98,7 @@ class nebula::profile::haproxy(
   $email = lookup('nebula::root_email')
 
   concat { '/etc/keepalived/keepalived.conf':
-    ensure  =>  'present',
+    ensure  => 'present',
     require => Package['keepalived'],
     notify  => Service['keepalived'],
     mode    => '0644',
@@ -113,12 +113,12 @@ class nebula::profile::haproxy(
   @@concat_fragment { "keepalived node ip ${::networking['hostname']}":
     target  => '/etc/keepalived/keepalived.conf',
     content => "    ${::networking['ip']}\n",
-    tag     => "keepalived-haproxy-ip-${::datacenter}",
+    tag     => "keepalived-haproxy-ip-${facts['datacenter']}",
     order   => '02'
   }
 
   # don't collect our own IP address, just the other haproxy nodes here
-  Concat_fragment <<| tag == "keepalived-haproxy-ip-${::datacenter}" and title != "keepalived node ip ${::networking['hostname']}" |>>
+  Concat_fragment <<| tag == "keepalived-haproxy-ip-${facts['datacenter']}" and title != "keepalived node ip ${::networking['hostname']}" |>>
 
   concat_fragment { 'keepalived postamble':
     target  => '/etc/keepalived/keepalived.conf',
@@ -127,7 +127,7 @@ class nebula::profile::haproxy(
   }
 
   file { '/etc/sysctl.d/keepalived.conf':
-    ensure  => 'present',
+    ensure  => 'file',
     require => Package['keepalived'],
     notify  => [Service['keepalived'], Service['procps'], Service['haproxy']],
     mode    => '0644',
@@ -140,7 +140,7 @@ class nebula::profile::haproxy(
     source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
-    tag    => "${::datacenter}_haproxy"
+    tag    => "${facts['datacenter']}_haproxy"
   }
 
   # HAProxy should listen for kubernetes connections.
@@ -166,5 +166,4 @@ class nebula::profile::haproxy(
   }
 
   @nebula::taghosts::tag { 'haproxy': }
-
 }

--- a/manifests/profile/haproxy/prereqs.pp
+++ b/manifests/profile/haproxy/prereqs.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -15,8 +15,6 @@ class nebula::profile::hathitrust::apache (
   String $monitoring_user = 'haproxyctl',
   Optional[Hash] $monitoring_pubkey = undef
 ) {
-
-
   if($monitoring_pubkey) {
     nebula::authzd_user { $monitoring_user:
       gid  => 'nogroup',
@@ -98,7 +96,7 @@ class nebula::profile::hathitrust::apache (
     ],
   }
   class { 'apache::mod::expires':
-    expires_active  =>  'true',
+    expires_active  => 'true',
     expires_by_type => [
       { 'application/javascript' => 'access plus 6 hours' },
       { 'text/css' => 'access plus 6 hours' }
@@ -161,10 +159,9 @@ class nebula::profile::hathitrust::apache (
     domain         => $domain
   }
 
-
   ['redirection','babel','old_www','www','catalog','crms_training','matomo'].each |$vhost| {
     class { "${title}::${vhost}":
-      * =>  $default_vhost_params
+      * => $default_vhost_params
     }
   }
 
@@ -176,7 +173,7 @@ class nebula::profile::hathitrust::apache (
 
   $http_files = lookup('nebula::http_files')
   file { '/usr/local/bin/ckapacheconn':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/ckapacheconn"
   }
@@ -202,13 +199,13 @@ class nebula::profile::hathitrust::apache (
   concat::fragment { 'client cert':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/certs/${certname}.pem",
-    order  =>  1
+    order  => 1
   }
 
   concat::fragment { 'client key':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
-    order  =>  2
+    order  => 2
   }
 
   nebula::log { 'apache':

--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -23,9 +23,8 @@ class nebula::profile::hathitrust::apache::babel (
   String $ptsearch_solr,
   String $ptsearch_solr_basic_auth,
   Boolean $prod_crms_instance = true,
-  Array[String] $cache_paths = [ ],
+  Array[String] $cache_paths = [],
 ) {
-
   ### client cert
 
   $certname = $trusted['certname'];
@@ -46,12 +45,12 @@ class nebula::profile::hathitrust::apache::babel (
 
   $monitor_requires = {
     enforce  => 'any',
-    requires => [ 'local' ] + $haproxy_ips.map |String $ip| { "ip ${ip}" }
+    requires => ['local'] + $haproxy_ips.map |String $ip| { "ip ${ip}" }
   }
 
   $metrics_requires = {
     enforce => 'any',
-    requires => [ 'local' ] + $prometheus_ips.map |String $ip| { "ip ${ip}" }
+    requires => ['local'] + $prometheus_ips.map |String $ip| { "ip ${ip}" }
   }
 
   class { 'nebula::profile::monitor_pl':
@@ -129,7 +128,7 @@ class nebula::profile::hathitrust::apache::babel (
       'USE_CATPROCIO 1'
     ] + if($prod_crms_instance) {
       ['CRMS_INSTANCE production']
-    } else{ [] },
+    } else {[] },
 
     rewrites                    => [
       {
@@ -154,14 +153,12 @@ class nebula::profile::hathitrust::apache::babel (
       },
 
       {
-
         # serve ht widgets from /widgets/<widget name>/web/
         #
         # 2012-12-10 skorner
         rewrite_cond => ['%{DOCUMENT_ROOT}/widgets/$1/web/$2 -f'],
         rewrite_rule => ['^/widgets/([^/]+)/(.*)      /widgets/$1/web/$2      [last]'],
       },
-
 
       # FROM SSL
 
@@ -231,7 +228,7 @@ class nebula::profile::hathitrust::apache::babel (
 
       {
         # user administration ruby application
-        rewrite_rule =>  ["^(/otis.*)$ ${otis_endpoint}\$1 [P]"]
+        rewrite_rule => ["^(/otis.*)$ ${otis_endpoint}\$1 [P]"]
       },
 
       {
@@ -243,20 +240,19 @@ class nebula::profile::hathitrust::apache::babel (
         rewrite_cond => ['"%{QUERY_STRING}" "(.*(?:^|&))entityID=([^&]*)&?(.*)&?$"'],
         rewrite_rule => ["\"(^/dex/auth)\" \"https://%{HTTP_HOST}/Shibboleth.sso/Login?entityID=\${unescape:%2}&target=https\\%3A\\%2F\\%2F%{HTTP_HOST}\\%2Fdex\\%2Fauth\\%3F%1%3\" [B,NE,L,R]"],
       },
-
     ],
 
     directories                 => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        location => '~$',
         require  => 'all denied'
       },
       {
         provider       => 'directory',
         location       => $sdrroot,
         allow_override => ['None'],
-        require        =>  'all denied'
+        require        => 'all denied'
       },
       {
         provider              => 'location',
@@ -270,7 +266,7 @@ class nebula::profile::hathitrust::apache::babel (
       },
       {
         provider => 'directory',
-        path     =>  "${sdrroot}/firebird-common",
+        path     => "${sdrroot}/firebird-common",
         require  => $default_access,
       },
       {
@@ -339,27 +335,26 @@ class nebula::profile::hathitrust::apache::babel (
         path                  => '/otis',
         auth_type             => 'shibboleth',
         require               => 'shibboleth',
-        shib_request_settings => { 'requireSession' => '0'},
+        shib_request_settings => { 'requireSession' => '0' },
       },
       {
         provider              => 'location',
         path                  => '/dex/',
         auth_type             => 'shibboleth',
         require               => 'shibboleth',
-        shib_request_settings => { 'requireSession' => '0'},
+        shib_request_settings => { 'requireSession' => '0' },
         request_headers       => ['unset X-Remote-User'],
-        proxy_pass            => [ { url =>$dex_endpoint }],
+        proxy_pass            => [{ url => $dex_endpoint }],
       },
       {
         provider              => 'location',
         path                  => '/dex/callback/htrc-saml-proxy',
         auth_type             => 'shibboleth',
         require               => 'valid-user',
-        shib_request_settings => { 'requireSession' => '1'},
-        request_headers       => [ 'set X-Remote-User "expr=%{REMOTE_USER}' ],
-        proxy_pass            => [ { url =>"${dex_endpoint}callback/htrc-saml-proxy" }],
+        shib_request_settings => { 'requireSession' => '1' },
+        request_headers       => ['set X-Remote-User "expr=%{REMOTE_USER}'],
+        proxy_pass            => [{ url => "${dex_endpoint}callback/htrc-saml-proxy" }],
       }
-
     ],
 
     ssl_proxyengine             => true,
@@ -402,7 +397,5 @@ class nebula::profile::hathitrust::apache::babel (
     ],
 
     allow_encoded_slashes       => 'on',
-
   }
-
 }

--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -17,7 +17,6 @@ class nebula::profile::hathitrust::apache::catalog (
   String $domain,
   String $docroot = '/htapps/catalog/web',
 ) {
-
   $servername = "${prefix}catalog.${domain}"
 
   cron { 'purge catalog apache access logs':
@@ -49,7 +48,7 @@ class nebula::profile::hathitrust::apache::catalog (
     directories        => [
       {
         provider => 'filesmatch',
-        path     =>  '~$',
+        path     => '~$',
         require  => 'all denied'
       },
       {
@@ -61,12 +60,12 @@ class nebula::profile::hathitrust::apache::catalog (
       },
       {
         provider => 'directory',
-        path     =>  "${sdrroot}/firebird-common",
+        path     => "${sdrroot}/firebird-common",
         require  => $default_access,
       },
       {
         provider => 'directory',
-        path     =>  "${sdrroot}/common/web",
+        path     => "${sdrroot}/common/web",
         require  => $default_access,
       },
     ],
@@ -88,7 +87,6 @@ class nebula::profile::hathitrust::apache::catalog (
 
     rewrites           => [
       {
-
         # redirect top-level page to www.hathitrust.org, but not for mobile or orphanworks host names
         #
         # 2010-11-12 csnavely per jjyork
@@ -100,7 +98,6 @@ class nebula::profile::hathitrust::apache::catalog (
 
         rewrite_cond => "%{HTTP_HOST}    ^(${prefix}catalog)  [nocase]",
         rewrite_rule => "^(/$|/index.html$)  https://${prefix}www.${domain}/  [redirect=permanent,last]"
-
       }
     ]
   }

--- a/manifests/profile/hathitrust/apache/crms_training.pp
+++ b/manifests/profile/hathitrust/apache/crms_training.pp
@@ -16,7 +16,6 @@ class nebula::profile::hathitrust::apache::crms_training (
   String $prefix,
   String $domain,
 ) {
-
   ## VHOST DEFINITION
 
   $servername = "crms-training.${prefix}babel.${domain}"
@@ -94,14 +93,12 @@ class nebula::profile::hathitrust::apache::crms_training (
       },
 
       {
-
         # serve ht widgets from /widgets/<widget name>/web/
         #
         # 2012-12-10 skorner
         rewrite_cond => ['%{DOCUMENT_ROOT}/widgets/$1/web/$2 -f'],
         rewrite_rule => ['^/widgets/([^/]+)/(.*)      /widgets/$1/web/$2      [last]'],
       },
-
 
       # FROM SSL
 
@@ -151,28 +148,26 @@ class nebula::profile::hathitrust::apache::crms_training (
       {
         rewrite_rule => ["  ^(/$|/index.html$)      https://${servername}/cgi/crms  [redirect=permanent,last]"],
       },
-
-
     ],
 
     directories           => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        location => '~$',
         require  => 'all denied'
       },
       {
         provider       => 'directory',
         location       => $sdrroot,
         allow_override => ['None'],
-        require        =>  'all denied'
+        require        => 'all denied'
       },
       {
         provider              => 'location',
         path                  => '/',
         auth_type             => 'shibboleth',
         require               => 'shibboleth',
-        shib_request_settings => { 'requireSession' => '0'}
+        shib_request_settings => { 'requireSession' => '0' }
       },
       {
         # Grant access to necessary directories under the document root:
@@ -215,11 +210,8 @@ class nebula::profile::hathitrust::apache::crms_training (
         path     => '^/shibboleth-sp/main.css',
         require  => 'all granted'
       },
-
     ],
 
     allow_encoded_slashes => 'on',
-
   }
-
 }

--- a/manifests/profile/hathitrust/apache/logs.pp
+++ b/manifests/profile/hathitrust/apache/logs.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -10,7 +9,6 @@
 # @example
 #   include nebula::profile::hathitrust::apache::logs
 class nebula::profile::hathitrust::apache::logs {
-
   cron { 'purge apache error logs':
     command => '/usr/bin/find /var/log/apache2 -type f -name "error_log*" -mtime +14 -exec /bin/rm {} \; > /dev/null 2>&1 ',
     user    => 'root',
@@ -31,5 +29,4 @@ class nebula::profile::hathitrust::apache::logs {
     minute  => '0',
     hour    => '2',
   }
-
 }

--- a/manifests/profile/hathitrust/apache/matomo.pp
+++ b/manifests/profile/hathitrust/apache/matomo.pp
@@ -18,7 +18,6 @@ class nebula::profile::hathitrust::apache::matomo (
   String $matomo_endpoint,
   String $subdomain = 'matomo.www',
 ) {
-
   ### client cert
 
   $certname = $trusted['certname'];
@@ -62,19 +61,19 @@ class nebula::profile::hathitrust::apache::matomo (
     directories                 => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        location => '~$',
         require  => 'all denied'
       },
       {
         provider       => 'directory',
         location       => $sdrroot,
         allow_override => ['None'],
-        require        =>  'all denied'
+        require        => 'all denied'
       },
       {
         provider   => 'location',
         path       => '/',
-        proxy_pass => [ { url =>$matomo_endpoint }],
+        proxy_pass => [{ url => $matomo_endpoint }],
       },
     ],
 
@@ -91,7 +90,5 @@ class nebula::profile::hathitrust::apache::matomo (
       # Remove existing X-Forwarded-For headers; mod_proxy will automatically add the correct one.
       'unset X-Forwarded-For',
     ],
-
   }
-
 }

--- a/manifests/profile/hathitrust/apache/old_www.pp
+++ b/manifests/profile/hathitrust/apache/old_www.pp
@@ -17,7 +17,6 @@ class nebula::profile::hathitrust::apache::old_www (
   String $domain,
   String $docroot = '/htapps/old.www'
 ) {
-
   $servername = "old.${prefix}www.${domain}"
 
   apache::vhost { "${servername} ssl":
@@ -36,7 +35,7 @@ class nebula::profile::hathitrust::apache::old_www (
     directories        => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        location => '~$',
         require  => 'all denied'
       },
       {
@@ -56,6 +55,5 @@ class nebula::profile::hathitrust::apache::old_www (
     ],
 
     headers            => 'set "Strict-Transport-Security" "max-age=31536000"',
-
   }
 }

--- a/manifests/profile/hathitrust/apache/redirection.pp
+++ b/manifests/profile/hathitrust/apache/redirection.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -18,14 +17,9 @@ class nebula::profile::hathitrust::apache::redirection (
   String $domain,
   Array[String] $alias_domains = []
 ) {
-
-
   $babel_servername   = "${prefix}babel.${domain}"
   $catalog_servername = "${prefix}catalog.${domain}"
-  $www_servername     = "${prefix}www.${domain}"
-
-
-  ['babel', 'catalog', 'm', 'www', 'old.www'].each |String $vhost| {
+  $www_servername     = "${prefix}www.${domain}" ['babel', 'catalog', 'm', 'www', 'old.www'].each |String $vhost| {
     $servername = "${prefix}${vhost}.${domain}"
 
     apache::vhost { "${servername} non-ssl":
@@ -91,5 +85,4 @@ class nebula::profile::hathitrust::apache::redirection (
         }
       ],
   }
-
 }

--- a/manifests/profile/hathitrust/apache/test.pp
+++ b/manifests/profile/hathitrust/apache/test.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -10,7 +9,6 @@
 # @example
 #   include nebula::profile::hathitrust::apache::test
 class nebula::profile::hathitrust::apache::test {
-
   cron { 'purge apache access logs':
     command  => "/usr/bin/find /var/log/apache2 -regextype posix-egrep -type f -mtime +14 -regex '.*/(access|error)_log.*-.*' -exec /bin/rm {} ';' > /dev/null 2>&1",
     user     => 'root',
@@ -18,5 +16,4 @@ class nebula::profile::hathitrust::apache::test {
     hour     => '1',
     monthday => '*'
   }
-
 }

--- a/manifests/profile/hathitrust/apache/www.pp
+++ b/manifests/profile/hathitrust/apache/www.pp
@@ -17,7 +17,6 @@ class nebula::profile::hathitrust::apache::www (
   String $domain,
   String $docroot = '/htapps/www'
 ) {
-
   cron { 'purge non-babel apache access logs':
     command => '/usr/bin/find /var/log/apache2/www -type f -name "access_log*" -mtime +7 -exec /bin/rm {} \; > /dev/null 2>&1',
     user    => 'root',
@@ -50,7 +49,7 @@ class nebula::profile::hathitrust::apache::www (
     directories        => [
       {
         provider => 'filesmatch',
-        location =>  '~$',
+        location => '~$',
         require  => 'all denied'
       },
       {
@@ -62,12 +61,12 @@ class nebula::profile::hathitrust::apache::www (
       },
       {
         provider => 'directory',
-        path     =>  "${sdrroot}/firebird-common",
+        path     => "${sdrroot}/firebird-common",
         require  => $default_access,
       },
       {
         provider => 'directory',
-        path     =>  "${sdrroot}/common/web",
+        path     => "${sdrroot}/common/web",
         require  => $default_access,
       },
     ],
@@ -88,6 +87,5 @@ class nebula::profile::hathitrust::apache::www (
     ],
 
     headers            => 'set "Strict-Transport-Security" "max-age=31536000"',
-
   }
 }

--- a/manifests/profile/hathitrust/babel_logs.pp
+++ b/manifests/profile/hathitrust/babel_logs.pp
@@ -14,7 +14,6 @@ class nebula::profile::hathitrust::babel_logs (
   String $log_owner = 'nobody',
   String $log_group = 'nogroup',
 ) {
-
   file { $log_path:
     ensure => 'directory',
     owner  => $log_owner,

--- a/manifests/profile/hathitrust/cron/catalog.pp
+++ b/manifests/profile/hathitrust/cron/catalog.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -14,7 +13,6 @@ class nebula::profile::hathitrust::cron::catalog (
   String $user = 'libadm',
   String $catalog_home = '/htapps/catalog/web'
 ) {
-
   cron {
     default:
       user        => $user,
@@ -31,5 +29,4 @@ class nebula::profile::hathitrust::cron::catalog (
       minute  => [0,15,30,45],
       command => "/usr/bin/perl ${catalog_home}/derived_data/clean_sessions.pl";
   }
-
 }

--- a/manifests/profile/hathitrust/cron/mdp_misc.pp
+++ b/manifests/profile/hathitrust/cron/mdp_misc.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -23,7 +22,6 @@ class nebula::profile::hathitrust::cron::mdp_misc (
     "HOME=${home}"
   ]
 ) {
-
   cron {
     default:
       user        => $user,
@@ -45,8 +43,8 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       command => "${sdr_root}/pt/scripts/manage_exclusivity.pl";
 
     'harvest proxy downloads':
-      minute      => 01,
-      hour        => 00,
+      minute      => '01',
+      hour        => '00',
       environment => $sdr_environment + ["MAILTO=''"],
       command     => "${sdr_root}/pt/scripts/harvest_proxy_downloads.pl 2>&1 || /usr/bin/mail -s '${::networking['hostname']} harvest_proxy_downloads problems' ${mail_recipient}";
 
@@ -59,9 +57,7 @@ class nebula::profile::hathitrust::cron::mdp_misc (
       command => "${catalog_home}/derived_data/getall.sh ${catalog_home}/derived_data";
 
     'merge application logs':
-      minute  => 05,
+      minute  => '05',
       command => "${home}/scripts/merge_application_logs.pl";
-
   }
-
 }

--- a/manifests/profile/hathitrust/dependencies.pp
+++ b/manifests/profile/hathitrust/dependencies.pp
@@ -31,7 +31,6 @@ class nebula::profile::hathitrust::dependencies () {
     ensure => 'directory'
   }
 
-
   file { '/l/local':
     ensure => 'directory'
   }
@@ -42,7 +41,7 @@ class nebula::profile::hathitrust::dependencies () {
   }
 
   file { '/usr/share/GeoIP':
-    target =>  '/htapps/babel/geoip'
+    target => '/htapps/babel/geoip'
   }
 
   package {
@@ -51,7 +50,7 @@ class nebula::profile::hathitrust::dependencies () {
 
   $http_files = lookup('nebula::http_files')
   file { '/usr/local/bin/kdu_munge':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/kdu_munge"
   }
@@ -66,9 +65,8 @@ class nebula::profile::hathitrust::dependencies () {
   ensure_packages(['mariadb-client'])
 
   file { '/usr/local/bin/catprocio':
-    ensure  => 'present',
+    ensure  => 'file',
     content => file('nebula/imgsrv/catprocio'),
     mode    => '0755',
   }
-
 }

--- a/manifests/profile/hathitrust/hosts.pp
+++ b/manifests/profile/hathitrust/hosts.pp
@@ -8,7 +8,7 @@
 #
 # @example
 #   include nebula::profile::hathitrust::hosts
-class nebula::profile::hathitrust::hosts(
+class nebula::profile::hathitrust::hosts (
   String $mysql_sdr,
   String $mysql_htdev,
   String $apps_ht,
@@ -17,7 +17,6 @@ class nebula::profile::hathitrust::hosts(
   String $solr_vufind_primary,
   String $solr_vufind_failover
 ) {
-
   host { 'localhost':
     ip => '127.0.0.1'
   }
@@ -70,5 +69,4 @@ class nebula::profile::hathitrust::hosts(
     comment => 'solr (vufind failover)',
     ip      => $solr_vufind_failover
   }
-
 }

--- a/manifests/profile/hathitrust/imgsrv.pp
+++ b/manifests/profile/hathitrust/imgsrv.pp
@@ -27,7 +27,7 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   logrotate::rule { 'imgsrv':
-    path          => [ "${log_path}/imgsrv.out", "${log_path}/imgsrv.err" ],
+    path          => ["${log_path}/imgsrv.out", "${log_path}/imgsrv.err"],
     rotate        => 7,
     rotate_every  => 'day',
     missingok     => true,
@@ -37,14 +37,14 @@ class nebula::profile::hathitrust::imgsrv (
   }
 
   file { '/usr/local/bin/startup_imgsrv':
-    ensure  => 'present',
+    ensure  => 'file',
     content => template('nebula/profile/hathitrust/imgsrv/startup_imgsrv.erb'),
     notify  => Service['imgsrv'],
     mode    => '0755'
   }
 
   file { '/etc/systemd/system/imgsrv.service':
-    ensure  => 'present',
+    ensure  => 'file',
     content => template('nebula/profile/hathitrust/imgsrv/imgsrv.service.erb'),
     notify  => Service['imgsrv']
   }
@@ -52,7 +52,7 @@ class nebula::profile::hathitrust::imgsrv (
   service { 'imgsrv':
     ensure     => 'running',
     enable     => true,
-    hasrestart =>  true
+    hasrestart => true
   }
 
   package { 'libfcgi-bin': }
@@ -66,20 +66,19 @@ class nebula::profile::hathitrust::imgsrv (
 
   $http_files = lookup('nebula::http_files')
   file { '/usr/local/bin/check_imgsrv':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/check_imgsrv"
   }
 
   file { '/usr/local/bin/startup_app':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/startup_app"
   }
 
   file { '/etc/sudoers.d/imgsrv-catprocio':
-    ensure  => 'present',
+    ensure  => 'file',
     content => 'nobody ALL=(root) NOPASSWD: /usr/local/bin/catprocio'
   }
-
 }

--- a/manifests/profile/hathitrust/ingest_hosts.pp
+++ b/manifests/profile/hathitrust/ingest_hosts.pp
@@ -8,7 +8,7 @@
 #
 # @example
 #   include nebula::profile::hathitrust::ingest_hosts
-class nebula::profile::hathitrust::ingest_hosts(
+class nebula::profile::hathitrust::ingest_hosts (
   String $mysql_sdr,
   String $mysql_quod,
   Array[String] $solr_build,
@@ -19,7 +19,6 @@ class nebula::profile::hathitrust::ingest_hosts(
   String $solr_vufind_primary,
   String $solr_vufind_failover
 ) {
-
   host { $::networking['hostname']:
     host_aliases => [$::networking['fqdn']],
     ip           => $::networking['ip']
@@ -70,5 +69,4 @@ class nebula::profile::hathitrust::ingest_hosts(
     comment => 'solr (vufind failover)',
     ip      => $solr_vufind_failover
   }
-
 }

--- a/manifests/profile/hathitrust/mounts.pp
+++ b/manifests/profile/hathitrust/mounts.pp
@@ -37,7 +37,7 @@ class nebula::profile::hathitrust::mounts (
 
   $smartconnect_mounts.each |$mount| {
     nebula::nfs_mount { $mount:
-      remote_target   => "nas-${::datacenter}.sc:/ifs${mount}",
+      remote_target   => "nas-${facts['datacenter']}.sc:/ifs${mount}",
       tag             => 'smartconnect',
       private_network => true,
       monitored       => true
@@ -55,7 +55,7 @@ class nebula::profile::hathitrust::mounts (
   Integer[1, 24].each |$partition| {
     nebula::nfs_mount { "/sdr${partition}":
       options       => $sdr_options,
-      remote_target => "nas-${::datacenter}.sc:/ifs/sdr/${partition}",
+      remote_target => "nas-${facts['datacenter']}.sc:/ifs/sdr/${partition}",
       tag           => 'smartconnect',
       monitored     => true
     }

--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -153,5 +153,4 @@ class nebula::profile::hathitrust::perl () {
     'MARC::File::MiJ',
     'Prometheus::Tiny::Shared']:
   }
-
 }

--- a/manifests/profile/hathitrust/php.pp
+++ b/manifests/profile/hathitrust/php.pp
@@ -30,7 +30,7 @@ class nebula::profile::hathitrust::php () {
     ]:
   }
 
-  -> class { '::php':
+  -> class { 'php':
     ensure       => present,     # Don't touch stuff from above; should be equivalent
     manage_repos => false, # Set true to add dotdeb repos
     fpm          => false,          # We only use mod_php at present
@@ -74,5 +74,4 @@ class nebula::profile::hathitrust::php () {
       'mail function/sendmail_path' => '/usr/sbin/sendmail -t -i'
     },
   }
-
 }

--- a/manifests/profile/hathitrust/rsync.pp
+++ b/manifests/profile/hathitrust/rsync.pp
@@ -35,14 +35,13 @@ class nebula::profile::hathitrust::rsync (
   }
 
   file { '/etc/rsyncd.conf':
-    require => Package[rsync],
-    notify  => Service[rsync],
+    require => Package['rsync'],
+    notify  => Service['rsync'],
     content => template('nebula/profile/hathitrust/rsync/rsyncd.conf.erb')
   }
 
   $datasets.each |String $name, Hash $dataset| {
     $dataset['users'].each |Hash $user| {
-
       firewall { "200 rsync: dataset ${name} - ${user['comment']}":
         proto  => 'tcp',
         dport  => 873,
@@ -52,5 +51,4 @@ class nebula::profile::hathitrust::rsync (
       }
     }
   }
-
 }

--- a/manifests/profile/hathitrust/secure_rsync.pp
+++ b/manifests/profile/hathitrust/secure_rsync.pp
@@ -36,7 +36,7 @@ class nebula::profile::hathitrust::secure_rsync (
         Package['rsync'],
         Package['stunnel4'],
       ],
-      notify  => Service[secure-rsync];
+      notify  => Service['secure-rsync'];
     '/etc/systemd/system/secure-rsync.service':
       content  => template('nebula/profile/hathitrust/secure_rsync/secure-rsync.service.erb');
     "${rsync_home}/stunnel.conf":

--- a/manifests/profile/hathitrust/slip.pp
+++ b/manifests/profile/hathitrust/slip.pp
@@ -13,7 +13,7 @@ class nebula::profile::hathitrust::slip (
   nebula::usergroup { 'slip': }
 
   file { '/etc/sudoers.d/slip-catprocio':
-    ensure  => 'present',
+    ensure  => 'file',
     content => 'slip ALL=(root) NOPASSWD: /usr/local/bin/catprocio'
   }
 }

--- a/manifests/profile/hathitrust/solr6.pp
+++ b/manifests/profile/hathitrust/solr6.pp
@@ -9,11 +9,11 @@ class nebula::profile::hathitrust::solr6 (
   String $port,
   String $jdk_version = '8',
   String $solr_home = '/var/lib/solr',
-  String $java_home = "/usr/lib/jvm/temurin-${jdk_version}-jre-${::os['architecture']}",
+  String $java_home = "/usr/lib/jvm/temurin-${jdk_version}-jre-${facts['os']['architecture']}",
   String $heap = '16G',
   String $timezone = 'America/Detroit',
   String $solr_bin = '/opt/solr/bin/solr',
-){
+) {
   include nebula::profile::hathitrust::networking
   include nebula::profile::hathitrust::hosts
 
@@ -46,7 +46,7 @@ class nebula::profile::hathitrust::solr6 (
       monitored       => true,
       before          => Service['solr'],
     ;
-    '/htapps':            remote_target => "nas-${::datacenter}.sc:/ifs/htapps";
+    '/htapps':            remote_target => "nas-${facts['datacenter']}.sc:/ifs/htapps";
   }
 
   # solr config files

--- a/manifests/profile/hathitrust/solr6/catalog.pp
+++ b/manifests/profile/hathitrust/solr6/catalog.pp
@@ -12,7 +12,7 @@ class nebula::profile::hathitrust::solr6::catalog (
   String $release_flag_prefix = lookup('nebula::profile::hathitrust::solr6::release_flag_prefix', default_value => ''),
   String $mirror_site_ip = lookup('nebula::profile::hathitrust::solr6::mirror_site_ip'),
   String $mail_recipient = lookup('nebula::profile::hathitrust::solr6::mail_recipient'),
-){
+) {
   class { 'nebula::profile::hathitrust::solr6':
     port      => $port,
     solr_home => $solr_home,
@@ -24,7 +24,7 @@ class nebula::profile::hathitrust::solr6::catalog (
     private_network => true,
     monitored       => true,
     before          => Service['solr'],
-    remote_target   => "nas-${::datacenter}.sc:/ifs/htsolr/catalog";
+    remote_target   => "nas-${facts['datacenter']}.sc:/ifs/htsolr/catalog";
   }
 
   # link to core in solr home

--- a/manifests/profile/hathitrust/solr6/classic.pp
+++ b/manifests/profile/hathitrust/solr6/classic.pp
@@ -5,7 +5,7 @@
 # @example
 #   include nebula::profile::hathitrust::solr6::classic
 class nebula::profile::hathitrust::solr6::classic (
-){
+) {
   nebula::log { 'lss_solr':
     files => ['/var/lib/solr-current-lss/logs/solr.log'],
   }

--- a/manifests/profile/hathitrust/solr6/lss.pp
+++ b/manifests/profile/hathitrust/solr6/lss.pp
@@ -14,7 +14,7 @@ class nebula::profile::hathitrust::solr6::lss (
   String $release_flag_prefix = lookup('nebula::profile::hathitrust::solr6::release_flag_prefix', default_value => ''),
   String $mirror_site_ip = lookup('nebula::profile::hathitrust::solr6::mirror_site_ip'),
   String $mail_recipient = lookup('nebula::profile::hathitrust::solr6::mail_recipient'),
-){
+) {
   class { 'nebula::profile::hathitrust::solr6':
     port      => $port,
     solr_home => $solr_home,
@@ -27,7 +27,7 @@ class nebula::profile::hathitrust::solr6::lss (
       private_network => true,
       monitored       => true,
       before          => Service['solr'],
-      remote_target   => "nas-${::datacenter}.sc:/ifs/htsolr/lss/cores/${core}";
+      remote_target   => "nas-${facts['datacenter']}.sc:/ifs/htsolr/lss/cores/${core}";
     }
   }
   nebula::nfs_mount {
@@ -37,9 +37,9 @@ class nebula::profile::hathitrust::solr6::lss (
       monitored       => true,
       before          => Service['solr'],
     ;
-    '/htsolr/lss/flags':  remote_target => "nas-${::datacenter}.sc:/ifs/htsolr/lss/flags";
-    '/htsolr/lss/prep':   remote_target => "nas-${::datacenter}.sc:/ifs/htsolr/lss/prep";
-    '/htsolr/lss/shared': remote_target => "nas-${::datacenter}.sc:/ifs/htsolr/lss/shared";
+    '/htsolr/lss/flags':  remote_target => "nas-${facts['datacenter']}.sc:/ifs/htsolr/lss/flags";
+    '/htsolr/lss/prep':   remote_target => "nas-${facts['datacenter']}.sc:/ifs/htsolr/lss/prep";
+    '/htsolr/lss/shared': remote_target => "nas-${facts['datacenter']}.sc:/ifs/htsolr/lss/shared";
   }
 
   # core configs require jars to be available in solr home as well as /htsolr/serve

--- a/manifests/profile/http_fileserver.pp
+++ b/manifests/profile/http_fileserver.pp
@@ -13,7 +13,6 @@ class nebula::profile::http_fileserver (
   String $storage_path,
   String $docroot = '/srv/www',
 ) {
-
   package { 'nfs-common': }
 
   file { $docroot:
@@ -33,7 +32,7 @@ class nebula::profile::http_fileserver (
   }
 
   @nebula::taghosts::tag { 'apache': }
-  $letsencrypt_directory = $::letsencrypt_directory[$::networking['fqdn']]
+  $letsencrypt_directory = $facts['letsencrypt_directory'][$::networking['fqdn']]
   if $letsencrypt_directory {
     class { 'apache':
       docroot           => '/srv/www',
@@ -93,5 +92,4 @@ class nebula::profile::http_fileserver (
       target => '../conf-available/serve-cgi-bin.conf',
     ;
   }
-
 }

--- a/manifests/profile/https_to_port.pp
+++ b/manifests/profile/https_to_port.pp
@@ -23,7 +23,7 @@ class nebula::profile::https_to_port (
   # This fact is set by the letsencrypt module. If letsencrypt has
   # created a cert, then this will be set to the directory that cert
   # exists in. If the cert doesn't exist yet, this will be null.
-  $letsencrypt_directory = $::letsencrypt_directory[$server_name]
+  $letsencrypt_directory = $facts['letsencrypt_directory'][$server_name]
 
   if $letsencrypt_directory {
     # Only serve the HTTPS site if the cert aleady exists.

--- a/manifests/profile/known_host_public_keys.pp
+++ b/manifests/profile/known_host_public_keys.pp
@@ -13,7 +13,7 @@
 # only trusts the hosts; it does not actually grant access through a
 # firewall or anything.
 class nebula::profile::known_host_public_keys {
-  $::ssh.each |$name, $key_obj| {
+  $facts['ssh'].each |$name, $key_obj| {
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 

--- a/manifests/profile/krb5.pp
+++ b/manifests/profile/krb5.pp
@@ -13,7 +13,6 @@
 class nebula::profile::krb5 (
   String  $realm
 ) {
-
   include nebula::profile::networking::keytab
 
   package { 'krb5-user': }

--- a/manifests/profile/kubernetes/destination_port/etcd.pp
+++ b/manifests/profile/kubernetes/destination_port/etcd.pp
@@ -13,7 +13,7 @@ class nebula::profile::kubernetes::destination_port::etcd {
   }
 
   @@concat_fragment { "prometheus etcd service ${::networking['hostname']}":
-    tag     => "${::datacenter}_prometheus_etcd_service_list",
+    tag     => "${facts['datacenter']}_prometheus_etcd_service_list",
     target  => '/etc/prometheus/etcd.yml',
     content => template('nebula/profile/prometheus/exporter/etcd/target.yaml.erb')
   }

--- a/manifests/profile/kubernetes/dns_client.pp
+++ b/manifests/profile/kubernetes/dns_client.pp
@@ -19,7 +19,7 @@ class nebula::profile::kubernetes::dns_client {
     content => template('nebula/profile/kubernetes/dns/resolv.conf.erb'),
   }
 
-  $::ssh.each |$name, $key_obj| {
+  $facts['ssh'].each |$name, $key_obj| {
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 

--- a/manifests/profile/kubernetes/filesystems.pp
+++ b/manifests/profile/kubernetes/filesystems.pp
@@ -6,7 +6,7 @@ class nebula::profile::kubernetes::filesystems (
   Hash[String, Hash] $cifs_mounts = {},
   Hash[String, Hash] $local_storage_volumes = {},
 ) {
-  ensure_packages(['nfs-common', 'lvm2'], {'ensure' => 'present'})
+  ensure_packages(['nfs-common', 'lvm2'], { 'ensure' => 'present' })
 
   $cifs_mounts.each |$mount_title, $mount_parameters| {
     nebula::cifs_mount { "/mnt/legacy_cifs_${mount_title}":

--- a/manifests/profile/kubernetes/haproxy.pp
+++ b/manifests/profile/kubernetes/haproxy.pp
@@ -50,9 +50,9 @@ class nebula::profile::kubernetes::haproxy {
 
   firewall {
     default:
-      proto  => 'tcp',
-      state  => 'NEW',
-      jump   => 'accept',
+      proto => 'tcp',
+      state => 'NEW',
+      jump  => 'accept',
     ;
 
     '200 private api':

--- a/manifests/profile/kubernetes/keepalived.pp
+++ b/manifests/profile/kubernetes/keepalived.pp
@@ -59,7 +59,7 @@ class nebula::profile::kubernetes::keepalived (
   package { 'keepalived': }
   package { 'ipset': }
 
-  $::ssh.each |$name, $key_obj| {
+  $facts['ssh'].each |$name, $key_obj| {
     $type = $key_obj["type"]
     $key = $key_obj["key"]
 

--- a/manifests/profile/kubernetes/prometheus.pp
+++ b/manifests/profile/kubernetes/prometheus.pp
@@ -12,5 +12,5 @@ class nebula::profile::kubernetes::prometheus {
     require => File['/var/local/prometheus'],
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_node_service_list" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_node_service_list" |>>
 }

--- a/manifests/profile/letsencrypt.pp
+++ b/manifests/profile/letsencrypt.pp
@@ -19,9 +19,9 @@ class nebula::profile::letsencrypt (
   }
 
   firewall { '200 HTTP':
-    proto  => 'tcp',
-    dport  => 80,
-    state  => 'NEW',
-    jump   => 'accept',
+    proto => 'tcp',
+    dport => 80,
+    state => 'NEW',
+    jump  => 'accept',
   }
 }

--- a/manifests/profile/loki.pp
+++ b/manifests/profile/loki.pp
@@ -7,7 +7,7 @@
 #
 class nebula::profile::loki (
   String $endpoint_url = 'https://loki-gateway.loki/loki/api/v1/push',
-){
+) {
   $certname = $trusted['certname']
   $hostname = $trusted['hostname']
   $user = 'alloy'

--- a/manifests/profile/machine_cert.pp
+++ b/manifests/profile/machine_cert.pp
@@ -25,12 +25,12 @@ class nebula::profile::machine_cert (
   concat::fragment { 'client cert':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/certs/${certname}.pem",
-    order  =>  1
+    order  => 1
   }
 
   concat::fragment { 'client key':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
-    order  =>  2
+    order  => 2
   }
 }

--- a/manifests/profile/monitor_pl.pp
+++ b/manifests/profile/monitor_pl.pp
@@ -31,14 +31,13 @@ class nebula::profile::monitor_pl (
   Optional[Hash] $mysql = undef,
   Boolean $shibboleth = false,
 ) {
-
   $http_files = lookup('nebula::http_files')
 
   file { $directory:
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
-    mode   =>  '0755'
+    mode   => '0755'
   }
 
   file { "${directory}/monitor.pl":
@@ -51,7 +50,7 @@ class nebula::profile::monitor_pl (
 
   $monitor_file = "${directory}/monitor_config.yaml"
 
-  concat_file {  $monitor_file:
+  concat_file { $monitor_file:
     tag    => 'monitor_config',
     owner  => 'root',
     group  => 'root',
@@ -73,7 +72,5 @@ class nebula::profile::monitor_pl (
       content => { 'mysql' => $mysql }.to_yaml();
     'monitor shibboleth':
       content => { 'shibd' => $shibboleth }.to_yaml();
-
   }
-
 }

--- a/manifests/profile/mysql.pp
+++ b/manifests/profile/mysql.pp
@@ -8,7 +8,6 @@
 class nebula::profile::mysql (
   String $password
 ) {
-
   # Install and configure mysql server
   class { 'mysql::server':
     create_root_user        => true,
@@ -21,5 +20,4 @@ class nebula::profile::mysql (
   class { 'mysql::client':
     bindings_enable => false
   }
-
 }

--- a/manifests/profile/networking.pp
+++ b/manifests/profile/networking.pp
@@ -16,7 +16,6 @@
 class nebula::profile::networking (
   Boolean $bridge = false,
 ) {
-
   class { 'nebula::profile::networking::sysctl':
     bridge => $bridge,
   }

--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -47,7 +47,7 @@ class nebula::profile::networking::firewall (
           '-j DOCKER',
         ]
 
-        case $::os['name'] {
+        case $facts['os']['name'] {
           default: {
             $forward_ignore = []
           }
@@ -138,7 +138,6 @@ class nebula::profile::networking::firewall (
       'OUTPUT:filter:IPv6':
       ;
     }
-
   }
 
   $firewall_defaults = {
@@ -152,9 +151,9 @@ class nebula::profile::networking::firewall (
 
   # Default IPv4 items, sorted by title
   firewall { '001 accept related established rules':
-    proto  => 'all',
-    state  => ['RELATED', 'ESTABLISHED'],
-    jump   => 'accept',
+    proto => 'all',
+    state => ['RELATED', 'ESTABLISHED'],
+    jump  => 'accept',
   }
 
   firewall { '001 accept all to lo interface':
@@ -190,5 +189,4 @@ class nebula::profile::networking::firewall (
     before   => undef,
     protocol => 'ip6tables',
   }
-
 }

--- a/manifests/profile/networking/firewall/http.pp
+++ b/manifests/profile/networking/firewall/http.pp
@@ -14,7 +14,5 @@
 # @example
 #   include nebula::profile::networking::firewall::http
 class nebula::profile::networking::firewall::http () {
-  Firewall <<| tag == "${::datacenter}_haproxy" |>>
+  Firewall <<| tag == "${facts['datacenter']}_haproxy" |>>
 }
-
-

--- a/manifests/profile/networking/firewall/http_datacenters.pp
+++ b/manifests/profile/networking/firewall/http_datacenters.pp
@@ -11,7 +11,6 @@
 class nebula::profile::networking::firewall::http_datacenters (
   Array $networks = [],
 ) {
-
   $params = {
     proto  => 'tcp',
     dport  => [80, 443],

--- a/manifests/profile/networking/private.pp
+++ b/manifests/profile/networking/private.pp
@@ -17,8 +17,7 @@ class nebula::profile::networking::private (
   String $broadcast = '192.168.255.255',
   Optional[String] $interface = undef,
 ) {
-
-  if !$interface and $::os['family'] == 'Debian' and $facts['is_virtual']
+  if !$interface and $facts['os']['family'] == 'Debian' and $facts['is_virtual']
     and 'ens4' in $::networking['interfaces'] {
     $real_interface = 'ens4'
   } else {
@@ -40,9 +39,7 @@ class nebula::profile::networking::private (
 
     Exec["ifup ${real_interface}"] -> Service <| tag == 'private_network' |>
     Exec["ifup ${real_interface}"] -> Mount <| tag == 'private_network' |>
-
   } else {
     err('No network interface to configure')
   }
 }
-

--- a/manifests/profile/networking/sshd.pp
+++ b/manifests/profile/networking/sshd.pp
@@ -16,7 +16,6 @@ class nebula::profile::networking::sshd (
   String $addon_directives = '',
   Integer $port = 22,
 ) {
-
   # This will do nothing if the keytab doesn't exist
   include nebula::profile::networking::keytab
   $gssapi_auth = defined(File['/etc/krb5.keytab'])

--- a/manifests/profile/networking/sysctl.pp
+++ b/manifests/profile/networking/sysctl.pp
@@ -24,4 +24,3 @@ class nebula::profile::networking::sysctl (
     notify  => Service['procps'],
   }
 }
-

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -24,7 +24,7 @@ class nebula::profile::nodejs (
     apt::source { 'nodesource.com':
       comment       => 'Nodesource apt source for recent nodejs',
       location      => "https://deb.nodesource.com/node_${version}.x",
-      release       => $::os['distro']['codename'],
+      release       => $facts['os']['distro']['codename'],
       repos         => 'main',
       notify_update => true,
       key           => {

--- a/manifests/profile/ntp.pp
+++ b/manifests/profile/ntp.pp
@@ -13,7 +13,6 @@
 class nebula::profile::ntp (
   Array[String] $servers,
 ) {
-
   class { 'ntp':
     servers       => $servers,
     # debian default

--- a/manifests/profile/openjdk_java.pp
+++ b/manifests/profile/openjdk_java.pp
@@ -17,4 +17,3 @@ class nebula::profile::openjdk_java (
     require => Package[$default_jdk]
   }
 }
-

--- a/manifests/profile/php73.pp
+++ b/manifests/profile/php73.pp
@@ -7,16 +7,15 @@
 # Installs php73 from community repositories.
 class nebula::profile::php73 (
 ) {
-
   apt::source { 'php-community':
     location     => 'https://packages.sury.org/php/',
-    key          =>  {
+    key          => {
       name   => 'php-community-sury.org.gpg',
       source => 'https://packages.sury.org/php/apt.gpg'
     },
-    release      => $::os['distro']['codename'],
+    release      => $facts['os']['distro']['codename'],
     repos        => 'main',
-    architecture => $::os['architecture'],
+    architecture => $facts['os']['architecture'],
   }
 
   ensure_packages (

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -71,27 +71,27 @@ class nebula::profile::prometheus (
 
   $static_nodes.each |$static_node| {
     concat_fragment { "prometheus node service ${static_node['labels']['hostname']}":
-      tag     => "${::datacenter}_prometheus_node_service_list",
+      tag     => "${facts['datacenter']}_prometheus_node_service_list",
       target  => '/etc/prometheus/nodes.yml',
       content => template('nebula/profile/prometheus/exporter/node/static_target.yaml.erb'),
     }
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_node_service_list" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_node_service_list" |>>
 
   concat_file { '/etc/prometheus/haproxy.yml':
     notify  => Docker::Run['prometheus'],
     require => File['/etc/prometheus'],
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_haproxy_service_list" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_haproxy_service_list" |>>
 
   concat_file { '/etc/prometheus/mysql.yml':
     notify  => Docker::Run['prometheus'],
     require => File['/etc/prometheus'],
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_mysql_service_list" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_mysql_service_list" |>>
 
   concat_file { '/etc/prometheus/ipmi.yml':
     notify  => Docker::Run['prometheus'],
@@ -104,14 +104,14 @@ class nebula::profile::prometheus (
     content => "scrape_configs:\n"
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_ipmi_exporter" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_ipmi_exporter" |>>
 
   concat_file { '/etc/prometheus/etcd.yml':
     notify  => Docker::Run['prometheus'],
     require => File['/etc/prometheus'],
   }
 
-  Concat_fragment <<| tag == "${::datacenter}_prometheus_etcd_service_list" |>>
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_etcd_service_list" |>>
 
   file { '/etc/prometheus':
     ensure => 'directory',
@@ -173,10 +173,10 @@ class nebula::profile::prometheus (
       },
     }
     firewall { '200 HTTPS: Client Cert':
-      proto  => 'tcp',
-      dport  => [443],
-      state  => 'NEW',
-      jump   => 'accept',
+      proto => 'tcp',
+      dport => [443],
+      state => 'NEW',
+      jump  => 'accept',
     }
   }
 
@@ -193,20 +193,20 @@ class nebula::profile::prometheus (
   }
 
   if $all_public_addresses != [] {
-    @@concat_fragment { "02 pushgateway advanced public url ${::datacenter}":
+    @@concat_fragment { "02 pushgateway advanced public url ${facts['datacenter']}":
       target  => '/usr/local/bin/pushgateway_advanced',
       content => "PUSHGATEWAY='http://${all_public_addresses[0]}:9091'\n",
     }
 
     # Legacy resource name, delete when no longer in use.
-    @@concat_fragment { "02 pushgateway advanced url ${::datacenter}":
+    @@concat_fragment { "02 pushgateway advanced url ${facts['datacenter']}":
       target  => '/usr/local/bin/pushgateway_advanced',
       content => "PUSHGATEWAY='http://${all_public_addresses[0]}:9091'\n",
     }
   }
 
   if $all_private_addresses != [] {
-    @@concat_fragment { "02 pushgateway advanced private url ${::datacenter}":
+    @@concat_fragment { "02 pushgateway advanced private url ${facts['datacenter']}":
       target  => '/usr/local/bin/pushgateway_advanced',
       content => "PUSHGATEWAY='http://${all_private_addresses[0]}:9091'\n",
     }
@@ -222,12 +222,12 @@ class nebula::profile::prometheus (
       ;
 
       "010 prometheus public node exporter ${::networking['hostname']} ${address}":
-        tag   => "${::datacenter}_prometheus_public_node_exporter",
+        tag   => "${facts['datacenter']}_prometheus_public_node_exporter",
         dport => 9100,
       ;
 
       "010 prometheus public ipmi exporter ${::networking['hostname']} ${address}":
-        tag   => "${::datacenter}_prometheus_public_ipmi_exporter",
+        tag   => "${facts['datacenter']}_prometheus_public_ipmi_exporter",
         dport => 9290,
       ;
     }
@@ -243,19 +243,19 @@ class nebula::profile::prometheus (
       ;
 
       "010 prometheus private node exporter ${::networking['hostname']} ${address}":
-        tag   => "${::datacenter}_prometheus_private_node_exporter",
+        tag   => "${facts['datacenter']}_prometheus_private_node_exporter",
         dport => 9100,
       ;
 
       "010 prometheus private ipmi exporter ${::networking['hostname']} ${address}":
-        tag   => "${::datacenter}_prometheus_private_ipmi_exporter",
+        tag   => "${facts['datacenter']}_prometheus_private_ipmi_exporter",
         dport => 9290,
       ;
     }
   }
 
   @@firewall { "010 prometheus haproxy exporter ${::networking['hostname']}":
-    tag    => "${::datacenter}_prometheus_haproxy_exporter",
+    tag    => "${facts['datacenter']}_prometheus_haproxy_exporter",
     proto  => 'tcp',
     dport  => 9101,
     source => $::networking['ip'],
@@ -264,7 +264,7 @@ class nebula::profile::prometheus (
   }
 
   @@firewall { "010 prometheus mysql exporter ${::networking['hostname']}":
-    tag    => "${::datacenter}_prometheus_mysql_exporter",
+    tag    => "${facts['datacenter']}_prometheus_mysql_exporter",
     proto  => 'tcp',
     dport  => 9104,
     source => $::networking['ip'],
@@ -272,5 +272,5 @@ class nebula::profile::prometheus (
     jump   => 'accept',
   }
 
-  Firewall <<| tag == "${::datacenter}_pushgateway_node" |>>
+  Firewall <<| tag == "${facts['datacenter']}_pushgateway_node" |>>
 }

--- a/manifests/profile/prometheus/exporter/haproxy.pp
+++ b/manifests/profile/prometheus/exporter/haproxy.pp
@@ -5,7 +5,6 @@
 class nebula::profile::prometheus::exporter::haproxy (
   Boolean $master,
 ) {
-
   package { 'prometheus-haproxy-exporter': }
 
   service { 'prometheus-haproxy-exporter':
@@ -25,13 +24,11 @@ class nebula::profile::prometheus::exporter::haproxy (
     content => template('nebula/profile/prometheus/exporter/haproxy/defaults.sh.erb')
   }
 
-
   @@concat_fragment { "prometheus haproxy service ${::networking['hostname']}":
-    tag     => "${::datacenter}_prometheus_haproxy_service_list",
+    tag     => "${facts['datacenter']}_prometheus_haproxy_service_list",
     target  => '/etc/prometheus/haproxy.yml',
     content => template('nebula/profile/prometheus/exporter/haproxy/target.yaml.erb')
   }
 
-  Firewall <<| tag == "${::datacenter}_prometheus_haproxy_exporter" |>>
-
+  Firewall <<| tag == "${facts['datacenter']}_prometheus_haproxy_exporter" |>>
 }

--- a/manifests/profile/prometheus/exporter/ipmi.pp
+++ b/manifests/profile/prometheus/exporter/ipmi.pp
@@ -33,14 +33,14 @@ class nebula::profile::prometheus::exporter::ipmi (
       fail('Host cannot be scraped without a public or private IP address')
     } elsif $all_private_addresses != [] {
       $ipaddress = $all_private_addresses[0]
-      Firewall <<| tag == "${::datacenter}_prometheus_private_ipmi_exporter" |>>
+      Firewall <<| tag == "${facts['datacenter']}_prometheus_private_ipmi_exporter" |>>
     } else {
       $ipaddress = $all_public_addresses[0]
-      Firewall <<| tag == "${::datacenter}_prometheus_public_ipmi_exporter" |>>
+      Firewall <<| tag == "${facts['datacenter']}_prometheus_public_ipmi_exporter" |>>
     }
 
     @@concat_fragment { "prometheus ipmi scrape config ${::networking['hostname']}":
-      tag     => "${::datacenter}_prometheus_ipmi_exporter",
+      tag     => "${facts['datacenter']}_prometheus_ipmi_exporter",
       target  => '/etc/prometheus/ipmi.yml',
       order   => '02',
       content => template('nebula/profile/prometheus/exporter/ipmi/scrape_config.yaml.erb')

--- a/manifests/profile/prometheus/exporter/mysql.pp
+++ b/manifests/profile/prometheus/exporter/mysql.pp
@@ -2,9 +2,7 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-class nebula::profile::prometheus::exporter::mysql ()
-  {
-
+class nebula::profile::prometheus::exporter::mysql () {
   package { 'prometheus-mysqld-exporter': }
 
   service { 'prometheus-mysqld-exporter':
@@ -25,13 +23,12 @@ class nebula::profile::prometheus::exporter::mysql ()
   }
 
   @@concat_fragment { "prometheus mysql service ${::networking['hostname']}":
-    tag     => "${::datacenter}_prometheus_mysql_service_list",
+    tag     => "${facts['datacenter']}_prometheus_mysql_service_list",
     target  => '/etc/prometheus/mysql.yml',
     content => template('nebula/profile/prometheus/exporter/mysql/target.yaml.erb')
   }
 
-  Firewall <<| tag == "${::datacenter}_prometheus_mysql_exporter" |>>
+  Firewall <<| tag == "${facts['datacenter']}_prometheus_mysql_exporter" |>>
 
   $role = lookup_role()
-
 }

--- a/manifests/profile/prometheus/exporter/node.pp
+++ b/manifests/profile/prometheus/exporter/node.pp
@@ -51,7 +51,7 @@ class nebula::profile::prometheus::exporter::node (
     notify  => Service['prometheus-node-exporter', 'rsyslog'],
   }
 
-  $prometheus_errors_total = $::prometheus_errors_total
+  $prometheus_errors_total = $facts['prometheus_errors_total']
   file { '/var/lib/prometheus/node-exporter/node_exporter_errors.prom':
     content => template('nebula/profile/prometheus/exporter/node/node_exporter_errors.prom.erb'),
   }
@@ -105,7 +105,7 @@ class nebula::profile::prometheus::exporter::node (
   realize User['prometheus']
 
   $role = lookup_role()
-  $datacenter = $::datacenter
+  $datacenter = $facts['datacenter']
 
   if $::networking['domain'] == lookup('umich::default_domain', default_value => 'prometheus-node-exporter.default.invalid') {
     $hostname = $::networking['hostname']

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -7,9 +7,7 @@
 # @example
 #   include nebula::profile::python
 class nebula::profile::python {
-
   package {[
     'python3-dev'
-  ]:}
-
+  ]: }
 }

--- a/manifests/profile/quod/dependencies/packages.pp
+++ b/manifests/profile/quod/dependencies/packages.pp
@@ -24,6 +24,6 @@ class nebula::profile::quod::dependencies::packages () {
     ]
   )
   file { '/usr/share/GeoIP':
-    target =>  '/quod/misc/g/geoip'
+    target => '/quod/misc/g/geoip'
   }
 }

--- a/manifests/profile/quod/prod/haproxy.pp
+++ b/manifests/profile/quod/prod/haproxy.pp
@@ -10,7 +10,7 @@ class nebula::profile::quod::prod::haproxy {
   @@nebula::haproxy::binding { "${::networking['hostname']} quod":
     service       => 'quod',
     https_offload => true,
-    datacenter    => $::datacenter,
+    datacenter    => $facts['datacenter'],
     hostname      => $::networking['hostname'],
     ipaddress     => $::networking['ip'];
   }

--- a/manifests/profile/root_ssh_private_keys.pp
+++ b/manifests/profile/root_ssh_private_keys.pp
@@ -4,7 +4,6 @@
 
 # nebula::profile::root_ssh_private_keys
 class nebula::profile::root_ssh_private_keys {
-
   $users = lookup('nebula::profile::authorized_keys::ssh_keys').keys
 
   $users.each |$user| {
@@ -31,5 +30,4 @@ class nebula::profile::root_ssh_private_keys {
   file { '/var/local/ssh':
     ensure => 'directory',
   }
-
 }

--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -26,7 +26,6 @@ class nebula::profile::ruby (
   # These should be removed as soon as practical in coordination with devs.
   String $manage_blacklist = '^jruby-(1\.7|9\.0)\.',
 ) {
-
   ensure_packages([
     'autoconf',
     'build-essential',
@@ -41,7 +40,7 @@ class nebula::profile::ruby (
     'libgdbm-dev'
   ])
 
-  case $::os['release']['major'] {
+  case $facts['os']['release']['major'] {
     '8':     { package { 'libmysqlclient-dev': } }
     '9':     { package { 'default-libmysqlclient-dev': } }
     default: { package { 'libmariadb-dev': } }
@@ -71,7 +70,7 @@ class nebula::profile::ruby (
 
   $supported_versions.each |$version| {
     # Ruby < 2.4 is incompatible with debian stretch
-    unless $::os['release']['major'] == '9' and $version =~ /^2\.3\./ {
+    unless $facts['os']['release']['major'] == '9' and $version =~ /^2\.3\./ {
       unless $version =~ $manage_blacklist {
         unless $version == $global_version {
           rbenv::build { $version:
@@ -91,7 +90,7 @@ class nebula::profile::ruby (
     }
   }
 
-  $::ruby_versions.each |$version| {
+  $facts['ruby_versions'].each |$version| {
     unless $version in $supported_versions {
       unless $version == $global_version {
         exec { "rbenv uninstall ${version}":

--- a/manifests/profile/shibboleth.pp
+++ b/manifests/profile/shibboleth.pp
@@ -73,7 +73,6 @@ class nebula::profile::shibboleth (
       |ODBCINST
   }
 
-
   file { '/etc/shibboleth':
     ensure  => 'directory',
     mode    => 'u=rw,u+X,g=r,g+X,o=r,o+X',
@@ -131,9 +130,8 @@ class nebula::profile::shibboleth (
 
   $http_files = lookup('nebula::http_files')
   file { '/usr/local/bin/ckshibd':
-    ensure => 'present',
+    ensure => 'file',
     mode   => '0755',
     source => "https://${http_files}/ae-utils/bins/ckshibd"
   }
-
 }

--- a/manifests/profile/solr.pp
+++ b/manifests/profile/solr.pp
@@ -67,5 +67,4 @@ class nebula::profile::solr (
       File['/etc/systemd/system/solr.service']
     ]
   }
-
 }

--- a/manifests/profile/taghosts/tags.pp
+++ b/manifests/profile/taghosts/tags.pp
@@ -28,7 +28,7 @@ class nebula::profile::taghosts::tags (
     content => "\n",
   }
 
-  $datacenter_tag = $::datacenter ? {
+  $datacenter_tag = $facts['datacenter'] ? {
     /^aws.*/                      => 'aws',
     'hatcher'                     => 'hatcher',
     'miserver'                    => 'miserver',
@@ -41,13 +41,13 @@ class nebula::profile::taghosts::tags (
     order => '001',
   }
 
-  if $::kernel == 'Linux' {
+  if $facts['kernel'] == 'Linux' {
     nebula::taghosts::tag { 'linux':
       order => '002',
     }
   }
 
-  if $::is_virtual {
+  if $facts['is_virtual'] {
     nebula::taghosts::tag { 'virtual':
       order => '003',
     }
@@ -67,7 +67,7 @@ class nebula::profile::taghosts::tags (
     }
 
     default: {
-      unless $::is_virtual {
+      unless $facts['is_virtual'] {
         nebula::taghosts::tag { 'no-manufacturer':
           order => '003',
         }
@@ -75,8 +75,8 @@ class nebula::profile::taghosts::tags (
     }
   }
 
-  if $::os['family'] == 'Debian' {
-    $os_name = $::os['name'] ? {
+  if $facts['os']['family'] == 'Debian' {
+    $os_name = $facts['os']['name'] ? {
       'Ubuntu' => 'ubuntu',
       default  => 'debian',
     }
@@ -85,7 +85,7 @@ class nebula::profile::taghosts::tags (
       order => '004',
     }
 
-    nebula::taghosts::tag { $::os['distro']['codename']:
+    nebula::taghosts::tag { $facts['os']['distro']['codename']:
       order => '005',
     }
   }

--- a/manifests/profile/tesseract.pp
+++ b/manifests/profile/tesseract.pp
@@ -7,20 +7,18 @@
 # Installs Tesseract from Official repositories.
 class nebula::profile::tesseract (
 ) {
-
   apt::source { 'tesseract':
     location     => 'https://notesalexp.org/debian/bullseye/',
-    key          =>  {
+    key          => {
       name   => 'tesseract-notesalexp.org.asc',
       source => 'https://notesalexp.org/debian/alexp_key.asc'
     },
     release      => 'bullseye',
     repos        => 'main',
-    architecture => $::os['architecture'],
+    architecture => $facts['os']['architecture'],
   }
 
   package { 'tesseract-ocr':
     require => Apt::Source['tesseract'],
   }
-
 }

--- a/manifests/profile/tsm.pp
+++ b/manifests/profile/tsm.pp
@@ -45,7 +45,6 @@ class nebula::profile::tsm (
   Array[String] $exclude_dirs = ['/afs/','/net/','/nfs/','/usr/vice/cache/'],
   Array[String] $opt_settings = ['* No custom settings']
 ) {
-
   ensure_packages(['tivsm-ba',])
   $tsm_home = '/opt/tivoli/tsm/client/ba/bin'
 
@@ -80,5 +79,4 @@ class nebula::profile::tsm (
     ensure  => 'file',
     content => template('nebula/profile/tsm/dsm.sys.erb'),
   }
-
 }

--- a/manifests/profile/unattended_upgrades.pp
+++ b/manifests/profile/unattended_upgrades.pp
@@ -4,7 +4,7 @@
 
 class nebula::profile::unattended_upgrades {
   class { 'unattended_upgrades':
-    extra_origins => [
+    extra_origins    => [
       'origin=Puppetlabs,codename=${distro_codename},label=Puppetlabs',
     ],
     only_on_ac_power => false,

--- a/manifests/profile/unison/client.pp
+++ b/manifests/profile/unison/client.pp
@@ -11,7 +11,6 @@
 class nebula::profile::unison::client (
   String $home = '/root',
 ) {
-
   ensure_packages(['unison'])
 
   file { "${home}/.unison":
@@ -22,5 +21,4 @@ class nebula::profile::unison::client (
     content => template('nebula/profile/unison/client/unisonsync.erb'),
     mode    => '0755'
   }
-
 }

--- a/manifests/profile/vmhost/host.pp
+++ b/manifests/profile/vmhost/host.pp
@@ -31,7 +31,6 @@ class nebula::profile::vmhost::host (
   String  $internet_bridge = 'br0',
   String  $lan_bridge      = 'br1',
 ) {
-
   file { '/etc/default/libvirt-guests':
     content => template('nebula/profile/vmhost/defaults.sh.erb'),
   }
@@ -54,11 +53,11 @@ class nebula::profile::vmhost::host (
     }
 
     mount { $local_storage:
-      ensure  =>  'mounted',
-      device  =>  '/dev/mapper/internal-vmimages',
-      atboot  =>  true,
-      fstype  =>  'ext4',
-      options =>  'defaults',
+      ensure  => 'mounted',
+      device  => '/dev/mapper/internal-vmimages',
+      atboot  => true,
+      fstype  => 'ext4',
+      options => 'defaults',
       require => ["File[${local_storage}]"]
     }
 
@@ -91,7 +90,7 @@ class nebula::profile::vmhost::host (
     }
   }
 
-  if($::os['name'] == 'Ubuntu') {
+  if($facts['os']['name'] == 'Ubuntu') {
     package { 'command-not-found': ensure => purged }
     package { 'python3-commandnotfound': ensure => purged }
   }

--- a/manifests/profile/www_lib/apache/base.pp
+++ b/manifests/profile/www_lib/apache/base.pp
@@ -62,7 +62,7 @@ class nebula::profile::www_lib::apache::base {
   include apache::mod::xsendfile
 
   file { '/etc/apache2/mods-available/shib2.conf':
-    ensure  => 'present',
+    ensure  => 'file',
     content => template('nebula/profile/www_lib/shib2.conf.erb'),
     require => File['/etc/apache2/mods-available'],
   }
@@ -72,5 +72,4 @@ class nebula::profile::www_lib::apache::base {
     target  => '/etc/apache2/mods-available/shib2.conf',
     require => File['/etc/apache2/mods-available/shib2.conf'],
   }
-
 }

--- a/manifests/profile/www_lib/apache/fulcrum.pp
+++ b/manifests/profile/www_lib/apache/fulcrum.pp
@@ -27,32 +27,32 @@ class nebula::profile::www_lib::apache::fulcrum (
 
     'minnesota.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/minnesota',
-      serveraliases => [ 'minnesota.fulcrum.org', 'minnesota.fulcrumservices.org'],
+      serveraliases => ['minnesota.fulcrum.org', 'minnesota.fulcrumservices.org'],
     ;
 
     'michigan.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/michigan',
-      serveraliases => [ 'michigan.fulcrum.org', 'michigan.fulcrumservices.org'],
+      serveraliases => ['michigan.fulcrum.org', 'michigan.fulcrumservices.org'],
     ;
 
     'indiana.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/indiana',
-      serveraliases => [ 'indiana.fulcrum.org', 'indiana.fulcrumservices.org'],
+      serveraliases => ['indiana.fulcrum.org', 'indiana.fulcrumservices.org'],
     ;
 
     'pennstate.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/pennstate',
-      serveraliases => [ 'pennstate.fulcrum.org', 'pennstate.fulcrumservices.org'],
+      serveraliases => ['pennstate.fulcrum.org', 'pennstate.fulcrumservices.org'],
     ;
 
     'nyupress.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/nyupress',
-      serveraliases => [ 'nyupress.fulcrum.org', 'nyupress.fulcrumservices.org'],
+      serveraliases => ['nyupress.fulcrum.org', 'nyupress.fulcrumservices.org'],
     ;
 
     'dialogue.fulcrumscholar.org':
       target        => 'https://www.fulcrum.org/dialogue',
-      serveraliases => [ 'dialogue.fulcrum.org', 'dialogue.fulcrumservices.org'],
+      serveraliases => ['dialogue.fulcrum.org', 'dialogue.fulcrumservices.org'],
     ;
   }
 

--- a/manifests/profile/www_lib/apache/misc.pp
+++ b/manifests/profile/www_lib/apache/misc.pp
@@ -50,9 +50,7 @@ class nebula::profile::www_lib::apache::misc (
   # depends on ssl_keypairs above (or delcared in includes like apache::fulcrum)
   include nebula::profile::www_lib::vhosts::redirects
 
-  $vhost_prefix = 'nebula::profile::www_lib::vhosts'
-
-  ['default','www_lib','apps_lib','staff_lib','datamart','deepblue', 'openmich', 'mgetit', 'press', 'search'].each |$vhost| {
+  $vhost_prefix = 'nebula::profile::www_lib::vhosts' ['default','www_lib','apps_lib','staff_lib','datamart','deepblue', 'openmich', 'mgetit', 'press', 'search'].each |$vhost| {
     class { "nebula::profile::www_lib::vhosts::${vhost}":
       prefix => $prefix,
       domain => $domain,
@@ -63,4 +61,3 @@ class nebula::profile::www_lib::apache::misc (
   include nebula::profile::www_lib::vhosts::publishing
   include nebula::profile::www_lib::vhosts::med
 }
-

--- a/manifests/profile/www_lib/dependencies.pp
+++ b/manifests/profile/www_lib/dependencies.pp
@@ -20,6 +20,4 @@ class nebula::profile::www_lib::dependencies {
       "openjdk-${jdk_version}-jre",
     ]
   )
-
-
 }

--- a/manifests/profile/www_lib/mounts.pp
+++ b/manifests/profile/www_lib/mounts.pp
@@ -34,4 +34,3 @@ class nebula::profile::www_lib::mounts (
     private_network => true
   }
 }
-

--- a/manifests/profile/www_lib/perl.pp
+++ b/manifests/profile/www_lib/perl.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -145,5 +144,4 @@ class nebula::profile::www_lib::perl {
     ensure  => 'file',
     content => template('nebula/profile/www_lib/etc/profile.d/perl-include.sh.erb'),
   }
-
 }

--- a/manifests/profile/www_lib/php.pp
+++ b/manifests/profile/www_lib/php.pp
@@ -11,21 +11,20 @@
 class nebula::profile::www_lib::php (
   String $default_php_version = '8.1'
 ) {
-
   # Set the php repo
   apt::source { 'php-community':
     location     => 'https://packages.sury.org/php/',
-    key          =>  {
+    key          => {
       name   => 'php-community-sury.org.gpg',
       source => 'https://packages.sury.org/php/apt.gpg'
     },
-    release      => $::os['distro']['codename'],
+    release      => $facts['os']['distro']['codename'],
     repos        => 'main',
-    architecture => $::os['architecture'],
+    architecture => $facts['os']['architecture'],
   }
 
   # Set default php
-  class { '::php::globals':
+  class { 'php::globals':
     php_version => $default_php_version,
     config_root => "/etc/php/${default_php_version}",
   }
@@ -106,7 +105,7 @@ class nebula::profile::www_lib::php (
   }
 
   # Configure default PHP
-  class { '::php':
+  class { 'php':
     ensure       => present, # Don't touch stuff from above; should be equivalent
     manage_repos => false, # Set true to add dotdeb repos
     fpm          => true,

--- a/manifests/profile/www_lib/register_for_load_balancing.pp
+++ b/manifests/profile/www_lib/register_for_load_balancing.pp
@@ -8,7 +8,7 @@ class nebula::profile::www_lib::register_for_load_balancing (
   $services.each |$service| {
     @@nebula::haproxy::binding { "${::networking['hostname']} ${service}":
       service       => $service,
-      datacenter    => $::datacenter,
+      datacenter    => $facts['datacenter'],
       hostname      => $::networking['hostname'],
       ipaddress     => $::networking['ip'],
       https_offload => false,

--- a/manifests/profile/www_lib/vhosts/apps_lib.pp
+++ b/manifests/profile/www_lib/vhosts/apps_lib.pp
@@ -15,7 +15,6 @@ class nebula::profile::www_lib::vhosts::apps_lib (
   String $www_lib_root = '/www/www.lib',
   String $docroot = "${www_lib_root}/web"
 ) {
-
   $servername = "${prefix}apps.${domain}"
 
   ### client cert
@@ -32,13 +31,13 @@ class nebula::profile::www_lib::vhosts::apps_lib (
   concat::fragment { 'client cert':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/certs/${certname}.pem",
-    order  =>  1
+    order  => 1
   }
 
   concat::fragment { 'client key':
     target => $client_cert,
     source => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
-    order  =>  2
+    order  => 2
   }
 
   nebula::apache::www_lib_vhost { 'apps.lib-http':
@@ -144,7 +143,7 @@ class nebula::profile::www_lib::vhosts::apps_lib (
         #
         # jhovater - 2008-12-04 varnum said to keep
         # 2008-08-28 csnavely per varnum
-        rewrite_rule =>  '^/wsfh		http://www.wsfh.org/	[redirect,last]'
+        rewrite_rule => '^/wsfh		http://www.wsfh.org/	[redirect,last]'
       },
       {
         # rewrites for aol-like, tinyurl-like "go" function
@@ -195,6 +194,5 @@ class nebula::profile::www_lib::vhosts::apps_lib (
         path        => "${www_lib_root}/cgi/",
       },
     ],
-
   }
 }

--- a/manifests/profile/www_lib/vhosts/datamart.pp
+++ b/manifests/profile/www_lib/vhosts/datamart.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -81,6 +80,5 @@ class nebula::profile::www_lib::vhosts::datamart (
         rewrite_rule => '^(.*)$ /dispatch.cgi/$1 [qsappend,last]'
       }
     ]
-
   }
 }

--- a/manifests/profile/www_lib/vhosts/deepblue.pp
+++ b/manifests/profile/www_lib/vhosts/deepblue.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.

--- a/manifests/profile/www_lib/vhosts/default.pp
+++ b/manifests/profile/www_lib/vhosts/default.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -15,7 +14,6 @@ class nebula::profile::www_lib::vhosts::default (
   String $domain,
   String $ssl_cn = 'www.lib.umich.edu'
 ) {
-
   nebula::apache::www_lib_vhost { '000-default':
     ssl        => false,
     ssl_cn     => $ssl_cn,
@@ -34,8 +32,8 @@ class nebula::profile::www_lib::vhosts::default (
     ssl         => true,
     ssl_cn      => $ssl_cn,
     servername  => $::networking['fqdn'],
-    directories => [ $nebula::profile::apache::monitoring::location ],
-    aliases     => [ $nebula::profile::apache::monitoring::scriptalias ],
+    directories => [$nebula::profile::apache::monitoring::location],
+    aliases     => [$nebula::profile::apache::monitoring::scriptalias],
     docroot     => false,
     rewrites    => [
       {

--- a/manifests/profile/www_lib/vhosts/openmich.pp
+++ b/manifests/profile/www_lib/vhosts/openmich.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.

--- a/manifests/profile/www_lib/vhosts/press.pp
+++ b/manifests/profile/www_lib/vhosts/press.pp
@@ -32,7 +32,7 @@ class nebula::profile::www_lib::vhosts::press (
   }
 
   logrotate::rule { 'press':
-    path          => [ "${mojo_log_path}/press.out", "${mojo_log_path}/press.err" ],
+    path          => ["${mojo_log_path}/press.out", "${mojo_log_path}/press.err"],
     rotate        => 7,
     rotate_every  => 'day',
     missingok     => true,
@@ -41,16 +41,15 @@ class nebula::profile::www_lib::vhosts::press (
     compress      => true,
   }
 
-
   file { '/usr/local/bin/startup_press':
-    ensure  => 'present',
+    ensure  => 'file',
     content => template('nebula/profile/www_lib/vhosts/press/startup_press.erb'),
     notify  => Service['press'],
     mode    => '0755',
   }
 
   file { '/etc/systemd/system/press.service':
-    ensure  => 'present',
+    ensure  => 'file',
     content => template('nebula/profile/www_lib/vhosts/press/press.service.erb'),
     notify  => Service['press'],
   }

--- a/manifests/profile/www_lib/vhosts/redirects.pp
+++ b/manifests/profile/www_lib/vhosts/redirects.pp
@@ -2,9 +2,8 @@
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
-class nebula::profile::www_lib::vhosts::redirects(
+class nebula::profile::www_lib::vhosts::redirects (
 ) {
-
   nebula::apache::redirect_vhost_http { 'mediaindustriesjournal.org':
     serveraliases => [],
   }
@@ -123,7 +122,5 @@ class nebula::profile::www_lib::vhosts::redirects(
         rewrite_rule => ['^/.*$ http://www.lib.umich.edu/searchtools? [redirect=permanent,last,noescape]']
       }
     ]
-
   }
-
 }

--- a/manifests/profile/www_lib/vhosts/staff_lib.pp
+++ b/manifests/profile/www_lib/vhosts/staff_lib.pp
@@ -16,7 +16,6 @@ class nebula::profile::www_lib::vhosts::staff_lib (
   String $vhost_root = '/www/staff.lib',
   String $docroot = "${vhost_root}/web"
 ) {
-
   nebula::apache::www_lib_vhost { 'apps.staff.lib http redirect':
     servername      => "${prefix}apps.staff.${domain}",
     ssl             => false,
@@ -169,4 +168,3 @@ class nebula::profile::www_lib::vhosts::staff_lib (
     ]
   }
 }
-

--- a/manifests/profile/www_lib/vhosts/www_lib.pp
+++ b/manifests/profile/www_lib/vhosts/www_lib.pp
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
@@ -16,7 +15,6 @@ class nebula::profile::www_lib::vhosts::www_lib (
   String $www_lib_root = '/www/www.lib-fallback',
   String $docroot = "${www_lib_root}/web"
 ) {
-
   nebula::apache::www_lib_vhost { 'www.lib-ssl':
     servername  => "${prefix}www.${domain}",
     ssl         => true,

--- a/manifests/profile/yarn.pp
+++ b/manifests/profile/yarn.pp
@@ -7,20 +7,18 @@
 # Installs Yarn from Official repositories.
 class nebula::profile::yarn (
 ) {
-
   apt::source { 'yarn':
     location     => 'https://dl.yarnpkg.com/debian/',
-    key          =>  {
+    key          => {
       name   => 'yarnpkg.asc',
       source => 'https://dl.yarnpkg.com/debian/pubkey.gpg'
     },
     release      => 'stable',
     repos        => 'main',
-    architecture => $::os['architecture'],
+    architecture => $facts['os']['architecture'],
   }
 
   package { 'yarn':
     require => Apt::Source['yarn'],
   }
-
 }

--- a/manifests/resolv_conf.pp
+++ b/manifests/resolv_conf.pp
@@ -2,7 +2,7 @@ class nebula::resolv_conf (
   Array[String] $nameservers,
   Array[String] $searchpath = [],
   String        $mode = '0644',
-){
+) {
   # replicate behavior of saz/resolv_conf for Debian based OS
   package { 'resolvconf':
     ensure => absent

--- a/manifests/role/aws.pp
+++ b/manifests/role/aws.pp
@@ -20,7 +20,7 @@ class nebula::role::aws (
 
   include nebula::profile::aws::filesystem
 
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     include nebula::profile::exim4
     include nebula::profile::ntp
     class { 'nebula::profile::networking':
@@ -31,5 +31,4 @@ class nebula::role::aws (
   include nebula::profile::dns::aws
   include nebula::profile::elastic::metricbeat
   include nebula::profile::elastic::filebeat::configs::ulib
-
 }

--- a/manifests/role/aws/auto.pp
+++ b/manifests/role/aws/auto.pp
@@ -7,8 +7,8 @@
 # @example
 #   include nebula::role::aws::auto
 class nebula::role::aws::auto {
-  if $::ec2_tag_role {
-    include Class[$::ec2_tag_role]
+  if $facts['ec2_tag_role'] {
+    include Class[$facts['ec2_tag_role']]
   } else {
     fail('no ec2 role tag defined')
   }

--- a/manifests/role/hathitrust.pp
+++ b/manifests/role/hathitrust.pp
@@ -13,12 +13,11 @@ class nebula::role::hathitrust (
   String $internal_routing = '',
   Boolean $afs = true,
 ) {
-
   class { 'nebula::role::minimum':
     internal_routing => $internal_routing,
   }
 
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     include nebula::profile::krb5
     if $afs {
       include nebula::profile::afs
@@ -38,5 +37,4 @@ class nebula::role::hathitrust (
   include nebula::profile::elastic::filebeat::configs::ulib
 
   @nebula::taghosts::tag { 'ht': }
-
 }

--- a/manifests/role/log_host.pp
+++ b/manifests/role/log_host.pp
@@ -16,5 +16,4 @@ class nebula::role::log_host {
     port  => 5044,
     block => 'umich::networks::datacenter',
   }
-
 }

--- a/manifests/role/minimal_docker.pp
+++ b/manifests/role/minimal_docker.pp
@@ -3,8 +3,7 @@
 # BSD License. See LICENSE.txt for details.
 
 # A server with this role will have docker and pretty much nothing else.
-class nebula::role::minimal_docker ()
-{
+class nebula::role::minimal_docker () {
   class { 'nebula::role::minimum':
     internal_routing => 'docker',
   }

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -9,7 +9,7 @@
 class nebula::role::minimum (
   String $internal_routing = '',
 ) {
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     include nebula::profile::base
     include nebula::profile::prometheus::exporter::node
     include nebula::profile::authorized_keys

--- a/manifests/role/prometheus.pp
+++ b/manifests/role/prometheus.pp
@@ -3,8 +3,7 @@
 # BSD License. See LICENSE.txt for details.
 
 # Prometheus for hardware monitoring
-class nebula::role::prometheus ()
-{
+class nebula::role::prometheus () {
   include nebula::role::minimal_docker
   include nebula::profile::ntp
   include nebula::profile::prometheus

--- a/manifests/role/umich.pp
+++ b/manifests/role/umich.pp
@@ -12,12 +12,11 @@ class nebula::role::umich (
   $bridge_network = false,
   $internal_routing = '',
 ) {
-
   class { 'nebula::role::minimum':
     internal_routing => $internal_routing,
   }
 
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     include nebula::profile::duo
     include nebula::profile::exim4
     include nebula::profile::grub
@@ -30,5 +29,4 @@ class nebula::role::umich (
   include nebula::profile::dns::standard
   include nebula::profile::elastic::metricbeat
   include nebula::profile::elastic::filebeat::configs::ulib
-
 }

--- a/manifests/role/umich_mailserver.pp
+++ b/manifests/role/umich_mailserver.pp
@@ -12,12 +12,11 @@ class nebula::role::umich_mailserver (
   $bridge_network = false,
   $internal_routing = '',
 ) {
-
   class { 'nebula::role::minimum':
     internal_routing => $internal_routing,
   }
 
-  if $::os['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     include nebula::profile::duo
     include nebula::profile::postfix
     include nebula::profile::grub
@@ -30,5 +29,4 @@ class nebula::role::umich_mailserver (
   include nebula::profile::dns::standard
   include nebula::profile::elastic::metricbeat
   include nebula::profile::elastic::filebeat::configs::ulib
-
 }

--- a/manifests/role/webhost/htvm/global_primary.pp
+++ b/manifests/role/webhost/htvm/global_primary.pp
@@ -12,7 +12,7 @@ class nebula::role::webhost::htvm::global_primary {
 
   cron {
     'wordpress cron':
-      user    =>  'nobody',
+      user    => 'nobody',
       minute  => 0,
       command => '/usr/bin/curl -s https://www.hathitrust.org/wp-cron.php --resolve "www.hathitrust.org:443:127.0.0.1"';
   }

--- a/manifests/role/webhost/htvm/prod.pp
+++ b/manifests/role/webhost/htvm/prod.pp
@@ -13,7 +13,7 @@ class nebula::role::webhost::htvm::prod {
   @@nebula::haproxy::binding { "${::networking['hostname']} hathitrust":
     service       => 'hathitrust',
     https_offload => false,
-    datacenter    => $::datacenter,
+    datacenter    => $facts['datacenter'],
     hostname      => $::networking['hostname'],
     ipaddress     => $::networking['ip']
   }

--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -34,7 +34,7 @@ class nebula::role::webhost::htvm::test {
   include nebula::profile::hathitrust::apache::test
 
   file { '/etc/sudoers.d/htprod-systemctl-imgsrv':
-    ensure  => 'present',
+    ensure  => 'file',
     content => @("SUDOERS")
       %htprod  ALL=(root) NOPASSWD: /bin/journalctl
       %htprod  ALL=(root) NOPASSWD: /bin/systemctl start imgsrv,/bin/systemctl stop imgsrv,/bin/systemctl restart imgsrv,/bin/systemctl status imgsrv
@@ -42,5 +42,4 @@ class nebula::role::webhost::htvm::test {
   }
 
   @nebula::taghosts::tag { 'test': }
-
 }

--- a/manifests/unison/client.pp
+++ b/manifests/unison/client.pp
@@ -12,7 +12,6 @@ define nebula::unison::client (
   Integer $watchdog_sec = 7200,
   Optional[Array[String]] $ignores = undef,
 ) {
-
   include nebula::profile::unison::client
 
   $remote_root = "socket://${server}:${port}${root}"
@@ -31,7 +30,7 @@ define nebula::unison::client (
     ensure     => 'running',
     enable     => true,
     hasrestart => true,
-    require    => Package[unison]
+    require    => Package['unison']
   }
 
   @@firewall { "200 Unison: ${title} ${::networking['hostname']}":
@@ -40,6 +39,6 @@ define nebula::unison::client (
     source => $::networking['ip'],
     state  => 'NEW',
     jump   => 'accept',
-    tag    =>  "unison-client-${title}"
+    tag    => "unison-client-${title}"
   }
 }

--- a/manifests/unison/server.pp
+++ b/manifests/unison/server.pp
@@ -21,7 +21,7 @@ define nebula::unison::server (
     ensure     => 'running',
     enable     => true,
     hasrestart => true,
-    require    => Package[unison]
+    require    => Package['unison']
   }
 
   @@nebula::unison::client { $title:
@@ -34,5 +34,4 @@ define nebula::unison::server (
   }
 
   Firewall <<| tag == "unison-client-${title}" |>>
-
 }

--- a/manifests/usergroup.pp
+++ b/manifests/usergroup.pp
@@ -6,7 +6,7 @@
 #
 # @example Provision all sudoers
 #   nebula::usergroup { 'sudo': }
-define nebula::usergroup(
+define nebula::usergroup (
 ) {
   $membership = lookup('nebula::usergroup::membership')
   include nebula::virtual::users

--- a/manifests/virtual/users.pp
+++ b/manifests/virtual/users.pp
@@ -32,7 +32,7 @@
 #
 # @example
 #   include nebula::virtual::users
-class nebula::virtual::users(
+class nebula::virtual::users (
   Hash   $all_users,
   String $default_group,
 ) {

--- a/manifests/virtual_machine.pp
+++ b/manifests/virtual_machine.pp
@@ -58,7 +58,7 @@
 #     $timeout => 0,                        # the special value of 0
 #                                           # disables the timeout
 #   }
-define nebula::virtual_machine(
+define nebula::virtual_machine (
   String  $addr            = '127.0.0.1',
   String  $build           = 'bullseye',
   Integer $cpus            = 2,
@@ -93,7 +93,7 @@ define nebula::virtual_machine(
     ensure => 'directory',
   }
 
-  unless $::vm_guests.member($title) {
+  unless $facts['vm_guests'].member($title) {
     if $build == 'stretch' or $build == 'buster' or $build == 'bullseye' {
       file { "${tmpdir}/preseed.cfg":
         content => template("nebula/virtual_machine/${build}.cfg.erb"),

--- a/rakelib/forge.rake
+++ b/rakelib/forge.rake
@@ -1,26 +1,26 @@
 desc "list outdated modules in .fixtures.yml"
 task :outdated do |t|
-  require 'yaml'
-  require 'net/http'
-  require 'uri'
-  require 'json'
+  require "yaml"
+  require "net/http"
+  require "uri"
+  require "json"
 
-  fixtures = YAML.load_file('.fixtures.yml')
-  fixtures['fixtures']['forge_modules'].values.each do |mod|
-    repo = mod['repo']
-    slug = repo.tr('/','-')
-    vers = mod['ref']
+  fixtures = YAML.load_file(".fixtures.yml")
+  fixtures["fixtures"]["forge_modules"].values.each do |mod|
+    repo = mod["repo"]
+    slug = repo.tr("/", "-")
+    vers = mod["ref"]
     uri = URI.parse "https://forgeapi.puppet.com/v3/modules/#{slug}"
 
     response = Net::HTTP.get_response(uri)
-    raise "failed to fetch #{mod['repo']}" unless response.code == '200'
+    raise "failed to fetch #{mod["repo"]}" unless response.code == "200"
 
-    releases = JSON.parse(response.body)['releases'].map{|x| x['version']}
+    releases = JSON.parse(response.body)["releases"].map { |x| x["version"] }
     installed_index = releases.find_index(vers)
     installed = releases[installed_index]
 
     if installed_index != 0
-      newer = releases.slice(0,installed_index).join(', ')
+      newer = releases.slice(0, installed_index).join(", ")
       puts "#{repo} (#{installed}) < #{newer}"
       puts "https://forge.puppet.com/modules/#{repo}"
 

--- a/rakelib/librarian.rake
+++ b/rakelib/librarian.rake
@@ -3,10 +3,10 @@ task librarian: [:librarian_standalone, :librarian_clean]
 
 desc "don't clean after librarian"
 task :librarian_standalone do |t|
-  system('librarian-puppet install --verbose') or abort
+  system("librarian-puppet install --verbose") or abort
 end
 
 desc "rm Puppetfile.lock"
 task :librarian_clean do |t|
-  FileUtils.rm_f('Puppetfile.lock')
+  FileUtils.rm_f("Puppetfile.lock")
 end

--- a/rakelib/require.rake
+++ b/rakelib/require.rake
@@ -1,0 +1,1 @@
+require "standard/rake"

--- a/spec/classes/all_roles_1_spec.rb
+++ b/spec/classes/all_roles_1_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative './all_roles_spec'
+require "spec_helper"
+require_relative "./all_roles_spec"
 
 test_roles(1, 5)

--- a/spec/classes/all_roles_2_spec.rb
+++ b/spec/classes/all_roles_2_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative './all_roles_spec'
+require "spec_helper"
+require_relative "./all_roles_spec"
 
 test_roles(2, 5)

--- a/spec/classes/all_roles_3_spec.rb
+++ b/spec/classes/all_roles_3_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative './all_roles_spec'
+require "spec_helper"
+require_relative "./all_roles_spec"
 
 test_roles(3, 5)

--- a/spec/classes/all_roles_4_spec.rb
+++ b/spec/classes/all_roles_4_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative './all_roles_spec'
+require "spec_helper"
+require_relative "./all_roles_spec"
 
 test_roles(4, 5)

--- a/spec/classes/all_roles_5_spec.rb
+++ b/spec/classes/all_roles_5_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require_relative './all_roles_spec'
+require "spec_helper"
+require_relative "./all_roles_spec"
 
 test_roles(5, 5)

--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -3,10 +3,10 @@
 # Copyright (c) 2018-2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
 def puppet_role_name_from(path)
-  path.strip.gsub('/', '::').gsub(%r{^manifests}, 'nebula').gsub(%r{\.pp}, '')
+  path.strip.gsub("/", "::").gsub(%r{^manifests}, "nebula").gsub(%r{\.pp}, "")
 end
 
 module RSpec::Puppet
@@ -68,7 +68,7 @@ def test_roles(slice_number = 1, slice_count = 1)
               %w[nebula::role::webhost::www_lib_vm www_lib],
               %w[nebula::role::webhost::fulcrum_www_and_app fulcrum],
               %w[nebula::role::fulcrum::standalone fulcrum],
-              %w[nebula default],
+              %w[nebula default]
             ].select { |role_base, _| role_name.start_with? role_base }.first[1]
           end
 
@@ -79,10 +79,10 @@ def test_roles(slice_number = 1, slice_count = 1)
           end
 
           it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
-          it { is_expected.to contain_class('nebula::role::minimum') }
+          it { is_expected.to contain_class("nebula::role::minimum") }
 
           if role_name.match?(%r{^nebula::role::hathitrust})
-            it { is_expected.to contain_nebula__taghosts__tag('ht') }
+            it { is_expected.to contain_nebula__taghosts__tag("ht") }
           end
         end
       end

--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -69,7 +69,7 @@ def test_roles(slice_number = 1, slice_count = 1)
               %w[nebula::role::webhost::fulcrum_www_and_app fulcrum],
               %w[nebula::role::fulcrum::standalone fulcrum],
               %w[nebula default]
-            ].select { |role_base, _| role_name.start_with? role_base }.first[1]
+            ].find { |role_base, _| role_name.start_with? role_base }[1]
           end
 
           before(:each) do

--- a/spec/classes/profile/afs_spec.rb
+++ b/spec/classes/profile/afs_spec.rb
@@ -3,95 +3,95 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::afs' do
+describe "nebula::profile::afs" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:kernelrelease) { os_facts[:kernelrelease] }
 
-      today = Date.today.strftime('%Y-%m-%d')
-      tomorrow = (Date.today + 1).strftime('%Y-%m-%d')
+      today = Date.today.strftime("%Y-%m-%d")
+      tomorrow = (Date.today + 1).strftime("%Y-%m-%d")
 
-      it { is_expected.to contain_package('libpam-afs-session') }
-      it { is_expected.to contain_package('openafs-client') }
-      it { is_expected.to contain_package('openafs-krb5') }
-      it { is_expected.to contain_package('openafs-modules-dkms') }
+      it { is_expected.to contain_package("libpam-afs-session") }
+      it { is_expected.to contain_package("openafs-client") }
+      it { is_expected.to contain_package("openafs-krb5") }
+      it { is_expected.to contain_package("openafs-modules-dkms") }
 
-      it { is_expected.to contain_class('nebula::profile::krb5') }
+      it { is_expected.to contain_class("nebula::profile::krb5") }
 
       it do
-        expect(subject).to contain_exec('reinstall kernel to enable afs').with(
-          command: '/usr/bin/apt-get -y install --reinstall linux-headers-amd64',
+        expect(subject).to contain_exec("reinstall kernel to enable afs").with(
+          command: "/usr/bin/apt-get -y install --reinstall linux-headers-amd64",
           creates: "/lib/modules/#{kernelrelease}/updates/dkms/openafs.ko",
           timeout: 600,
-          require: 'Package[openafs-modules-dkms]',
+          require: "Package[openafs-modules-dkms]"
         )
       end
 
-      it { is_expected.not_to contain_reboot('afs') }
+      it { is_expected.not_to contain_reboot("afs") }
 
       context "when allow_auto_reboot_until is #{today}" do
-        let(:params) { { allow_auto_reboot_until: today } }
+        let(:params) { {allow_auto_reboot_until: today} }
 
-        it { is_expected.not_to contain_reboot('afs') }
+        it { is_expected.not_to contain_reboot("afs") }
       end
 
       context "when allow_auto_reboot_until is #{tomorrow}" do
-        let(:params) { { allow_auto_reboot_until: tomorrow } }
+        let(:params) { {allow_auto_reboot_until: tomorrow} }
 
         it do
-          expect(subject).to contain_reboot('afs')
-            .that_subscribes_to('Exec[reinstall kernel to enable afs]')
-            .with_apply('finished')
+          expect(subject).to contain_reboot("afs")
+            .that_subscribes_to("Exec[reinstall kernel to enable afs]")
+            .with_apply("finished")
         end
       end
 
       it do
-        expect(subject).to contain_debconf('openafs-client/thiscell')
-          .with_type('string')
-          .with_value('cell.default.invalid')
+        expect(subject).to contain_debconf("openafs-client/thiscell")
+          .with_type("string")
+          .with_value("cell.default.invalid")
       end
 
       it do
-        expect(subject).to contain_debconf('openafs-client/cachesize')
-          .with_type('string')
-          .with_value('50000')
+        expect(subject).to contain_debconf("openafs-client/cachesize")
+          .with_type("string")
+          .with_value("50000")
       end
 
-      context 'with a cell of example.com' do
-        let(:params) { { cell: 'example.com' } }
+      context "with a cell of example.com" do
+        let(:params) { {cell: "example.com"} }
 
         it do
-          expect(subject).to contain_debconf('openafs-client/thiscell')
-            .with_type('string')
-            .with_value('example.com')
+          expect(subject).to contain_debconf("openafs-client/thiscell")
+            .with_type("string")
+            .with_value("example.com")
         end
       end
 
-      context 'with a cache_size of 100' do
-        let(:params) { { cache_size: 100 } }
+      context "with a cache_size of 100" do
+        let(:params) { {cache_size: 100} }
 
         it do
-          expect(subject).to contain_debconf('openafs-client/cachesize')
-            .with_type('string')
-            .with_value('100')
+          expect(subject).to contain_debconf("openafs-client/cachesize")
+            .with_type("string")
+            .with_value("100")
         end
       end
 
       %w[login profile].each do |suffix|
         it do
           expect(subject).to contain_file("/usr/local/skel/sys.#{suffix}")
-            .with_source('puppet:///modules/nebula/skel.txt')
-            .that_requires('File[/usr/local/skel]')
+            .with_source("puppet:///modules/nebula/skel.txt")
+            .that_requires("File[/usr/local/skel]")
         end
       end
 
       it do
-        expect(subject).to contain_file('/usr/local/skel').with(
-          ensure: 'directory',
-          mode: '0755',
+        expect(subject).to contain_file("/usr/local/skel").with(
+          ensure: "directory",
+          mode: "0755"
         )
       end
     end

--- a/spec/classes/profile/alma_integrations_spec.rb
+++ b/spec/classes/profile/alma_integrations_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::alma_integrations' do
+describe "nebula::profile::alma_integrations" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -13,32 +13,32 @@ describe 'nebula::profile::alma_integrations' do
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_user('alma')
-          .with_home('/var/local/alma')
+        expect(subject).to contain_user("alma")
+          .with_home("/var/local/alma")
           .with_managehome(true)
       end
 
       it do
-        expect(subject).to contain_nebula__file__ssh_keys('/var/local/alma/.ssh/authorized_keys')
+        expect(subject).to contain_nebula__file__ssh_keys("/var/local/alma/.ssh/authorized_keys")
           .with(secret: true)
-          .with(owner: 'alma')
-          .with(group: 'alma')
+          .with(owner: "alma")
+          .with(group: "alma")
           .with(keys: [])
       end
 
-      describe 'takes keys from hiera' do
-        let(:hiera_config) { 'spec/fixtures/hiera/alma_config.yaml' }
+      describe "takes keys from hiera" do
+        let(:hiera_config) { "spec/fixtures/hiera/alma_config.yaml" }
 
         it do
-          expect(subject).to contain_nebula__file__ssh_keys('/var/local/alma/.ssh/authorized_keys')
+          expect(subject).to contain_nebula__file__ssh_keys("/var/local/alma/.ssh/authorized_keys")
             .with(secret: true)
-            .with(owner: 'alma')
-            .with(group: 'alma')
+            .with(owner: "alma")
+            .with(group: "alma")
             .with(keys: [{
-                    'type' => 'ssh-rsa',
-                    'data' => 'abcdefgh',
-                    'comment' => 'sshuser@host',
-                  }])
+              "type" => "ssh-rsa",
+              "data" => "abcdefgh",
+              "comment" => "sshuser@host"
+            }])
         end
       end
     end

--- a/spec/classes/profile/apt/mono_spec.rb
+++ b/spec/classes/profile/apt/mono_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::apt::mono' do
+describe "nebula::profile::apt::mono" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_apt__source('mono-official-stable').with(
-          location: 'https://download.mono-project.com/repo/debian',
-          release: 'stable-buster',
-          repos: 'main',
+        expect(subject).to contain_apt__source("mono-official-stable").with(
+          location: "https://download.mono-project.com/repo/debian",
+          release: "stable-buster",
+          repos: "main"
         )
       end
     end

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -3,191 +3,191 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::apt' do
+describe "nebula::profile::apt" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      if os.start_with? 'debian'
+      if os.start_with? "debian"
         it do
-          expect(subject).to contain_class('apt').with(
+          expect(subject).to contain_class("apt").with(
             purge: {
-              'sources.list' => true,
-              'sources.list.d' => true,
-              'preferences' => true,
-              'preferences.d' => true,
+              "sources.list" => true,
+              "sources.list.d" => true,
+              "preferences" => true,
+              "preferences.d" => true
             },
             update: {
-              'frequency' => 'daily',
-            },
+              "frequency" => "daily"
+            }
           )
         end
 
-        it 'sets apt to never install recommended packages' do
-          expect(subject).to contain_file('/etc/apt/apt.conf.d/99no-recommends')
+        it "sets apt to never install recommended packages" do
+          expect(subject).to contain_file("/etc/apt/apt.conf.d/99no-recommends")
             .with_content(%r{^APT::Install-Recommends "0";$})
             .with_content(%r{^APT::Install-Suggests "0";$})
         end
 
         it do
-          expect(subject).to contain_apt__source('main').with(
-            location: 'http://ftp.us.debian.org/debian/',
+          expect(subject).to contain_apt__source("main").with(
+            location: "http://ftp.us.debian.org/debian/",
             repos: case os
-                   when 'debian-12-x86_64'
-                     'main contrib non-free non-free-firmware'
+                   when "debian-12-x86_64"
+                     "main contrib non-free non-free-firmware"
                    else
-                     'main contrib non-free'
-                   end,
+                     "main contrib non-free"
+                   end
           )
         end
 
         it do
-          expect(subject).to contain_apt__source('security').with(
+          expect(subject).to contain_apt__source("security").with(
             repos: case os
-                   when 'debian-12-x86_64'
-                     'main contrib non-free non-free-firmware'
+                   when "debian-12-x86_64"
+                     "main contrib non-free non-free-firmware"
                    else
-                     'main contrib non-free'
-                   end,
+                     "main contrib non-free"
+                   end
           )
         end
 
         it do
-          expect(subject).to contain_apt__source('security').with_release(
+          expect(subject).to contain_apt__source("security").with_release(
             case os
-            when 'debian-9-x86_64'
+            when "debian-9-x86_64"
               "#{facts[:lsbdistcodename]}/updates"
-            when 'debian-10-x86_64'
+            when "debian-10-x86_64"
               "#{facts[:lsbdistcodename]}/updates"
             else
               "#{facts[:lsbdistcodename]}-security"
-            end,
+            end
           )
         end
 
         it do
-          expect(subject).to contain_apt__source('puppet').with(
-            location: 'http://apt.puppetlabs.com',
-            repos: 'puppet5',
+          expect(subject).to contain_apt__source("puppet").with(
+            location: "http://apt.puppetlabs.com",
+            repos: "puppet5"
           )
         end
 
         it do
-          expect(subject).to contain_file('/etc/apt/apt.conf.d/99force-ipv4')
+          expect(subject).to contain_file("/etc/apt/apt.conf.d/99force-ipv4")
             .with_content(%r{^Acquire::ForceIPv4 "true";$})
         end
 
-        context 'when given a mirror of http://debian.uchicago.edu/' do
-          let(:params) { { mirror: 'http://debian.uchicago.edu/' } }
+        context "when given a mirror of http://debian.uchicago.edu/" do
+          let(:params) { {mirror: "http://debian.uchicago.edu/"} }
 
           it do
-            expect(subject).to contain_apt__source('main')
-              .with_location('http://debian.uchicago.edu/')
+            expect(subject).to contain_apt__source("main")
+              .with_location("http://debian.uchicago.edu/")
           end
         end
 
-        context 'when given a puppet_repo of PC1' do
-          let(:params) { { puppet_repo: 'PC1' } }
+        context "when given a puppet_repo of PC1" do
+          let(:params) { {puppet_repo: "PC1"} }
 
-          it { is_expected.to contain_apt__source('puppet').with_repos('PC1') }
+          it { is_expected.to contain_apt__source("puppet").with_repos("PC1") }
         end
       end
 
-      it { is_expected.to contain_apt__source('local').with_architecture('amd64') }
+      it { is_expected.to contain_apt__source("local").with_architecture("amd64") }
 
       case os
       when %r{^debian}
         it do
-          expect(subject).to contain_apt__source('security')
-            .with_location('http://security.debian.org/debian-security')
+          expect(subject).to contain_apt__source("security")
+            .with_location("http://security.debian.org/debian-security")
         end
 
         it do
-          expect(subject).to contain_apt__source('updates').with(
-            location: 'http://ftp.us.debian.org/debian/',
+          expect(subject).to contain_apt__source("updates").with(
+            location: "http://ftp.us.debian.org/debian/",
             release: "#{facts[:lsbdistcodename]}-updates",
             repos: case os
-                   when 'debian-12-x86_64'
-                     'main contrib non-free non-free-firmware'
+                   when "debian-12-x86_64"
+                     "main contrib non-free non-free-firmware"
                    else
-                     'main contrib non-free'
-                   end,
+                     "main contrib non-free"
+                   end
           )
         end
 
-        context 'when given a local repo' do
+        context "when given a local repo" do
           let(:params) do
-            { local_repo:
-                             { 'location' => 'http://somehost.example.invalid/debs',
-                               'key' => { 'id' => '12345678', 'source' => 'http://somehost.example.invalid/repo-key.gpg' } } }
+            {local_repo:
+                             {"location" => "http://somehost.example.invalid/debs",
+                              "key" => {"id" => "12345678", "source" => "http://somehost.example.invalid/repo-key.gpg"}}}
           end
 
           it do
-            expect(subject).to contain_apt__source('local').with(location: 'http://somehost.example.invalid/debs',
-                                                                 architecture: 'amd64',
-                                                                 release: facts[:lsbdistcodename].to_s,
-                                                                 key: params[:local_repo]['key'],
-                                                                 repos: 'main')
+            expect(subject).to contain_apt__source("local").with(location: "http://somehost.example.invalid/debs",
+              architecture: "amd64",
+              release: facts[:lsbdistcodename].to_s,
+              key: params[:local_repo]["key"],
+              repos: "main")
           end
         end
 
-        it { is_expected.not_to contain_class('apt::backports') }
+        it { is_expected.not_to contain_class("apt::backports") }
 
-        context 'when abc is installed from backports' do
-          let(:facts) { os_facts.merge(installed_backports: ['abc']) }
+        context "when abc is installed from backports" do
+          let(:facts) { os_facts.merge(installed_backports: ["abc"]) }
 
           it do
-            expect(subject).to contain_class('apt::backports')
-              .with_location('http://ftp.us.debian.org/debian/')
+            expect(subject).to contain_class("apt::backports")
+              .with_location("http://ftp.us.debian.org/debian/")
           end
         end
       when %r{^ubuntu}
         it do
-          expect(subject).to contain_apt__source('main')
-            .with_location('http://us.archive.ubuntu.com/ubuntu')
-            .with_repos('main restricted universe')
+          expect(subject).to contain_apt__source("main")
+            .with_location("http://us.archive.ubuntu.com/ubuntu")
+            .with_repos("main restricted universe")
             .with_release(facts[:lsbdistcodename].to_s)
-          expect(subject).to contain_apt__source('updates')
-            .with_location('http://us.archive.ubuntu.com/ubuntu')
-            .with_repos('main restricted universe')
+          expect(subject).to contain_apt__source("updates")
+            .with_location("http://us.archive.ubuntu.com/ubuntu")
+            .with_repos("main restricted universe")
             .with_release("#{facts[:lsbdistcodename]}-updates")
-          expect(subject).to contain_apt__source('security')
-            .with_location('http://us.archive.ubuntu.com/ubuntu')
-            .with_repos('main restricted universe')
+          expect(subject).to contain_apt__source("security")
+            .with_location("http://us.archive.ubuntu.com/ubuntu")
+            .with_repos("main restricted universe")
             .with_release("#{facts[:lsbdistcodename]}-security")
-          expect(subject).to contain_apt__source('backports')
-            .with_location('http://us.archive.ubuntu.com/ubuntu')
-            .with_repos('main restricted universe')
+          expect(subject).to contain_apt__source("backports")
+            .with_location("http://us.archive.ubuntu.com/ubuntu")
+            .with_repos("main restricted universe")
             .with_release("#{facts[:lsbdistcodename]}-backports")
         end
       end
 
-      it { is_expected.not_to contain_apt__source('hp') }
+      it { is_expected.not_to contain_apt__source("hp") }
 
-      context 'when on an HPE machine' do
-        let(:facts) { os_facts.merge('dmi' => { 'manufacturer' => 'HPE' }) }
+      context "when on an HPE machine" do
+        let(:facts) { os_facts.merge("dmi" => {"manufacturer" => "HPE"}) }
 
         it do
-          expect(subject).to contain_apt__source('hp').with(
-            location: 'http://downloads.linux.hpe.com/SDR/repo/mcp/debian',
+          expect(subject).to contain_apt__source("hp").with(
+            location: "http://downloads.linux.hpe.com/SDR/repo/mcp/debian",
             release: "#{facts[:lsbdistcodename]}/current",
-            repos: 'non-free',
+            repos: "non-free"
           )
         end
 
-        context 'with ubuntu instead of debian' do
+        context "with ubuntu instead of debian" do
           let(:facts) do
-            os_facts.merge('dmi' => { 'manufacturer' => 'HPE' },
-                           'operatingsystem' => 'Ubuntu')
+            os_facts.merge("dmi" => {"manufacturer" => "HPE"},
+              "operatingsystem" => "Ubuntu")
           end
 
           it do
-            expect(subject).to contain_apt__source('hp').with(
-              location: 'http://downloads.linux.hpe.com/SDR/repo/mcp/debian',
+            expect(subject).to contain_apt__source("hp").with(
+              location: "http://downloads.linux.hpe.com/SDR/repo/mcp/debian",
               release: "#{facts[:lsbdistcodename]}/current",
-              repos: 'non-free',
+              repos: "non-free"
             )
           end
         end

--- a/spec/classes/profile/authorized_keys_spec.rb
+++ b/spec/classes/profile/authorized_keys_spec.rb
@@ -3,28 +3,28 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::authorized_keys' do
+describe "nebula::profile::authorized_keys" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/ssh_keys_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }
 
       [
         %r{^ssh-rsa AAAAAAAAAAAA invalid_normal_admin@default\.invalid$},
-        %r{^ssh-dsa BBBBBBBBBBBB invalid_special_admin@special\.invalid$},
+        %r{^ssh-dsa BBBBBBBBBBBB invalid_special_admin@special\.invalid$}
       ].each do |line|
         it do
-          expect(subject).to contain_file('/etc/secretkeys/default.invalid')
+          expect(subject).to contain_file("/etc/secretkeys/default.invalid")
             .with_content(line)
         end
       end
 
       it do
-        expect(subject).to contain_file('/etc/secretkeys').with(
-          ensure: 'directory',
-          mode: '0700',
+        expect(subject).to contain_file("/etc/secretkeys").with(
+          ensure: "directory",
+          mode: "0700"
         )
       end
     end

--- a/spec/classes/profile/aws/filesystem_spec.rb
+++ b/spec/classes/profile/aws/filesystem_spec.rb
@@ -3,50 +3,50 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::aws::filesystem' do
+describe "nebula::profile::aws::filesystem" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
-        os_facts.merge('disks' => {
-                         'xvda' => 'some other stuff',
-                       })
+        os_facts.merge("disks" => {
+          "xvda" => "some other stuff"
+        })
       end
 
       it { is_expected.to compile.with_all_deps }
 
-      context 'with /dev/xvdb present' do
+      context "with /dev/xvdb present" do
         let(:facts) do
-          os_facts.merge('disks' => {
-                           'xvdb' => 'some stuff',
-                         })
+          os_facts.merge("disks" => {
+            "xvdb" => "some stuff"
+          })
         end
 
-        it 'formats the disk' do
-          expect(subject).to contain_filesystem('/dev/xvdb')
-            .with_ensure('present')
-            .with_fs_type('ext4')
+        it "formats the disk" do
+          expect(subject).to contain_filesystem("/dev/xvdb")
+            .with_ensure("present")
+            .with_fs_type("ext4")
         end
 
-        it 'creates the mountpoint' do
-          expect(subject).to contain_file('/l')
-            .with_ensure('directory')
+        it "creates the mountpoint" do
+          expect(subject).to contain_file("/l")
+            .with_ensure("directory")
         end
 
-        it 'mounts the disk' do
-          expect(subject).to contain_mount('/l')
-            .with_ensure('mounted')
-            .with_name('/l')
-            .with_device('/dev/xvdb')
-            .with_fstype('ext4')
+        it "mounts the disk" do
+          expect(subject).to contain_mount("/l")
+            .with_ensure("mounted")
+            .with_name("/l")
+            .with_device("/dev/xvdb")
+            .with_fstype("ext4")
         end
       end
 
-      context 'without /dev/xvdb present' do
-        it { is_expected.not_to contain_filesystem('/dev/xvdb') }
-        it { is_expected.not_to contain_file('/l') }
-        it { is_expected.not_to contain_mount('/l') }
+      context "without /dev/xvdb present" do
+        it { is_expected.not_to contain_filesystem("/dev/xvdb") }
+        it { is_expected.not_to contain_file("/l") }
+        it { is_expected.not_to contain_mount("/l") }
       end
     end
   end

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::base' do
+describe "nebula::profile::base" do
   def contain_base_class(name)
     contain_class("nebula::profile::base::#{name}")
   end
@@ -15,45 +15,45 @@ describe 'nebula::profile::base' do
       let(:facts) { os_facts }
       let(:fqdn) { facts[:fqdn] }
 
-      it { is_expected.to contain_service('puppet').without_ensure }
-      it { is_expected.to contain_service('puppet').with_enable(true) }
+      it { is_expected.to contain_service("puppet").without_ensure }
+      it { is_expected.to contain_service("puppet").with_enable(true) }
 
       case os
       when %r{^debian}, %r{^ubuntu}
-        it { is_expected.to contain_package('dselect') }
-        it { is_expected.to contain_package('ifenslave') }
-        it { is_expected.to contain_package('vlan') }
-        it { is_expected.to contain_package('dbus') }
-        it { is_expected.to contain_package('dkms') }
+        it { is_expected.to contain_package("dselect") }
+        it { is_expected.to contain_package("ifenslave") }
+        it { is_expected.to contain_package("vlan") }
+        it { is_expected.to contain_package("dbus") }
+        it { is_expected.to contain_package("dkms") }
 
         it do
-          expect(subject).to contain_file('/etc/localtime')
-            .with_ensure('link')
-            .with_target('/usr/share/zoneinfo/US/Eastern')
+          expect(subject).to contain_file("/etc/localtime")
+            .with_ensure("link")
+            .with_target("/usr/share/zoneinfo/US/Eastern")
         end
 
         it do
-          expect(subject).to contain_file('/etc/timezone')
+          expect(subject).to contain_file("/etc/timezone")
             .with_content("US/Eastern\n")
         end
 
-        context 'with timezone set to America/Detroit' do
-          let(:params) { { timezone: 'America/Detroit' } }
+        context "with timezone set to America/Detroit" do
+          let(:params) { {timezone: "America/Detroit"} }
 
           it do
-            expect(subject).to contain_file('/etc/localtime')
-              .with_ensure('link')
-              .with_target('/usr/share/zoneinfo/America/Detroit')
+            expect(subject).to contain_file("/etc/localtime")
+              .with_ensure("link")
+              .with_target("/usr/share/zoneinfo/America/Detroit")
           end
 
           it do
-            expect(subject).to contain_file('/etc/timezone')
+            expect(subject).to contain_file("/etc/timezone")
               .with_content("America/Detroit\n")
           end
         end
 
         it do
-          expect(subject).to contain_file('/etc/hostname')
+          expect(subject).to contain_file("/etc/hostname")
             .with_content("#{fqdn}\n")
             .that_notifies("Exec[/bin/hostname #{fqdn}]")
         end
@@ -64,25 +64,25 @@ describe 'nebula::profile::base' do
         end
 
         it do
-          expect(subject).to contain_file('/etc/motd')
+          expect(subject).to contain_file("/etc/motd")
             .with_content(%r{contact us at contact@default\.invalid\.$})
             .with_content(%r{administered by Default Incorrect Dept\.$})
         end
 
-        context 'when given a contact_email of the_dean@umich.edu' do
-          let(:params) { { contact_email: 'the_dean@umich.edu' } }
+        context "when given a contact_email of the_dean@umich.edu" do
+          let(:params) { {contact_email: "the_dean@umich.edu"} }
 
           it do
-            expect(subject).to contain_file('/etc/motd')
+            expect(subject).to contain_file("/etc/motd")
               .with_content(%r{contact us at the_dean@umich\.edu\.$})
           end
         end
 
-        context 'when given a sysadmin_dept of The Cool Team' do
-          let(:params) { { sysadmin_dept: 'The Cool Team' } }
+        context "when given a sysadmin_dept of The Cool Team" do
+          let(:params) { {sysadmin_dept: "The Cool Team"} }
 
           it do
-            expect(subject).to contain_file('/etc/motd')
+            expect(subject).to contain_file("/etc/motd")
               .with_content(%r{administered by The Cool Team\.$})
           end
         end
@@ -90,77 +90,77 @@ describe 'nebula::profile::base' do
 
       case os
       when %r{^ubuntu}
-        it 'disables ubuntu motd spam' do
-          expect(subject).to contain_file('/var/lib/update-notifier/hide-esm-in-motd')
+        it "disables ubuntu motd spam" do
+          expect(subject).to contain_file("/var/lib/update-notifier/hide-esm-in-motd")
         end
       else
-        it 'does not manage ubuntu specific motd files' do
-          expect(subject).not_to contain_file('/var/lib/update-notifier/hide-esm-in-motd')
+        it "does not manage ubuntu specific motd files" do
+          expect(subject).not_to contain_file("/var/lib/update-notifier/hide-esm-in-motd")
         end
       end
 
       it do
-        expect(subject).to contain_service('mcollective').with(
-          ensure: 'stopped',
-          enable: false,
+        expect(subject).to contain_service("mcollective").with(
+          ensure: "stopped",
+          enable: false
         )
       end
 
-      context 'when on an HP machine' do
+      context "when on an HP machine" do
         let(:facts) do
-          super().merge('dmi' => { 'manufacturer' => 'HP' })
+          super().merge("dmi" => {"manufacturer" => "HP"})
         end
 
         it do
-          expect(subject).to contain_kmod__blacklist('hpwdt').with(
-            file: '/etc/modprobe.d/hpwdt-blacklist.conf',
+          expect(subject).to contain_kmod__blacklist("hpwdt").with(
+            file: "/etc/modprobe.d/hpwdt-blacklist.conf"
           )
         end
 
         it do
-          expect(subject).to contain_kmod__blacklist('acpi_power_meter').with(
-            file: '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
+          expect(subject).to contain_kmod__blacklist("acpi_power_meter").with(
+            file: "/etc/modprobe.d/acpi_power_meter-blacklist.conf"
           )
         end
       end
 
-      context 'when on an HPE machine' do
+      context "when on an HPE machine" do
         let(:facts) do
-          super().merge('dmi' => { 'manufacturer' => 'HPE' })
+          super().merge("dmi" => {"manufacturer" => "HPE"})
         end
 
         it do
-          expect(subject).to contain_kmod__blacklist('hpwdt').with(
-            file: '/etc/modprobe.d/hpwdt-blacklist.conf',
+          expect(subject).to contain_kmod__blacklist("hpwdt").with(
+            file: "/etc/modprobe.d/hpwdt-blacklist.conf"
           )
         end
 
         it do
-          expect(subject).to contain_kmod__blacklist('acpi_power_meter').with(
-            file: '/etc/modprobe.d/acpi_power_meter-blacklist.conf',
+          expect(subject).to contain_kmod__blacklist("acpi_power_meter").with(
+            file: "/etc/modprobe.d/acpi_power_meter-blacklist.conf"
           )
         end
 
-        it { is_expected.to contain_package('ssacli') }
+        it { is_expected.to contain_package("ssacli") }
       end
 
-      context 'when on an Dell machine' do
+      context "when on an Dell machine" do
         let(:facts) do
-          super().merge('dmi' => { 'manufacturer' => 'Dell Inc.' })
+          super().merge("dmi" => {"manufacturer" => "Dell Inc."})
         end
 
-        it { is_expected.not_to contain_kmod__blacklist('hpwdt') }
-        it { is_expected.not_to contain_kmod__blacklist('acpi_power_meter') }
+        it { is_expected.not_to contain_kmod__blacklist("hpwdt") }
+        it { is_expected.not_to contain_kmod__blacklist("acpi_power_meter") }
       end
 
-      it { is_expected.not_to contain_package('i40e-dkms') }
+      it { is_expected.not_to contain_package("i40e-dkms") }
 
-      context 'with an Intel X710 network card' do
+      context "with an Intel X710 network card" do
         let(:facts) do
-          super().merge('network_cards' => ['Intel Corporation Ethernet Controller X710 for 10GbE SFP+ (rev 01)'])
+          super().merge("network_cards" => ["Intel Corporation Ethernet Controller X710 for 10GbE SFP+ (rev 01)"])
         end
 
-        it { is_expected.not_to contain_package('i40e-dkms') }
+        it { is_expected.not_to contain_package("i40e-dkms") }
       end
     end
   end

--- a/spec/classes/profile/bolt_spec.rb
+++ b/spec/classes/profile/bolt_spec.rb
@@ -3,17 +3,17 @@
 # Copyright (c) 2022, 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::bolt' do
+describe "nebula::profile::bolt" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('puppet-bolt') }
-      it { is_expected.to contain_file('/opt/bolt').with_ensure('directory') }
-      it { is_expected.to contain_vcsrepo('/opt/bolt').with_ensure('latest') }
+      it { is_expected.to contain_package("puppet-bolt") }
+      it { is_expected.to contain_file("/opt/bolt").with_ensure("directory") }
+      it { is_expected.to contain_vcsrepo("/opt/bolt").with_ensure("latest") }
     end
   end
 end

--- a/spec/classes/profile/certbot_cloudflare_spec.rb
+++ b/spec/classes/profile/certbot_cloudflare_spec.rb
@@ -3,107 +3,107 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::certbot_cloudflare' do
+describe "nebula::profile::certbot_cloudflare" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('certbot') }
-      it { is_expected.to contain_package('python3-certbot-dns-cloudflare') }
+      it { is_expected.to contain_package("certbot") }
+      it { is_expected.to contain_package("python3-certbot-dns-cloudflare") }
 
-      it { is_expected.to contain_file('/root/.secrets/certbot').with_ensure('directory') }
+      it { is_expected.to contain_file("/root/.secrets/certbot").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_file('/root/.secrets/certbot/cloudflare.ini')
-          .with_mode('0600')
-          .that_requires('File[/root/.secrets/certbot]')
+        expect(subject).to contain_file("/root/.secrets/certbot/cloudflare.ini")
+          .with_mode("0600")
+          .that_requires("File[/root/.secrets/certbot]")
           .with_content(
-            <<~CREDENTIALS,
+            <<~CREDENTIALS
               dns_cloudflare_api_token = default.invalid
             CREDENTIALS
           )
       end
 
-      context 'with a single cert' do
+      context "with a single cert" do
         let(:params) do
           {
-            certs: { 'onlyservice' => { 'example.invalid' => [] } },
-            cert_dir: '/certs',
-            haproxy_cert_dir: '/haproxy',
-            letsencrypt_email: 'our_real_email@email.gov',
-            cloudflare_api_token: 'MYTOKEN',
+            certs: {"onlyservice" => {"example.invalid" => []}},
+            cert_dir: "/certs",
+            haproxy_cert_dir: "/haproxy",
+            letsencrypt_email: "our_real_email@email.gov",
+            cloudflare_api_token: "MYTOKEN"
           }
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_file('/root/.secrets/certbot/cloudflare.ini')
+          expect(subject).to contain_file("/root/.secrets/certbot/cloudflare.ini")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 dns_cloudflare_api_token = MYTOKEN
               CREDENTIALS
             )
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "our_real_email@email.gov" -d "example.invalid,*.example.invalid"
               CREDENTIALS
             )
         end
 
-        it { is_expected.to contain_concat('/certs/example.invalid.crt').with_group('puppet') }
-        it { is_expected.to contain_concat('/certs/example.invalid.key').with_group('puppet') }
-        it { is_expected.to contain_concat('/haproxy/onlyservice/example.invalid.pem').with_group('puppet') }
+        it { is_expected.to contain_concat("/certs/example.invalid.crt").with_group("puppet") }
+        it { is_expected.to contain_concat("/certs/example.invalid.key").with_group("puppet") }
+        it { is_expected.to contain_concat("/haproxy/onlyservice/example.invalid.pem").with_group("puppet") }
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.crt cert')
-            .with_target('/certs/example.invalid.crt')
-            .with_source('/etc/letsencrypt/live/example.invalid/fullchain.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.crt cert")
+            .with_target("/certs/example.invalid.crt")
+            .with_source("/etc/letsencrypt/live/example.invalid/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.key key')
-            .with_target('/certs/example.invalid.key')
-            .with_source('/etc/letsencrypt/live/example.invalid/privkey.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.key key")
+            .with_target("/certs/example.invalid.key")
+            .with_source("/etc/letsencrypt/live/example.invalid/privkey.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.pem cert')
-            .with_order('01')
-            .with_target('/haproxy/onlyservice/example.invalid.pem')
-            .with_source('/etc/letsencrypt/live/example.invalid/fullchain.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.pem cert")
+            .with_order("01")
+            .with_target("/haproxy/onlyservice/example.invalid.pem")
+            .with_source("/etc/letsencrypt/live/example.invalid/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.pem key')
-            .with_order('02')
-            .with_target('/haproxy/onlyservice/example.invalid.pem')
-            .with_source('/etc/letsencrypt/live/example.invalid/privkey.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.pem key")
+            .with_order("02")
+            .with_target("/haproxy/onlyservice/example.invalid.pem")
+            .with_source("/etc/letsencrypt/live/example.invalid/privkey.pem")
         end
       end
 
-      context 'with a multiple certs and services' do
+      context "with a multiple certs and services" do
         let(:params) do
           {
             certs: {
-              'a' => { 'abc.invalid' => %w[abc.example], 'abc.com' => [] },
-              'z' => { 'zyx.invalid' => [] },
-            },
+              "a" => {"abc.invalid" => %w[abc.example], "abc.com" => []},
+              "z" => {"zyx.invalid" => []}
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.invalid,*.abc.invalid,abc.example,*.abc.example"
                 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.com,*.abc.com"
                 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "zyx.invalid,*.zyx.invalid"
@@ -113,117 +113,117 @@ describe 'nebula::profile::certbot_cloudflare' do
 
         it { is_expected.to compile }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.invalid.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.invalid.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/a/abc.invalid.pem') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.crt cert') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.key key') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.pem cert') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.invalid.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.invalid.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/a/abc.invalid.pem") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.crt cert") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.key key") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.pem cert") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.pem key") }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.com.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.com.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/a/abc.com.pem') }
-        it { is_expected.to contain_concat_fragment('abc.com.crt cert') }
-        it { is_expected.to contain_concat_fragment('abc.com.key key') }
-        it { is_expected.to contain_concat_fragment('abc.com.pem cert') }
-        it { is_expected.to contain_concat_fragment('abc.com.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.com.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.com.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/a/abc.com.pem") }
+        it { is_expected.to contain_concat_fragment("abc.com.crt cert") }
+        it { is_expected.to contain_concat_fragment("abc.com.key key") }
+        it { is_expected.to contain_concat_fragment("abc.com.pem cert") }
+        it { is_expected.to contain_concat_fragment("abc.com.pem key") }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/zyx.invalid.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/zyx.invalid.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/z/zyx.invalid.pem') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.crt cert') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.key key') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.pem cert') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/zyx.invalid.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/zyx.invalid.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/z/zyx.invalid.pem") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.crt cert") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.key key") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.pem cert") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.pem key") }
 
-        it { is_expected.not_to contain_concat('/var/local/cert_dir/abc.example.crt') }
-        it { is_expected.not_to contain_concat('/var/local/cert_dir/abc.example.key') }
-        it { is_expected.not_to contain_concat('/var/local/haproxy_cert_dir/a/abc.example.pem') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.crt cert') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.key key') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.pem cert') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.pem key') }
+        it { is_expected.not_to contain_concat("/var/local/cert_dir/abc.example.crt") }
+        it { is_expected.not_to contain_concat("/var/local/cert_dir/abc.example.key") }
+        it { is_expected.not_to contain_concat("/var/local/haproxy_cert_dir/a/abc.example.pem") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.crt cert") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.key key") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.pem cert") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.pem key") }
       end
 
-      context 'with one simple cert, no SANs' do
+      context "with one simple cert, no SANs" do
         let(:params) do
           {
             simple_certs: {
-              "abc.example": [],
-            },
+              "abc.example": []
+            }
           }
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example"})
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/var/local/cert_dir/abc.example.crt cert')
-            .with_target('/var/local/cert_dir/abc.example.crt')
-            .with_source('/etc/letsencrypt/live/abc.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("/var/local/cert_dir/abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/var/local/cert_dir/abc.example.key key')
-            .with_target('/var/local/cert_dir/abc.example.key')
-            .with_source('/etc/letsencrypt/live/abc.example/privkey.pem')
+          expect(subject).to contain_concat_fragment("/var/local/cert_dir/abc.example.key key")
+            .with_target("/var/local/cert_dir/abc.example.key")
+            .with_source("/etc/letsencrypt/live/abc.example/privkey.pem")
         end
       end
 
-      context 'with one simple cert, two SANs' do
+      context "with one simple cert, two SANs" do
         let(:params) do
           {
             simple_certs: {
-              "abc.example": ['san.local', 'xyz.local'],
-            },
+              "abc.example": ["san.local", "xyz.local"]
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example,san.local,xyz.local"
               CREDENTIALS
             )
         end
       end
 
-      context 'with two simple certs' do
+      context "with two simple certs" do
         let(:params) do
           {
             simple_certs: {
               "abc.example": [],
-              "xyz.example": ['alt.example', '*.alt.example'],
-            },
+              "xyz.example": ["alt.example", "*.alt.example"]
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "abc.example"})
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands_cloudflare')
+          expect(subject).to contain_file("/tmp/all_cert_commands_cloudflare")
             .with_content(%r{certbot certonly --dns-cloudflare --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini -m "nope@nope.zone" -d "xyz.example,alt.example,\*.alt.example"})
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/var/local/cert_dir/abc.example.crt cert')
-            .with_target('/var/local/cert_dir/abc.example.crt')
-            .with_source('/etc/letsencrypt/live/abc.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("/var/local/cert_dir/abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/var/local/cert_dir/xyz.example.crt cert')
-            .with_target('/var/local/cert_dir/xyz.example.crt')
-            .with_source('/etc/letsencrypt/live/xyz.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("/var/local/cert_dir/xyz.example.crt cert")
+            .with_target("/var/local/cert_dir/xyz.example.crt")
+            .with_source("/etc/letsencrypt/live/xyz.example/fullchain.pem")
         end
       end
     end

--- a/spec/classes/profile/certbot_route53_spec.rb
+++ b/spec/classes/profile/certbot_route53_spec.rb
@@ -3,33 +3,33 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::certbot_route53' do
+describe "nebula::profile::certbot_route53" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('certbot') }
-      it { is_expected.to contain_package('awscli') }
-      it { is_expected.to contain_package('python3-certbot-dns-route53') }
+      it { is_expected.to contain_package("certbot") }
+      it { is_expected.to contain_package("awscli") }
+      it { is_expected.to contain_package("python3-certbot-dns-route53") }
 
-      it { is_expected.to contain_file('/root/.aws').with_ensure('directory') }
+      it { is_expected.to contain_file("/root/.aws").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_file('/root/.aws/config')
-          .with_mode('0600')
-          .that_requires('File[/root/.aws]')
+        expect(subject).to contain_file("/root/.aws/config")
+          .with_mode("0600")
+          .that_requires("File[/root/.aws]")
       end
 
       it do
-        expect(subject).to contain_file('/root/.aws/credentials')
-          .with_mode('0600')
-          .that_requires('File[/root/.aws]')
+        expect(subject).to contain_file("/root/.aws/credentials")
+          .with_mode("0600")
+          .that_requires("File[/root/.aws]")
           .with_content(
-            <<~CREDENTIALS,
+            <<~CREDENTIALS
               [default]
               aws_access_key_id = default.invalid
               aws_secret_access_key = default.invalid
@@ -37,24 +37,24 @@ describe 'nebula::profile::certbot_route53' do
           )
       end
 
-      context 'with a single cert' do
+      context "with a single cert" do
         let(:params) do
           {
-            certs: { 'onlyservice' => { 'example.invalid' => [] } },
-            cert_dir: '/certs',
-            haproxy_cert_dir: '/haproxy',
-            letsencrypt_email: 'our_real_email@email.gov',
-            aws_access_key_id: 'ACCESSKEY',
-            aws_secret_access_key: 'SECRETKEY',
+            certs: {"onlyservice" => {"example.invalid" => []}},
+            cert_dir: "/certs",
+            haproxy_cert_dir: "/haproxy",
+            letsencrypt_email: "our_real_email@email.gov",
+            aws_access_key_id: "ACCESSKEY",
+            aws_secret_access_key: "SECRETKEY"
           }
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_file('/root/.aws/credentials')
+          expect(subject).to contain_file("/root/.aws/credentials")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 [default]
                 aws_access_key_id = ACCESSKEY
                 aws_secret_access_key = SECRETKEY
@@ -63,59 +63,59 @@ describe 'nebula::profile::certbot_route53' do
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-route53 -m "our_real_email@email.gov" -d "example.invalid,*.example.invalid"
               CREDENTIALS
             )
         end
 
-        it { is_expected.to contain_concat('/certs/example.invalid.crt').with_group('puppet') }
-        it { is_expected.to contain_concat('/certs/example.invalid.key').with_group('puppet') }
-        it { is_expected.to contain_concat('/haproxy/onlyservice/example.invalid.pem').with_group('puppet') }
+        it { is_expected.to contain_concat("/certs/example.invalid.crt").with_group("puppet") }
+        it { is_expected.to contain_concat("/certs/example.invalid.key").with_group("puppet") }
+        it { is_expected.to contain_concat("/haproxy/onlyservice/example.invalid.pem").with_group("puppet") }
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.crt cert')
-            .with_target('/certs/example.invalid.crt')
-            .with_source('/etc/letsencrypt/live/example.invalid/fullchain.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.crt cert")
+            .with_target("/certs/example.invalid.crt")
+            .with_source("/etc/letsencrypt/live/example.invalid/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.key key')
-            .with_target('/certs/example.invalid.key')
-            .with_source('/etc/letsencrypt/live/example.invalid/privkey.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.key key")
+            .with_target("/certs/example.invalid.key")
+            .with_source("/etc/letsencrypt/live/example.invalid/privkey.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.pem cert')
-            .with_order('01')
-            .with_target('/haproxy/onlyservice/example.invalid.pem')
-            .with_source('/etc/letsencrypt/live/example.invalid/fullchain.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.pem cert")
+            .with_order("01")
+            .with_target("/haproxy/onlyservice/example.invalid.pem")
+            .with_source("/etc/letsencrypt/live/example.invalid/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('example.invalid.pem key')
-            .with_order('02')
-            .with_target('/haproxy/onlyservice/example.invalid.pem')
-            .with_source('/etc/letsencrypt/live/example.invalid/privkey.pem')
+          expect(subject).to contain_concat_fragment("example.invalid.pem key")
+            .with_order("02")
+            .with_target("/haproxy/onlyservice/example.invalid.pem")
+            .with_source("/etc/letsencrypt/live/example.invalid/privkey.pem")
         end
       end
 
-      context 'with a multiple certs and services' do
+      context "with a multiple certs and services" do
         let(:params) do
           {
             certs: {
-              'a' => { 'abc.invalid' => %w[abc.example], 'abc.com' => [] },
-              'z' => { 'zyx.invalid' => [] },
-            },
+              "a" => {"abc.invalid" => %w[abc.example], "abc.com" => []},
+              "z" => {"zyx.invalid" => []}
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-route53 -m "nope@nope.zone" -d "abc.invalid,*.abc.invalid,abc.example,*.abc.example"
                 certbot certonly --dns-route53 -m "nope@nope.zone" -d "abc.com,*.abc.com"
                 certbot certonly --dns-route53 -m "nope@nope.zone" -d "zyx.invalid,*.zyx.invalid"
@@ -125,117 +125,117 @@ describe 'nebula::profile::certbot_route53' do
 
         it { is_expected.to compile }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.invalid.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.invalid.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/a/abc.invalid.pem') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.crt cert') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.key key') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.pem cert') }
-        it { is_expected.to contain_concat_fragment('abc.invalid.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.invalid.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.invalid.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/a/abc.invalid.pem") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.crt cert") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.key key") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.pem cert") }
+        it { is_expected.to contain_concat_fragment("abc.invalid.pem key") }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.com.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/abc.com.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/a/abc.com.pem') }
-        it { is_expected.to contain_concat_fragment('abc.com.crt cert') }
-        it { is_expected.to contain_concat_fragment('abc.com.key key') }
-        it { is_expected.to contain_concat_fragment('abc.com.pem cert') }
-        it { is_expected.to contain_concat_fragment('abc.com.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.com.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/abc.com.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/a/abc.com.pem") }
+        it { is_expected.to contain_concat_fragment("abc.com.crt cert") }
+        it { is_expected.to contain_concat_fragment("abc.com.key key") }
+        it { is_expected.to contain_concat_fragment("abc.com.pem cert") }
+        it { is_expected.to contain_concat_fragment("abc.com.pem key") }
 
-        it { is_expected.to contain_concat('/var/local/cert_dir/zyx.invalid.crt') }
-        it { is_expected.to contain_concat('/var/local/cert_dir/zyx.invalid.key') }
-        it { is_expected.to contain_concat('/var/local/haproxy_cert_dir/z/zyx.invalid.pem') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.crt cert') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.key key') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.pem cert') }
-        it { is_expected.to contain_concat_fragment('zyx.invalid.pem key') }
+        it { is_expected.to contain_concat("/var/local/cert_dir/zyx.invalid.crt") }
+        it { is_expected.to contain_concat("/var/local/cert_dir/zyx.invalid.key") }
+        it { is_expected.to contain_concat("/var/local/haproxy_cert_dir/z/zyx.invalid.pem") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.crt cert") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.key key") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.pem cert") }
+        it { is_expected.to contain_concat_fragment("zyx.invalid.pem key") }
 
-        it { is_expected.not_to contain_concat('/var/local/cert_dir/abc.example.crt') }
-        it { is_expected.not_to contain_concat('/var/local/cert_dir/abc.example.key') }
-        it { is_expected.not_to contain_concat('/var/local/haproxy_cert_dir/a/abc.example.pem') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.crt cert') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.key key') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.pem cert') }
-        it { is_expected.not_to contain_concat_fragment('abc.example.pem key') }
+        it { is_expected.not_to contain_concat("/var/local/cert_dir/abc.example.crt") }
+        it { is_expected.not_to contain_concat("/var/local/cert_dir/abc.example.key") }
+        it { is_expected.not_to contain_concat("/var/local/haproxy_cert_dir/a/abc.example.pem") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.crt cert") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.key key") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.pem cert") }
+        it { is_expected.not_to contain_concat_fragment("abc.example.pem key") }
       end
 
-      context 'with one simple cert, no SANs' do
+      context "with one simple cert, no SANs" do
         let(:params) do
           {
             simple_certs: {
-              "abc.example": [],
-            },
+              "abc.example": []
+            }
           }
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(%r{certbot certonly --dns-route53 -m "nope@nope.zone" -d "abc.example"})
         end
 
         it do
-          expect(subject).to contain_concat_fragment('abc.example.crt cert')
-            .with_target('/var/local/cert_dir/abc.example.crt')
-            .with_source('/etc/letsencrypt/live/abc.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('abc.example.key key')
-            .with_target('/var/local/cert_dir/abc.example.key')
-            .with_source('/etc/letsencrypt/live/abc.example/privkey.pem')
+          expect(subject).to contain_concat_fragment("abc.example.key key")
+            .with_target("/var/local/cert_dir/abc.example.key")
+            .with_source("/etc/letsencrypt/live/abc.example/privkey.pem")
         end
       end
 
-      context 'with one simple cert, two SANs' do
+      context "with one simple cert, two SANs" do
         let(:params) do
           {
             simple_certs: {
-              "abc.example": ['san.local', 'xyz.local'],
-            },
+              "abc.example": ["san.local", "xyz.local"]
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(
-              <<~CREDENTIALS,
+              <<~CREDENTIALS
                 certbot certonly --dns-route53 -m "nope@nope.zone" -d "abc.example,san.local,xyz.local"
               CREDENTIALS
             )
         end
       end
 
-      context 'with two simple certs' do
+      context "with two simple certs" do
         let(:params) do
           {
             simple_certs: {
               "abc.example": [],
-              "xyz.example": ['alt.example', '*.alt.example'],
-            },
+              "xyz.example": ["alt.example", "*.alt.example"]
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(%r{certbot certonly --dns-route53 -m "nope@nope.zone" -d "abc.example"})
         end
 
         it do
-          expect(subject).to contain_file('/tmp/all_cert_commands')
+          expect(subject).to contain_file("/tmp/all_cert_commands")
             .with_content(%r{certbot certonly --dns-route53 -m "nope@nope.zone" -d "xyz.example,alt.example,\*.alt.example"})
         end
 
         it do
-          expect(subject).to contain_concat_fragment('abc.example.crt cert')
-            .with_target('/var/local/cert_dir/abc.example.crt')
-            .with_source('/etc/letsencrypt/live/abc.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("abc.example.crt cert")
+            .with_target("/var/local/cert_dir/abc.example.crt")
+            .with_source("/etc/letsencrypt/live/abc.example/fullchain.pem")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('xyz.example.crt cert')
-            .with_target('/var/local/cert_dir/xyz.example.crt')
-            .with_source('/etc/letsencrypt/live/xyz.example/fullchain.pem')
+          expect(subject).to contain_concat_fragment("xyz.example.crt cert")
+            .with_target("/var/local/cert_dir/xyz.example.crt")
+            .with_source("/etc/letsencrypt/live/xyz.example/fullchain.pem")
         end
       end
     end

--- a/spec/classes/profile/containerd_spec.rb
+++ b/spec/classes/profile/containerd_spec.rb
@@ -3,21 +3,21 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::containerd' do
+describe "nebula::profile::containerd" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_apt__source('docker') }
-      it { is_expected.to contain_package('containerd.io').that_requires('Apt::Source[docker]') }
-      it { is_expected.to contain_service('containerd').that_requires('Package[containerd.io]') }
-      it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(%r{^disabled_plugins = \[\]$}) }
-      it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(%r{^\s*SystemdCgroup = true$}) }
-      it { is_expected.to contain_file('/etc/containerd').with_ensure('directory') }
-      it { is_expected.to contain_file('/etc/containerd').that_comes_before('File[/etc/containerd/config.toml]') }
+      it { is_expected.to contain_apt__source("docker") }
+      it { is_expected.to contain_package("containerd.io").that_requires("Apt::Source[docker]") }
+      it { is_expected.to contain_service("containerd").that_requires("Package[containerd.io]") }
+      it { is_expected.to contain_file("/etc/containerd/config.toml").with_content(%r{^disabled_plugins = \[\]$}) }
+      it { is_expected.to contain_file("/etc/containerd/config.toml").with_content(%r{^\s*SystemdCgroup = true$}) }
+      it { is_expected.to contain_file("/etc/containerd").with_ensure("directory") }
+      it { is_expected.to contain_file("/etc/containerd").that_comes_before("File[/etc/containerd/config.toml]") }
     end
   end
 end

--- a/spec/classes/profile/cron_runner_spec.rb
+++ b/spec/classes/profile/cron_runner_spec.rb
@@ -3,34 +3,34 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::cron_runner' do
+describe "nebula::profile::cron_runner" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_nebula__usergroup('cron') }
-      it { is_expected.not_to contain_cron('delete old backups') }
+      it { is_expected.to contain_nebula__usergroup("cron") }
+      it { is_expected.not_to contain_cron("delete old backups") }
 
       context 'when given a "delete old backups" cronjob' do
         let(:params) do
           {
             crons: {
-              'delete old backups' => {
-                'command' => "/usr/bin/find /backups -mtime +60 -exec rm '{}' + > /dev/null 2>&1",
-                'user' => 'foo',
-                'minute' => 50,
-                'hour' => 5,
-                'environment' => ['MAILTO=default@invalid.example'],
-              },
-            },
+              "delete old backups" => {
+                "command" => "/usr/bin/find /backups -mtime +60 -exec rm '{}' + > /dev/null 2>&1",
+                "user" => "foo",
+                "minute" => 50,
+                "hour" => 5,
+                "environment" => ["MAILTO=default@invalid.example"]
+              }
+            }
           }
         end
 
         it { is_expected.to compile }
-        it { is_expected.to contain_cron('delete old backups') }
+        it { is_expected.to contain_cron("delete old backups") }
       end
     end
   end

--- a/spec/classes/profile/dns/aws_spec.rb
+++ b/spec/classes/profile/dns/aws_spec.rb
@@ -3,21 +3,21 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::dns::aws' do
+describe "nebula::profile::dns::aws" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.not_to contain_class('resolv_conf')   }
-      it { is_expected.to contain_exec('restart_networking') }
-      it { is_expected.to contain_file_line('domain_name') }
+      it { is_expected.not_to contain_class("resolv_conf") }
+      it { is_expected.to contain_exec("restart_networking") }
+      it { is_expected.to contain_file_line("domain_name") }
       # search_domain should match content of nebula::resolv_conf::searchpath
 
       it do
-        expect(subject).to contain_file_line('search_domain').with_line(
-          'supersede domain-search "searchpath.default.invalid";',
+        expect(subject).to contain_file_line("search_domain").with_line(
+          'supersede domain-search "searchpath.default.invalid";'
         )
       end
     end

--- a/spec/classes/profile/dns/smartconnect_spec.rb
+++ b/spec/classes/profile/dns/smartconnect_spec.rb
@@ -3,40 +3,40 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::dns::smartconnect' do
+describe "nebula::profile::dns::smartconnect" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
         expect(subject).to contain_package(
-          'nebula::profile::dns::smartconnect::bind9',
-        ).with_name('bind9').with_ensure('present')
+          "nebula::profile::dns::smartconnect::bind9"
+        ).with_name("bind9").with_ensure("present")
       end
 
       it do
-        expect(subject).to contain_service('bind9').with_ensure('running')
+        expect(subject).to contain_service("bind9").with_ensure("running")
       end
 
       it do
-        expect(subject).to contain_class('nebula::resolv_conf').with_nameservers(
+        expect(subject).to contain_class("nebula::resolv_conf").with_nameservers(
           [
-            '127.0.0.1',  # localhost
-            '5.5.5.5',    # nebula::resolv_conf::nameservers[0]
-            '4.4.4.4',    # nebula::resolv_conf::nameservers[1]
-          ],
-        ).with_searchpath(['searchpath.default.invalid'])
-                                                               .with_require('Service[bind9]')
+            "127.0.0.1",  # localhost
+            "5.5.5.5",    # nebula::resolv_conf::nameservers[0]
+            "4.4.4.4"    # nebula::resolv_conf::nameservers[1]
+          ]
+        ).with_searchpath(["searchpath.default.invalid"])
+          .with_require("Service[bind9]")
       end
 
-      it 'removes resolvconf package if present' do
-        expect(subject).to contain_package('resolvconf').with_ensure('absent')
+      it "removes resolvconf package if present" do
+        expect(subject).to contain_package("resolvconf").with_ensure("absent")
       end
 
-      it 'contains expected resolv.conf file' do
-        expect(subject).to contain_file('/etc/resolv.conf')
+      it "contains expected resolv.conf file" do
+        expect(subject).to contain_file("/etc/resolv.conf")
           .with_content(%r{^#.*puppet})
           .with_content(%r{^search searchpath\.default\.invalid$})
           .with_content(%r{^nameserver 127.0.0.1$})
@@ -45,18 +45,18 @@ describe 'nebula::profile::dns::smartconnect' do
       end
 
       [
-        '/etc/bind/named.conf',
-        '/etc/bind/named.conf.local',
-        '/etc/bind/named.conf.options',
+        "/etc/bind/named.conf",
+        "/etc/bind/named.conf.local",
+        "/etc/bind/named.conf.options"
       ].each do |name|
-        it { is_expected.to contain_file(name).with_notify('Service[bind9]') }
+        it { is_expected.to contain_file(name).with_notify("Service[bind9]") }
       end
 
       it do
-        expect(subject).to contain_file('/etc/bind/named.conf').with_content(
-          %r{/etc/bind/named.conf.options},
+        expect(subject).to contain_file("/etc/bind/named.conf").with_content(
+          %r{/etc/bind/named.conf.options}
         ).with_content(
-          %r{/etc/bind/named.conf.local},
+          %r{/etc/bind/named.conf.local}
         )
       end
 
@@ -65,34 +65,34 @@ describe 'nebula::profile::dns::smartconnect' do
         %r{^zone "127\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.127";$}m,
         %r{^zone "0\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.0";$}m,
         %r{^zone "255\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.255";$}m,
-        %r{^zone "smartconnect\.default\.invalid" \{[^\}]*type forward;[^\}]*forward only;[^\}]*1\.2\.3\.4;$}m,
+        %r{^zone "smartconnect\.default\.invalid" \{[^\}]*type forward;[^\}]*forward only;[^\}]*1\.2\.3\.4;$}m
       ].each do |content|
-        it { is_expected.to contain_file('/etc/bind/named.conf.local').with_content(content) }
+        it { is_expected.to contain_file("/etc/bind/named.conf.local").with_content(content) }
       end
 
       it do
-        expect(subject).to contain_file('/etc/bind/named.conf.options').with_content(
-          %r{^\s*5\.5\.5\.5; 4\.4\.4\.4;$},
+        expect(subject).to contain_file("/etc/bind/named.conf.options").with_content(
+          %r{^\s*5\.5\.5\.5; 4\.4\.4\.4;$}
         )
       end
 
-      context 'when given other_ns_ips' do
-        let(:params) { { other_ns_ips: ['3.3.3.3', '2.2.2.2', '1.1.1.1'] } }
+      context "when given other_ns_ips" do
+        let(:params) { {other_ns_ips: ["3.3.3.3", "2.2.2.2", "1.1.1.1"]} }
 
         it do
-          expect(subject).to contain_class('nebula::resolv_conf').with_nameservers(
+          expect(subject).to contain_class("nebula::resolv_conf").with_nameservers(
             [
-              '127.0.0.1',
-              '3.3.3.3',
-              '2.2.2.2',
-              '1.1.1.1',
-            ],
-          ).with_searchpath(['searchpath.default.invalid'])
+              "127.0.0.1",
+              "3.3.3.3",
+              "2.2.2.2",
+              "1.1.1.1"
+            ]
+          ).with_searchpath(["searchpath.default.invalid"])
         end
 
         it do
-          expect(subject).to contain_file('/etc/bind/named.conf.options').with_content(
-            %r{^\s*3\.3\.3\.3; 2\.2\.2\.2; 1\.1\.1\.1;$},
+          expect(subject).to contain_file("/etc/bind/named.conf.options").with_content(
+            %r{^\s*3\.3\.3\.3; 2\.2\.2\.2; 1\.1\.1\.1;$}
           )
         end
       end

--- a/spec/classes/profile/dns/standard_spec.rb
+++ b/spec/classes/profile/dns/standard_spec.rb
@@ -3,25 +3,25 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::dns::standard' do
+describe "nebula::profile::dns::standard" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_class('nebula::resolv_conf').with_nameservers(
-          ['5.5.5.5', '4.4.4.4'],
-        ).with_searchpath(['searchpath.default.invalid'])
+        expect(subject).to contain_class("nebula::resolv_conf").with_nameservers(
+          ["5.5.5.5", "4.4.4.4"]
+        ).with_searchpath(["searchpath.default.invalid"])
       end
 
-      it 'removes resolvconf package if present' do
-        expect(subject).to contain_package('resolvconf').with_ensure('absent')
+      it "removes resolvconf package if present" do
+        expect(subject).to contain_package("resolvconf").with_ensure("absent")
       end
 
-      it 'contains expected resolv.conf file' do
-        expect(subject).to contain_file('/etc/resolv.conf')
+      it "contains expected resolv.conf file" do
+        expect(subject).to contain_file("/etc/resolv.conf")
           .with_content(%r{^#.*puppet})
           .with_content(%r{^search searchpath\.default\.invalid$})
           .with_content(%r{^nameserver 5.5.5.5$})

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::docker' do
+describe "nebula::profile::docker" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -13,70 +13,70 @@ describe 'nebula::profile::docker' do
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_concat_file('cri daemon')
-          .with_path('/etc/docker/daemon.json')
-          .with_format('json')
-          .that_notifies('Exec[docker: systemctl daemon-reload]')
-          .that_requires('File[/etc/docker]')
+        expect(subject).to contain_concat_file("cri daemon")
+          .with_path("/etc/docker/daemon.json")
+          .with_format("json")
+          .that_notifies("Exec[docker: systemctl daemon-reload]")
+          .that_requires("File[/etc/docker]")
       end
 
-      it { is_expected.to contain_file('/etc/docker').with_ensure('directory') }
+      it { is_expected.to contain_file("/etc/docker").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/docker.service.d')
-          .with_ensure('directory')
-          .that_notifies('Exec[docker: systemctl daemon-reload]')
+        expect(subject).to contain_file("/etc/systemd/system/docker.service.d")
+          .with_ensure("directory")
+          .that_notifies("Exec[docker: systemctl daemon-reload]")
       end
 
       it do
-        expect(subject).to contain_exec('docker: systemctl daemon-reload')
-          .with_command('/bin/systemctl daemon-reload')
+        expect(subject).to contain_exec("docker: systemctl daemon-reload")
+          .with_command("/bin/systemctl daemon-reload")
           .with_refreshonly(true)
-          .that_notifies('Service[docker]')
+          .that_notifies("Service[docker]")
       end
 
-      it { is_expected.to contain_service('docker') }
+      it { is_expected.to contain_service("docker") }
 
       [
-        ['exec-opts', '["native.cgroupdriver=systemd"]'],
-        ['log-driver', '"json-file"'],
-        ['log-opts', '{"max-size":"100m"}'],
-        ['storage-driver', '"overlay2"'],
+        ["exec-opts", '["native.cgroupdriver=systemd"]'],
+        ["log-driver", '"json-file"'],
+        ["log-opts", '{"max-size":"100m"}'],
+        ["storage-driver", '"overlay2"']
       ].each do |key, value|
         it do
           expect(subject).to contain_concat_fragment("cri daemon #{key}")
-            .with_target('cri daemon')
+            .with_target("cri daemon")
             .with_content("{\"#{key}\":#{value}}")
         end
       end
 
-      it { is_expected.not_to contain_class('docker::compose') }
+      it { is_expected.not_to contain_class("docker::compose") }
 
-      context 'without version set' do
-        it { is_expected.to contain_class('docker').without_version }
-        it { is_expected.not_to contain_apt__pin('docker-ce') }
+      context "without version set" do
+        it { is_expected.to contain_class("docker").without_version }
+        it { is_expected.not_to contain_apt__pin("docker-ce") }
       end
 
-      context 'with version set to 5' do
-        let(:params) { { version: '5' } }
+      context "with version set to 5" do
+        let(:params) { {version: "5"} }
 
-        it { is_expected.to contain_class('docker').with_version('5') }
+        it { is_expected.to contain_class("docker").with_version("5") }
 
         it do
-          expect(subject).to contain_apt__pin('docker-ce').with(
+          expect(subject).to contain_apt__pin("docker-ce").with(
             packages: %w[docker-ce docker-ce-cli],
-            version: '5',
+            version: "5"
           )
         end
       end
 
-      context 'with docker_compose_version set to 1.7.0' do
-        let(:params) { { docker_compose_version: '1.7.0' } }
+      context "with docker_compose_version set to 1.7.0" do
+        let(:params) { {docker_compose_version: "1.7.0"} }
 
         it do
-          expect(subject).to contain_class('docker::compose')
-            .with_ensure('present')
-            .with_version('1.7.0')
+          expect(subject).to contain_class("docker::compose")
+            .with_ensure("present")
+            .with_version("1.7.0")
         end
       end
     end

--- a/spec/classes/profile/duo_spec.rb
+++ b/spec/classes/profile/duo_spec.rb
@@ -3,38 +3,38 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::duo' do
+describe "nebula::profile::duo" do
   def contain_pam_duo
-    contain_file('/etc/security/pam_duo.conf')
+    contain_file("/etc/security/pam_duo.conf")
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_package('sudo') }
-      it { is_expected.to contain_package('libpam-duo') }
+      it { is_expected.to contain_package("sudo") }
+      it { is_expected.to contain_package("libpam-duo") }
 
       it do
-        expect(subject).to contain_concat_fragment('/etc/pam.d/sshd: pam_duo')
-          .with_target('/etc/pam.d/sshd')
+        expect(subject).to contain_concat_fragment("/etc/pam.d/sshd: pam_duo")
+          .with_target("/etc/pam.d/sshd")
           .with_content(%r{auth required pam_duo.so})
       end
 
       it do
-        expect(subject).to contain_file_line('/etc/pam.d/sudo: pam_duo')
-          .with_path('/etc/pam.d/sudo')
-          .with_line('auth required pam_duo.so')
-          .with_after('^@include common-auth')
-          .that_requires(['Package[sudo]', 'Package[libpam-duo]'])
+        expect(subject).to contain_file_line("/etc/pam.d/sudo: pam_duo")
+          .with_path("/etc/pam.d/sudo")
+          .with_line("auth required pam_duo.so")
+          .with_after("^@include common-auth")
+          .that_requires(["Package[sudo]", "Package[libpam-duo]"])
       end
 
       it do
         expect(subject).to contain_pam_duo
-          .with_mode('0600')
-          .that_requires('Package[libpam-duo]')
+          .with_mode("0600")
+          .that_requires("Package[libpam-duo]")
       end
 
       [
@@ -42,20 +42,20 @@ describe 'nebula::profile::duo' do
         %r{^skey = skey\.default\.invalid$},
         %r{^host = host\.default\.invalid$},
         %r{^pushinfo = push\.default\.invalid$},
-        %r{^failmode = fail\.default\.invalid$},
+        %r{^failmode = fail\.default\.invalid$}
       ].each do |line|
         it { is_expected.to contain_pam_duo.with_content(line) }
       end
 
       [
-        [:ikey, 'REALIKEY'],
-        [:skey, 'REALSKEY'],
-        [:host, 'REALHOST'],
-        [:pushinfo, 'REALPUSH'],
-        [:failmode, 'REALFAIL'],
+        [:ikey, "REALIKEY"],
+        [:skey, "REALSKEY"],
+        [:host, "REALHOST"],
+        [:pushinfo, "REALPUSH"],
+        [:failmode, "REALFAIL"]
       ].each do |key, value|
         context "given a #{key} of #{value}" do
-          let(:params) { { key => value } }
+          let(:params) { {key => value} }
 
           it { is_expected.to contain_pam_duo.with_content(%r{^#{key} = #{value}$}) }
         end

--- a/spec/classes/profile/elastic/filebeat/configs/ulib_spec.rb
+++ b/spec/classes/profile/elastic/filebeat/configs/ulib_spec.rb
@@ -3,22 +3,22 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::elastic::filebeat::configs::ulib' do
+describe "nebula::profile::elastic::filebeat::configs::ulib" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:file) { '/etc/filebeat/configs/ulib.yml' }
+      let(:file) { "/etc/filebeat/configs/ulib.yml" }
 
-      context 'with params' do
-        let(:params) { { files: ['/var/log/1.log', '/var/log/logger/2.txt'] } }
+      context "with params" do
+        let(:params) { {files: ["/var/log/1.log", "/var/log/logger/2.txt"]} }
 
-        it { is_expected.to contain_service('filebeat') }
+        it { is_expected.to contain_service("filebeat") }
 
         it do
           expect(subject).to contain_file(file)
-            .that_notifies('Service[filebeat]')
+            .that_notifies("Service[filebeat]")
             .with_content(%r{^\s+ulib_type: 90_day$})
         end
 
@@ -26,7 +26,7 @@ describe 'nebula::profile::elastic::filebeat::configs::ulib' do
         it { is_expected.to contain_file(file).with_content(%r{^    - "/var/log/logger/2.txt"$}) }
       end
 
-      context 'without params' do
+      context "without params" do
         it "doesn't fail with no files specified" do
           expect(subject).to compile
         end

--- a/spec/classes/profile/elastic/filebeat_spec.rb
+++ b/spec/classes/profile/elastic/filebeat_spec.rb
@@ -21,7 +21,7 @@ describe "nebula::profile::elastic::filebeat" do
 
       it do
         expect(subject).to contain_file("/etc/filebeat/filebeat.yml").with(
-          ensure: "present",
+          ensure: "file",
           require: "Package[filebeat]",
           notify: "Service[filebeat]",
           mode: "0644"

--- a/spec/classes/profile/elastic/filebeat_spec.rb
+++ b/spec/classes/profile/elastic/filebeat_spec.rb
@@ -3,42 +3,42 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::elastic::filebeat' do
+describe "nebula::profile::elastic::filebeat" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_service('filebeat').with(
-          ensure: 'running',
-          enable: true,
+        expect(subject).to contain_service("filebeat").with(
+          ensure: "running",
+          enable: true
         )
       end
 
-      it { is_expected.to contain_package('filebeat') }
+      it { is_expected.to contain_package("filebeat") }
 
       it do
-        expect(subject).to contain_file('/etc/filebeat/filebeat.yml').with(
-          ensure: 'present',
-          require: 'Package[filebeat]',
-          notify: 'Service[filebeat]',
-          mode: '0644',
+        expect(subject).to contain_file("/etc/filebeat/filebeat.yml").with(
+          ensure: "present",
+          require: "Package[filebeat]",
+          notify: "Service[filebeat]",
+          mode: "0644"
         )
       end
 
       [
         %r{^\s*path: configs/\*.yml$},
-        %r{^\s*hosts:.*"logstash.umdl.umich.edu:5044"},
+        %r{^\s*hosts:.*"logstash.umdl.umich.edu:5044"}
       ].each do |content|
-        it { is_expected.to contain_file('/etc/filebeat/filebeat.yml').with_content(content) }
+        it { is_expected.to contain_file("/etc/filebeat/filebeat.yml").with_content(content) }
       end
 
       it do
-        expect(subject).to contain_file('/etc/filebeat/configs').with(
-          ensure: 'directory',
-          require: 'Package[filebeat]',
+        expect(subject).to contain_file("/etc/filebeat/configs").with(
+          ensure: "directory",
+          require: "Package[filebeat]"
         )
       end
     end

--- a/spec/classes/profile/elastic/metricbeat_spec.rb
+++ b/spec/classes/profile/elastic/metricbeat_spec.rb
@@ -3,47 +3,47 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::elastic::metricbeat' do
+describe "nebula::profile::elastic::metricbeat" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_service('metricbeat').with(
-          ensure: 'stopped',
-          enable: false,
+        expect(subject).to contain_service("metricbeat").with(
+          ensure: "stopped",
+          enable: false
         )
       end
 
-      it { is_expected.to contain_package('metricbeat') }
+      it { is_expected.to contain_package("metricbeat") }
 
-      it { is_expected.to contain_apt__source('elastic.co') }
+      it { is_expected.to contain_apt__source("elastic.co") }
 
       it do
-        expect(subject).to contain_file('/etc/metricbeat/metricbeat.yml').with(
-          ensure: 'present',
-          require: 'Package[metricbeat]',
-          notify: 'Service[metricbeat]',
-          mode: '0644',
+        expect(subject).to contain_file("/etc/metricbeat/metricbeat.yml").with(
+          ensure: "present",
+          require: "Package[metricbeat]",
+          notify: "Service[metricbeat]",
+          mode: "0644"
         )
       end
 
       [
         %r{^\s*- module: system$.*^\s*  period: 90s$}m,
         %r{^\s*  hosts: \[['"]logstash\.default\.invalid:1234['"]\]$},
-        %r{^\s*#ssl.certificate_authorities:},
+        %r{^\s*#ssl.certificate_authorities:}
       ].each do |content|
-        it { is_expected.to contain_file('/etc/metricbeat/metricbeat.yml').with_content(content) }
+        it { is_expected.to contain_file("/etc/metricbeat/metricbeat.yml").with_content(content) }
       end
 
       context 'with logstash_auth_cert => "/some/file.crt"' do
-        let(:params) { { logstash_auth_cert: '/some/file.crt' } }
+        let(:params) { {logstash_auth_cert: "/some/file.crt"} }
 
         it do
-          expect(subject).to contain_file('/etc/metricbeat/metricbeat.yml').with_content(
-            %r{^\s*  ssl\.certificate_authorities: \["/etc/ssl/certs/logstash-forwarder\.crt"\]$},
+          expect(subject).to contain_file("/etc/metricbeat/metricbeat.yml").with_content(
+            %r{^\s*  ssl\.certificate_authorities: \["/etc/ssl/certs/logstash-forwarder\.crt"\]$}
           )
         end
       end

--- a/spec/classes/profile/elastic/metricbeat_spec.rb
+++ b/spec/classes/profile/elastic/metricbeat_spec.rb
@@ -23,7 +23,7 @@ describe "nebula::profile::elastic::metricbeat" do
 
       it do
         expect(subject).to contain_file("/etc/metricbeat/metricbeat.yml").with(
-          ensure: "present",
+          ensure: "file",
           require: "Package[metricbeat]",
           notify: "Service[metricbeat]",
           mode: "0644"

--- a/spec/classes/profile/elastic_spec.rb
+++ b/spec/classes/profile/elastic_spec.rb
@@ -31,7 +31,7 @@ describe "nebula::profile::elastic" do
 
         it do
           expect(subject).to contain_file("/etc/ssl/certs/logstash-forwarder.crt").with(
-            ensure: "present",
+            ensure: "file",
             require: "File[/etc/ssl/certs]",
             mode: "0644",
             source: "puppet:///some/file.crt"

--- a/spec/classes/profile/elastic_spec.rb
+++ b/spec/classes/profile/elastic_spec.rb
@@ -3,55 +3,55 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::elastic' do
+describe "nebula::profile::elastic" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_apt__source('elastic.co').with(
-          comment: 'Elastic.co apt source for beats and elastic search',
-          location: 'https://artifacts.elastic.co/packages/7.x/apt',
-          release: 'stable',
-          repos: 'main',
+        expect(subject).to contain_apt__source("elastic.co").with(
+          comment: "Elastic.co apt source for beats and elastic search",
+          location: "https://artifacts.elastic.co/packages/7.x/apt",
+          release: "stable",
+          repos: "main",
           include: {
-            'src' => false,
-            'deb' => true,
-          },
+            "src" => false,
+            "deb" => true
+          }
         )
       end
 
-      it { is_expected.not_to contain_file('/etc/ssl/certs') }
-      it { is_expected.not_to contain_file('/etc/ssl/certs/logstash-forwarder.crt') }
+      it { is_expected.not_to contain_file("/etc/ssl/certs") }
+      it { is_expected.not_to contain_file("/etc/ssl/certs/logstash-forwarder.crt") }
 
       context 'with logstash_auth_cert => "/some/file.crt"' do
-        let(:params) { { logstash_auth_cert: '/some/file.crt' } }
+        let(:params) { {logstash_auth_cert: "/some/file.crt"} }
 
         it do
-          expect(subject).to contain_file('/etc/ssl/certs/logstash-forwarder.crt').with(
-            ensure: 'present',
-            require: 'File[/etc/ssl/certs]',
-            mode: '0644',
-            source: 'puppet:///some/file.crt',
+          expect(subject).to contain_file("/etc/ssl/certs/logstash-forwarder.crt").with(
+            ensure: "present",
+            require: "File[/etc/ssl/certs]",
+            mode: "0644",
+            source: "puppet:///some/file.crt"
           )
         end
 
         it do
-          expect(subject).to contain_file('/etc/ssl/certs').with(
-            ensure: 'directory',
-            mode: '0755',
+          expect(subject).to contain_file("/etc/ssl/certs").with(
+            ensure: "directory",
+            mode: "0755"
           )
         end
       end
 
       context 'with logstash_auth_cert => "/another/cert.crt"' do
-        let(:params) { { logstash_auth_cert: '/another/cert.crt' } }
+        let(:params) { {logstash_auth_cert: "/another/cert.crt"} }
 
         it do
-          expect(subject).to contain_file('/etc/ssl/certs/logstash-forwarder.crt').with(
-            source: 'puppet:///another/cert.crt',
+          expect(subject).to contain_file("/etc/ssl/certs/logstash-forwarder.crt").with(
+            source: "puppet:///another/cert.crt"
           )
         end
       end

--- a/spec/classes/profile/exim4_spec.rb
+++ b/spec/classes/profile/exim4_spec.rb
@@ -3,92 +3,92 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::exim4' do
+describe "nebula::profile::exim4" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:fqdn) { facts[:fqdn] }
 
       it do
-        expect(subject).to contain_service('exim4').with(
-          ensure: 'running',
+        expect(subject).to contain_service("exim4").with(
+          ensure: "running",
           enable: true,
-          require: 'Package[exim4]',
+          require: "Package[exim4]"
         )
       end
 
       [
-        '/etc/aliases',
-        '/etc/email-addresses',
+        "/etc/aliases",
+        "/etc/email-addresses"
       ].each do |filename|
         it do
           expect(subject).to contain_file_line("#{filename}: root email").with(
             path: filename,
-            match: '^root: ',
-            line: 'root: root@default.invalid',
-            notify: 'Exec[load new email aliases]',
-            require: 'Package[exim4]',
+            match: "^root: ",
+            line: "root: root@default.invalid",
+            notify: "Exec[load new email aliases]",
+            require: "Package[exim4]"
           )
         end
       end
 
-      context 'when given root_email of majordomo@email.gov' do
-        let(:params) { { root_email: 'majordomo@email.gov' } }
+      context "when given root_email of majordomo@email.gov" do
+        let(:params) { {root_email: "majordomo@email.gov"} }
 
         [
-          '/etc/aliases',
-          '/etc/email-addresses',
+          "/etc/aliases",
+          "/etc/email-addresses"
         ].each do |filename|
           it do
             expect(subject).to contain_file_line("#{filename}: root email").with(
               path: filename,
-              match: '^root: ',
-              line: 'root: majordomo@email.gov',
-              notify: 'Exec[load new email aliases]',
+              match: "^root: ",
+              line: "root: majordomo@email.gov",
+              notify: "Exec[load new email aliases]"
             )
           end
         end
       end
 
       it do
-        expect(subject).to contain_file('/etc/mailname')
+        expect(subject).to contain_file("/etc/mailname")
           .with_content("#{fqdn}\n")
-          .that_notifies('Exec[update exim4 config]')
+          .that_notifies("Exec[update exim4 config]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/exim4/update-exim4.conf.conf')
+        expect(subject).to contain_file("/etc/exim4/update-exim4.conf.conf")
           .with_content(%r{^dc_other_hostnames='#{fqdn}'$})
           .with_content(%r{^dc_relay_domains='exim\.default\.invalid'$})
-          .that_notifies('Exec[update exim4 config]')
-          .that_requires('Package[exim4]')
+          .that_notifies("Exec[update exim4 config]")
+          .that_requires("Package[exim4]")
       end
 
-      context 'when given a relay_domain of umich.edu' do
-        let(:params) { { relay_domain: 'umich.edu' } }
+      context "when given a relay_domain of umich.edu" do
+        let(:params) { {relay_domain: "umich.edu"} }
 
         it do
-          expect(subject).to contain_file('/etc/exim4/update-exim4.conf.conf')
+          expect(subject).to contain_file("/etc/exim4/update-exim4.conf.conf")
             .with_content(%r{^dc_relay_domains='umich\.edu'$})
         end
       end
 
-      it { is_expected.to contain_package('exim4') }
+      it { is_expected.to contain_package("exim4") }
 
       it do
-        expect(subject).to contain_exec('load new email aliases').with(
-          command: '/usr/bin/newaliases',
-          refreshonly: true,
+        expect(subject).to contain_exec("load new email aliases").with(
+          command: "/usr/bin/newaliases",
+          refreshonly: true
         )
       end
 
       it do
-        expect(subject).to contain_exec('update exim4 config').with(
-          command: '/usr/sbin/update-exim4.conf',
+        expect(subject).to contain_exec("update exim4 config").with(
+          command: "/usr/sbin/update-exim4.conf",
           refreshonly: true,
-          notify: 'Service[exim4]',
+          notify: "Service[exim4]"
         )
       end
     end

--- a/spec/classes/profile/falcon_spec.rb
+++ b/spec/classes/profile/falcon_spec.rb
@@ -3,34 +3,34 @@
 # Copyright (c) 2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::falcon' do
+describe "nebula::profile::falcon" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with cid set to mycid' do
-        let(:params) { { cid: 'mycid' } }
+      context "with cid set to mycid" do
+        let(:params) { {cid: "mycid"} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_package('falcon-sensor') }
-        it { is_expected.to contain_service('falcon-sensor').with_ensure('running') }
+        it { is_expected.to contain_package("falcon-sensor") }
+        it { is_expected.to contain_service("falcon-sensor").with_ensure("running") }
 
         it do
-          expect(subject).to contain_exec('set falcon-sensor CID')
+          expect(subject).to contain_exec("set falcon-sensor CID")
             .with_command("/opt/CrowdStrike/falconctl -s '--cid=mycid'")
-            .with_unless('/opt/CrowdStrike/falconctl -g --cid')
-            .that_requires('Package[falcon-sensor]')
-            .that_notifies('Service[falcon-sensor]')
+            .with_unless("/opt/CrowdStrike/falconctl -g --cid")
+            .that_requires("Package[falcon-sensor]")
+            .that_notifies("Service[falcon-sensor]")
         end
       end
 
-      context 'with cid set to somethingelse' do
-        let(:params) { { cid: 'somethingelse' } }
+      context "with cid set to somethingelse" do
+        let(:params) { {cid: "somethingelse"} }
 
         it do
-          expect(subject).to contain_exec('set falcon-sensor CID')
+          expect(subject).to contain_exec("set falcon-sensor CID")
             .with_command("/opt/CrowdStrike/falconctl -s '--cid=somethingelse'")
         end
       end

--- a/spec/classes/profile/fulcrum/base_spec.rb
+++ b/spec/classes/profile/fulcrum/base_spec.rb
@@ -3,44 +3,44 @@
 # Copyright (c) 2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::fulcrum::base' do
+describe "nebula::profile::fulcrum::base" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      context 'with default uid and gid' do
+      context "with default uid and gid" do
         it do
-          expect(subject).to contain_user('fulcrum')
+          expect(subject).to contain_user("fulcrum")
             .with(uid: 717)
             .with(gid: 717)
         end
 
         it do
-          expect(subject).to contain_group('fulcrum')
+          expect(subject).to contain_group("fulcrum")
             .with(gid: 717)
         end
       end
 
-      context 'with a uid and gid specified' do
+      context "with a uid and gid specified" do
         let(:params) do
           {
             uid: 1001,
-            gid: 1001,
+            gid: 1001
           }
         end
 
         it do
-          expect(subject).to contain_user('fulcrum')
+          expect(subject).to contain_user("fulcrum")
             .with(uid: 1001)
             .with(gid: 1001)
         end
 
         it do
-          expect(subject).to contain_group('fulcrum')
+          expect(subject).to contain_group("fulcrum")
             .with(gid: 1001)
         end
       end

--- a/spec/classes/profile/fulcrum/logrotate_spec.rb
+++ b/spec/classes/profile/fulcrum/logrotate_spec.rb
@@ -3,30 +3,30 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::fulcrum::logrotate' do
+describe "nebula::profile::fulcrum::logrotate" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('Nebula::Profile::Logrotate') }
+      it { is_expected.to contain_class("Nebula::Profile::Logrotate") }
 
       it do
-        expect(subject).to contain_logrotate__rule('fulcrum')
-          .with_path('/fulcrum/app/shared/log/*.log')
+        expect(subject).to contain_logrotate__rule("fulcrum")
+          .with_path("/fulcrum/app/shared/log/*.log")
           .with_rotate(7)
-          .with_rotate_every('day')
+          .with_rotate_every("day")
           .with_missingok(true)
           .with_compress(true)
           .with_ifempty(false)
           .with_delaycompress(true)
           .with_copytruncate(true)
           .with_su(true)
-          .with_su_user('fulcrum')
-          .with_su_group('fulcrum')
+          .with_su_user("fulcrum")
+          .with_su_group("fulcrum")
       end
     end
   end

--- a/spec/classes/profile/github_pull_account_spec.rb
+++ b/spec/classes/profile/github_pull_account_spec.rb
@@ -3,22 +3,22 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::github_pull_account' do
+describe "nebula::profile::github_pull_account" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_user('git').with_home('/var/lib/autogit') }
-      it { is_expected.to contain_user('git').with_gid(100) }
-      it { is_expected.to contain_user('git').with_managehome(true) }
-      it { is_expected.to contain_file('/var/lib/autogit/.ssh').with_ensure('directory') }
-      it { is_expected.to contain_file('/var/lib/autogit/.ssh').with_mode('0700') }
-      it { is_expected.to contain_exec('create /var/lib/autogit/.ssh/id_ecdsa') }
-      it { is_expected.to contain_exec('create /var/local/github_ssh_keys') }
-      it { is_expected.to contain_concat_fragment('github ssh keys').with_target('/etc/ssh/ssh_known_hosts') }
+      it { is_expected.to contain_user("git").with_home("/var/lib/autogit") }
+      it { is_expected.to contain_user("git").with_gid(100) }
+      it { is_expected.to contain_user("git").with_managehome(true) }
+      it { is_expected.to contain_file("/var/lib/autogit/.ssh").with_ensure("directory") }
+      it { is_expected.to contain_file("/var/lib/autogit/.ssh").with_mode("0700") }
+      it { is_expected.to contain_exec("create /var/lib/autogit/.ssh/id_ecdsa") }
+      it { is_expected.to contain_exec("create /var/local/github_ssh_keys") }
+      it { is_expected.to contain_concat_fragment("github ssh keys").with_target("/etc/ssh/ssh_known_hosts") }
     end
   end
 end

--- a/spec/classes/profile/groups_spec.rb
+++ b/spec/classes/profile/groups_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::groups' do
+describe "nebula::profile::groups" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/usergroups_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/usergroups_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_group('examplegroup1').with_gid(1234) }
-      it { is_expected.to contain_group('examplegroup2').with_gid(2468) }
+      it { is_expected.to contain_group("examplegroup1").with_gid(1234) }
+      it { is_expected.to contain_group("examplegroup2").with_gid(2468) }
 
-      context 'when given different_group with a gid of 2358' do
-        let(:params) { { all_groups: { 'different_group' => 2358 } } }
+      context "when given different_group with a gid of 2358" do
+        let(:params) { {all_groups: {"different_group" => 2358}} }
 
-        it { is_expected.not_to contain_group('examplegroup1') }
-        it { is_expected.to contain_group('different_group').with_gid(2358) }
+        it { is_expected.not_to contain_group("examplegroup1") }
+        it { is_expected.to contain_group("different_group").with_gid(2358) }
       end
     end
   end

--- a/spec/classes/profile/grub_spec.rb
+++ b/spec/classes/profile/grub_spec.rb
@@ -3,76 +3,76 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::grub' do
+describe "nebula::profile::grub" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'when on a kvm vm' do
-        let(:facts) { super().merge(is_virtual: true, virtual: 'kvm') }
+      context "when on a kvm vm" do
+        let(:facts) { super().merge(is_virtual: true, virtual: "kvm") }
 
         [
-          ['^GRUB_CMDLINE_LINUX', 'GRUB_CMDLINE_LINUX="console=tty0 console=hvc0,9600n8"'],
-          ['^GRUB_CMDLINE_LINUX_DEFAULT', 'GRUB_CMDLINE_LINUX_DEFAULT=""'],
-          ['^#?GRUB_SERIAL_COMMAND', 'GRUB_SERIAL_COMMAND="serial --unit=0 --speed=9600"'],
-          ['^#?GRUB_TERMINAL', 'GRUB_TERMINAL=serial'],
+          ["^GRUB_CMDLINE_LINUX", 'GRUB_CMDLINE_LINUX="console=tty0 console=hvc0,9600n8"'],
+          ["^GRUB_CMDLINE_LINUX_DEFAULT", 'GRUB_CMDLINE_LINUX_DEFAULT=""'],
+          ["^#?GRUB_SERIAL_COMMAND", 'GRUB_SERIAL_COMMAND="serial --unit=0 --speed=9600"'],
+          ["^#?GRUB_TERMINAL", "GRUB_TERMINAL=serial"]
         ].each do |match, line|
           it do
             expect(subject).to contain_file_line("/etc/default/grub: #{match}").with(
-              path: '/etc/default/grub',
+              path: "/etc/default/grub",
               line: line,
               match: "#{match}=",
-              notify: 'Exec[/usr/sbin/update-grub]',
-              before: 'Service[getty@hvc0]',
+              notify: "Exec[/usr/sbin/update-grub]",
+              before: "Service[getty@hvc0]"
             )
           end
         end
 
         it do
-          expect(subject).to contain_service('getty@hvc0').with(
-            ensure: 'running',
-            enable: true,
+          expect(subject).to contain_service("getty@hvc0").with(
+            ensure: "running",
+            enable: true
           )
         end
       end
 
       [
-        [true, 'virtbox', 'on a virtbox vm'],
-        [false, 'kvm', 'on a somehow-physical kvm machine'],
-        [false, 'physical', 'on a physical machine'],
+        [true, "virtbox", "on a virtbox vm"],
+        [false, "kvm", "on a somehow-physical kvm machine"],
+        [false, "physical", "on a physical machine"]
       ].each do |isvirt, virt, desc|
         context desc do
           let(:facts) { super().merge(is_virtual: isvirt, virtual: virt) }
 
           [
-            ['^GRUB_CMDLINE_LINUX', 'GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8 ixgbe.allow_unsupported_sfp=1"'],
-            ['^GRUB_CMDLINE_LINUX_DEFAULT', 'GRUB_CMDLINE_LINUX_DEFAULT=""'],
-            ['^#?GRUB_TERMINAL', 'GRUB_TERMINAL=console'],
+            ["^GRUB_CMDLINE_LINUX", 'GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8 ixgbe.allow_unsupported_sfp=1"'],
+            ["^GRUB_CMDLINE_LINUX_DEFAULT", 'GRUB_CMDLINE_LINUX_DEFAULT=""'],
+            ["^#?GRUB_TERMINAL", "GRUB_TERMINAL=console"]
           ].each do |match, line|
             it do
               expect(subject).to contain_file_line("/etc/default/grub: #{match}").with(
-                path: '/etc/default/grub',
+                path: "/etc/default/grub",
                 line: line,
                 match: "#{match}=",
-                notify: 'Exec[/usr/sbin/update-grub]',
-                before: 'Service[serial-getty@ttyS1]',
+                notify: "Exec[/usr/sbin/update-grub]",
+                before: "Service[serial-getty@ttyS1]"
               )
             end
           end
 
           it do
-            expect(subject).to contain_service('serial-getty@ttyS1').with(
-              ensure: 'running',
-              enable: true,
+            expect(subject).to contain_service("serial-getty@ttyS1").with(
+              ensure: "running",
+              enable: true
             )
           end
         end
       end
 
       it do
-        expect(subject).to contain_exec('/usr/sbin/update-grub')
+        expect(subject).to contain_exec("/usr/sbin/update-grub")
           .with_refreshonly(true)
       end
     end

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -3,349 +3,349 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::haproxy' do
+describe "nebula::profile::haproxy" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:my_ip) { Faker::Internet.ip_v4_address }
 
       let(:facts) do
         os_facts.merge(
-          datacenter: 'somedc',
+          datacenter: "somedc",
           networking: {
             ip: my_ip,
-            primary: 'eth0',
-            hostname: 'thisnode',
+            primary: "eth0",
+            hostname: "thisnode"
           },
-          ipaddress: 'INVALID_DO_NOT_USE',
-          hostname: 'INVALID_DO_NOT_USE',
+          ipaddress: "INVALID_DO_NOT_USE",
+          hostname: "INVALID_DO_NOT_USE"
         )
       end
 
-      let(:default_file) { '/etc/default/haproxy' }
-      let(:haproxy_conf) { '/etc/haproxy/haproxy.cfg' }
-      let(:keepalived_conf) { '/etc/keepalived/keepalived.conf' }
-      let(:service) { 'keepalived' }
+      let(:default_file) { "/etc/default/haproxy" }
+      let(:haproxy_conf) { "/etc/haproxy/haproxy.cfg" }
+      let(:keepalived_conf) { "/etc/keepalived/keepalived.conf" }
+      let(:service) { "keepalived" }
 
-      let(:thisnode) { { 'ip' => facts[:networking][:ip], 'hostname' => facts[:hostname] } }
+      let(:thisnode) { {"ip" => facts[:networking][:ip], "hostname" => facts[:hostname]} }
       let(:base_params) do
         {
-          cert_source: '/some/where',
+          cert_source: "/some/where",
           services: {
-            'svc1' => {
-              'floating_ip' => '12.23.32.22',
-              'max_requests_per_sec' => 10,
-              'max_requests_burst' => 200,
+            "svc1" => {
+              "floating_ip" => "12.23.32.22",
+              "max_requests_per_sec" => 10,
+              "max_requests_burst" => 200
             },
-            'svc2' => {
-              'floating_ip' => '12.23.32.23',
+            "svc2" => {
+              "floating_ip" => "12.23.32.23"
             },
-            'svc3' => {
+            "svc3" => {
               # no floating IP, shouldn't be defined here
-              'max_requests_per_sec' => 10,
-              'max_requests_burst' => 200,
-            },
-          },
+              "max_requests_per_sec" => 10,
+              "max_requests_burst" => 200
+            }
+          }
         }
       end
       let(:params) { base_params }
 
-      describe 'services' do
+      describe "services" do
         # haproxy services are virtual resources which get realized by the
         # balanced_frontend type; realize them here so we can test params
         let :pre_condition do
-          'Nebula::Haproxy::Service<| |>'
+          "Nebula::Haproxy::Service<| |>"
         end
 
         it do
-          expect(subject).to contain_service('haproxy').with(
-            ensure: 'running',
+          expect(subject).to contain_service("haproxy").with(
+            ensure: "running",
             enable: true,
-            restart: '/bin/systemctl reload haproxy',
+            restart: "/bin/systemctl reload haproxy"
           )
         end
 
         it do
-          expect(subject).to contain_exec('check haproxy config').with(
-            command: "/usr/sbin/haproxy -f #{haproxy_conf} -c -q -f /etc/haproxy/services.d",
+          expect(subject).to contain_exec("check haproxy config").with(
+            command: "/usr/sbin/haproxy -f #{haproxy_conf} -c -q -f /etc/haproxy/services.d"
           )
         end
 
         it do
-          expect(subject).to contain_nebula__haproxy__service('svc1').with(
-            floating_ip: '12.23.32.22',
-            cert_source: '/some/where',
+          expect(subject).to contain_nebula__haproxy__service("svc1").with(
+            floating_ip: "12.23.32.22",
+            cert_source: "/some/where",
             max_requests_per_sec: 10,
-            max_requests_burst: 200,
+            max_requests_burst: 200
           )
         end
 
         it do
-          expect(subject).to contain_nebula__haproxy__service('svc2').with(
-            floating_ip: '12.23.32.23',
-            cert_source: '/some/where',
+          expect(subject).to contain_nebula__haproxy__service("svc2").with(
+            floating_ip: "12.23.32.23",
+            cert_source: "/some/where"
           )
         end
 
-        it { is_expected.not_to contain_nebula__haproxy__service('svc3') }
+        it { is_expected.not_to contain_nebula__haproxy__service("svc3") }
       end
 
-      describe 'packages' do
-        it { is_expected.to contain_package('haproxy') }
-        it { is_expected.to contain_package('haproxyctl') }
-        it { is_expected.to contain_package('keepalived') }
-        it { is_expected.to contain_package('ipset') }
+      describe "packages" do
+        it { is_expected.to contain_package("haproxy") }
+        it { is_expected.to contain_package("haproxyctl") }
+        it { is_expected.to contain_package("keepalived") }
+        it { is_expected.to contain_package("ipset") }
       end
 
-      describe 'users' do
+      describe "users" do
         it do
-          expect(subject).to contain_user('haproxyctl').with(
-            name: 'haproxyctl',
-            gid: 'haproxy',
+          expect(subject).to contain_user("haproxyctl").with(
+            name: "haproxyctl",
+            gid: "haproxy",
             managehome: true,
-            home: '/var/haproxyctl',
+            home: "/var/haproxyctl"
           )
         end
 
         it do
-          expect(subject).to contain_nebula__authzd_user('haproxyctl')
-            .that_requires(['Package[haproxy]', 'Package[haproxyctl]'])
+          expect(subject).to contain_nebula__authzd_user("haproxyctl")
+            .that_requires(["Package[haproxy]", "Package[haproxyctl]"])
         end
 
-        it 'grants ssh access to the monitoring user' do
-          expect(subject).to contain_file('/var/haproxyctl/.ssh/authorized_keys')
+        it "grants ssh access to the monitoring user" do
+          expect(subject).to contain_file("/var/haproxyctl/.ssh/authorized_keys")
             .with_content(%r{^ecdsa-sha2-nistp256 CCCCCCCCCCCC haproxyctl@default\.invalid$})
         end
       end
 
-      describe 'service' do
-        it { is_expected.to contain_service(service).that_requires('Package[keepalived]') }
+      describe "service" do
+        it { is_expected.to contain_service(service).that_requires("Package[keepalived]") }
         it { is_expected.to contain_service(service).with(enable: true) }
-        it { is_expected.to contain_service(service).with(ensure: 'running') }
+        it { is_expected.to contain_service(service).with(ensure: "running") }
       end
 
-      describe 'haproxy default file' do
+      describe "haproxy default file" do
         let(:file) { default_file }
 
-        it { is_expected.to contain_file(file).with(ensure: 'present') }
-        it { is_expected.to contain_file(file).with(require: 'Package[haproxy]') }
-        it { is_expected.to contain_file(file).with(notify: 'Service[haproxy]') }
-        it { is_expected.to contain_file(file).with(mode: '0644') }
+        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
+        it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
+        it { is_expected.to contain_file(file).with(mode: "0644") }
 
-        it 'says it is managed by puppet' do
+        it "says it is managed by puppet" do
           expect(subject).to contain_file(file).with_content(
-            %r{\A# Managed by puppet \(nebula/profile/haproxy/default\.erb\)\n},
+            %r{\A# Managed by puppet \(nebula/profile/haproxy/default\.erb\)\n}
           )
         end
 
-        it 'sets $CONFIG to the base config' do
+        it "sets $CONFIG to the base config" do
           expect(subject).to contain_file(file).with_content(%r{^CONFIG="#{haproxy_conf}"\n})
         end
 
-        it 'sets $EXTRAOPTS to include the service directory' do
+        it "sets $EXTRAOPTS to include the service directory" do
           expect(subject).to contain_file(file).with_content(
-            %r{EXTRAOPTS="-f /etc/haproxy/services.d"\n},
+            %r{EXTRAOPTS="-f /etc/haproxy/services.d"\n}
           )
         end
       end
 
-      describe 'Cloudflare proxy IP ranges' do
-        it 'saves Cloudflare trusted ranges in /etc/haproxy' do
-          expect(subject).to contain_file('/etc/haproxy/cloudflare-ipv4.txt')
-            .with_source('https://www.cloudflare.com/ips-v4')
+      describe "Cloudflare proxy IP ranges" do
+        it "saves Cloudflare trusted ranges in /etc/haproxy" do
+          expect(subject).to contain_file("/etc/haproxy/cloudflare-ipv4.txt")
+            .with_source("https://www.cloudflare.com/ips-v4")
         end
       end
 
-      describe 'global_badrobots.txt file' do
-        it 'lists ips to block' do
-          expect(subject).to contain_file('/etc/haproxy/global_badrobots.txt').with_content("1.2.3.0/24\n5.6.7.8\n")
+      describe "global_badrobots.txt file" do
+        it "lists ips to block" do
+          expect(subject).to contain_file("/etc/haproxy/global_badrobots.txt").with_content("1.2.3.0/24\n5.6.7.8\n")
         end
       end
 
-      describe 'base haproxy config file' do
+      describe "base haproxy config file" do
         let(:file) { haproxy_conf }
 
-        it { is_expected.to contain_file(file).with(ensure: 'present') }
-        it { is_expected.to contain_file(file).with(require: 'Package[haproxy]') }
-        it { is_expected.to contain_file(file).with(notify: 'Service[haproxy]') }
-        it { is_expected.to contain_file(file).with(mode: '0644') }
-        it { is_expected.to contain_file('/etc/haproxy/services.d').with(ensure: 'directory') }
+        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
+        it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
+        it { is_expected.to contain_file(file).with(mode: "0644") }
+        it { is_expected.to contain_file("/etc/haproxy/services.d").with(ensure: "directory") }
 
-        it 'says it is managed by puppet' do
+        it "says it is managed by puppet" do
           expect(subject).to contain_file(file).with_content(
-            %r{\A# Managed by puppet \(nebula/profile/haproxy/haproxy\.cfg\.erb\)\n},
+            %r{\A# Managed by puppet \(nebula/profile/haproxy/haproxy\.cfg\.erb\)\n}
           )
         end
 
-        it 'has a global section' do
+        it "has a global section" do
           expect(subject).to contain_file(file).with_content(%r{^global\n})
         end
 
-        it 'has a defaults section' do
+        it "has a defaults section" do
           expect(subject).to contain_file(file).with_content(%r{^defaults\n})
         end
 
-        it 'does not have a backend section' do
+        it "does not have a backend section" do
           expect(subject).not_to contain_file(file).with_content(%r{^backend\W+.*\n})
         end
 
-        it 'does not have a frontend section' do
+        it "does not have a frontend section" do
           expect(subject).not_to contain_file(file).with_content(%r{^frontend\W+.*\n})
         end
 
-        it 'configures the admin socket in the correct place with group privileges' do
+        it "configures the admin socket in the correct place with group privileges" do
           expect(subject).to contain_file(file).with_content(%r{stats socket /run/haproxy/admin.sock mode 660 level admin})
         end
 
-        it 'runs with the haproxy group' do
+        it "runs with the haproxy group" do
           expect(subject).to contain_file(file).with_content(%r{group haproxy})
         end
       end
 
-      describe 'haproxy errors' do
-        it { is_expected.to contain_file('/etc/haproxy/errors/hsts400.http').with_source('puppet:///modules/nebula/haproxy/errors/hsts400.http') }
+      describe "haproxy errors" do
+        it { is_expected.to contain_file("/etc/haproxy/errors/hsts400.http").with_source("puppet:///modules/nebula/haproxy/errors/hsts400.http") }
       end
 
-      describe 'base keepalived config file' do
+      describe "base keepalived config file" do
         let(:file) { keepalived_conf }
 
         it do
           expect(subject).to contain_concat(file).with(
-            ensure: 'present',
-            require: 'Package[keepalived]',
-            notify: 'Service[keepalived]',
-            mode: '0644',
+            ensure: "present",
+            require: "Package[keepalived]",
+            notify: "Service[keepalived]",
+            mode: "0644"
           )
         end
 
-        it { is_expected.to contain_concat_fragment('keepalived preamble').with_target(keepalived_conf) }
+        it { is_expected.to contain_concat_fragment("keepalived preamble").with_target(keepalived_conf) }
 
-        it 'has a vrrp_scripts check_haproxy section' do
-          expect(subject).to contain_concat_fragment('keepalived preamble').with_content(%r{^vrrp_script check_haproxy})
+        it "has a vrrp_scripts check_haproxy section" do
+          expect(subject).to contain_concat_fragment("keepalived preamble").with_content(%r{^vrrp_script check_haproxy})
         end
 
-        it 'has the haproxy floating ip addresses' do
-          expect(subject).to contain_concat_fragment('keepalived preamble').with_content(%r{virtual_ipaddress {\n\s*12\.23\.32\.22\n\s*12\.23\.32\.23\n\s*}}m)
+        it "has the haproxy floating ip addresses" do
+          expect(subject).to contain_concat_fragment("keepalived preamble").with_content(%r{virtual_ipaddress {\n\s*12\.23\.32\.22\n\s*12\.23\.32\.23\n\s*}}m)
         end
 
-        context 'with a floating ip address parameter' do
+        context "with a floating ip address parameter" do
           let(:params) do
             {
-              services: { 'svc1' => { 'floating_ip' => Faker::Internet.ip_v4_address },
-                          'svc2' => { 'floating_ip' => Faker::Internet.ip_v4_address } },
+              services: {"svc1" => {"floating_ip" => Faker::Internet.ip_v4_address},
+                         "svc2" => {"floating_ip" => Faker::Internet.ip_v4_address}}
             }
           end
 
           it do
-            expect(subject).to contain_concat_fragment('keepalived preamble')
+            expect(subject).to contain_concat_fragment("keepalived preamble")
               .with_content(%r{virtual_ipaddress {\n\s*#{params[:services]["svc1"]["floating_ip"]}\n\s*#{params[:services]["svc2"]["floating_ip"]}\n\s*}}m)
           end
         end
 
-        context 'with an extra_floating_ip set to 10.0.1.2' do
+        context "with an extra_floating_ip set to 10.0.1.2" do
           let(:params) do
-            { extra_floating_ips: { 'extra' => '10.0.1.2' } }
+            {extra_floating_ips: {"extra" => "10.0.1.2"}}
           end
 
           it do
-            expect(subject).to contain_concat_fragment('keepalived preamble')
+            expect(subject).to contain_concat_fragment("keepalived preamble")
               .with_content(%r{virtual_ipaddress {\n\s*10\.0\.1\.2\n\s*}}m)
           end
         end
 
-        it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{unicast_src_ip #{my_ip}}) }
+        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{unicast_src_ip #{my_ip}}) }
 
-        it 'exports its IP address for collection by other haproxy nodes' do
-          expect(exported_resources).to contain_concat_fragment('keepalived node ip thisnode').with(
+        it "exports its IP address for collection by other haproxy nodes" do
+          expect(exported_resources).to contain_concat_fragment("keepalived node ip thisnode").with(
             target: keepalived_conf,
             content: "    #{my_ip}\n",
-            tag: 'keepalived-haproxy-ip-somedc',
+            tag: "keepalived-haproxy-ip-somedc"
           )
         end
 
-        it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{interface #{facts[:networking][:primary]}}) }
+        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{interface #{facts[:networking][:primary]}}) }
 
-        it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{notification_email {\n\s.*root@default.invalid\n\s.*}}m) }
-        it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{notification_email_from root@default.invalid}) }
+        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{notification_email {\n\s.*root@default.invalid\n\s.*}}m) }
+        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{notification_email_from root@default.invalid}) }
 
-        context 'when on a master node' do
+        context "when on a master node" do
           let(:params) { base_params.merge(master: true) }
 
-          it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{priority 101}) }
-          it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{state MASTER}) }
+          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 101}) }
+          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{state MASTER}) }
 
           it do
-            expect(subject).to contain_class('Nebula::Profile::Prometheus::Exporter::Haproxy')
+            expect(subject).to contain_class("Nebula::Profile::Prometheus::Exporter::Haproxy")
               .with_master(true)
           end
         end
 
-        context 'when on a backup node' do
+        context "when on a backup node" do
           let(:params) { base_params.merge(master: false) }
 
-          it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{priority 100}) }
-          it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(%r{state BACKUP}) }
+          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 100}) }
+          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{state BACKUP}) }
 
           it do
-            expect(subject).to contain_class('Nebula::Profile::Prometheus::Exporter::Haproxy')
+            expect(subject).to contain_class("Nebula::Profile::Prometheus::Exporter::Haproxy")
               .with_master(false)
           end
         end
       end
 
-      describe 'sysctl conf' do
-        let(:file) { '/etc/sysctl.d/keepalived.conf' }
+      describe "sysctl conf" do
+        let(:file) { "/etc/sysctl.d/keepalived.conf" }
 
-        it { is_expected.to contain_file(file).with(ensure: 'present') }
-        it { is_expected.to contain_file(file).with(mode: '0644') }
+        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(mode: "0644") }
 
-        it 'says it is managed by puppet' do
+        it "says it is managed by puppet" do
           expect(subject).to contain_file(file).with_content(
-            %r{\A# Managed by puppet},
+            %r{\A# Managed by puppet}
           )
         end
 
-        it 'enables ip_nonlocal_bind' do
+        it "enables ip_nonlocal_bind" do
           expect(subject).to contain_file(file).with_content(%r{^net.ipv4.ip_nonlocal_bind = 1$})
         end
       end
 
-      it 'exports a firewall resource tagged haproxy' do
-        expect(exported_resources).to contain_firewall('200 HTTP: HAProxy thisnode').with(
+      it "exports a firewall resource tagged haproxy" do
+        expect(exported_resources).to contain_firewall("200 HTTP: HAProxy thisnode").with(
           source: my_ip,
-          tag: 'somedc_haproxy',
+          tag: "somedc_haproxy"
         )
       end
 
-      describe 'metrics' do
-        it 'defines haproxy stats file' do
-          expect(subject).to contain_file('/etc/haproxy/services.d/stats.cfg')
-            .that_requires('Package[haproxy]')
-            .that_notifies('Service[haproxy]')
+      describe "metrics" do
+        it "defines haproxy stats file" do
+          expect(subject).to contain_file("/etc/haproxy/services.d/stats.cfg")
+            .that_requires("Package[haproxy]")
+            .that_notifies("Service[haproxy]")
         end
       end
 
-      describe 'server monitoring / dynamic weighting' do
-        it 'includes the private key' do
-          expect(subject).to contain_file('/var/haproxyctl/.ssh/id_ecdsa')
+      describe "server monitoring / dynamic weighting" do
+        it "includes the private key" do
+          expect(subject).to contain_file("/var/haproxyctl/.ssh/id_ecdsa")
         end
 
-        it 'includes the monitoring script' do
-          expect(subject).to contain_file('/usr/local/bin/set_weights.rb')
+        it "includes the monitoring script" do
+          expect(subject).to contain_file("/usr/local/bin/set_weights.rb")
         end
       end
 
-      describe 'log rotation' do
-        let(:rotate_logs) { contain_logrotate__rule('haproxy') }
+      describe "log rotation" do
+        let(:rotate_logs) { contain_logrotate__rule("haproxy") }
 
-        it { is_expected.to rotate_logs.with_path('/var/log/haproxy.log') }
-        it { is_expected.to rotate_logs.with_rotate_every('day') }
+        it { is_expected.to rotate_logs.with_path("/var/log/haproxy.log") }
+        it { is_expected.to rotate_logs.with_rotate_every("day") }
         it { is_expected.to rotate_logs.with_rotate(5) }
         it { is_expected.to rotate_logs.with_missingok(true) }
         it { is_expected.to rotate_logs.with_ifempty(false) }
         it { is_expected.to rotate_logs.with_compress(true) }
-        it { is_expected.to rotate_logs.with_postrotate(['/usr/lib/rsyslog/rsyslog-rotate', '/bin/systemctl restart filebeat']) }
+        it { is_expected.to rotate_logs.with_postrotate(["/usr/lib/rsyslog/rsyslog-rotate", "/bin/systemctl restart filebeat"]) }
       end
     end
   end

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -128,7 +128,7 @@ describe "nebula::profile::haproxy" do
       describe "haproxy default file" do
         let(:file) { default_file }
 
-        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(ensure: "file") }
         it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
         it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
         it { is_expected.to contain_file(file).with(mode: "0644") }
@@ -166,7 +166,7 @@ describe "nebula::profile::haproxy" do
       describe "base haproxy config file" do
         let(:file) { haproxy_conf }
 
-        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(ensure: "file") }
         it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
         it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
         it { is_expected.to contain_file(file).with(mode: "0644") }
@@ -297,7 +297,7 @@ describe "nebula::profile::haproxy" do
       describe "sysctl conf" do
         let(:file) { "/etc/sysctl.d/keepalived.conf" }
 
-        it { is_expected.to contain_file(file).with(ensure: "present") }
+        it { is_expected.to contain_file(file).with(ensure: "file") }
         it { is_expected.to contain_file(file).with(mode: "0644") }
 
         it "says it is managed by puppet" do

--- a/spec/classes/profile/hathitrust/apache/babel_spec.rb
+++ b/spec/classes/profile/hathitrust/apache/babel_spec.rb
@@ -3,42 +3,42 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::apache::babel' do
+describe "nebula::profile::hathitrust::apache::babel" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
-      let(:pre_condition) { 'include apache' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
+      let(:pre_condition) { "include apache" }
 
       let(:base_params) do
         {
-          sdrroot: '/sdrroot',
-          sdremail: 'sdremail@default.invalid',
-          default_access: { enforce: 'all', requires: ['all denied'] },
+          sdrroot: "/sdrroot",
+          sdremail: "sdremail@default.invalid",
+          default_access: {enforce: "all", requires: ["all denied"]},
           haproxy_ips: [],
           ssl_params: {},
-          prefix: '',
-          domain: 'hathitrust.org',
+          prefix: "",
+          domain: "hathitrust.org"
         }
       end
 
       let(:params) { base_params }
 
-      describe 'CRMS_INSTANCE' do
+      describe "CRMS_INSTANCE" do
         let(:babel_env) do
-          catalogue.resource('apache::vhost', 'babel.hathitrust.org ssl')['setenv']
+          catalogue.resource("apache::vhost", "babel.hathitrust.org ssl")["setenv"]
         end
 
-        it 'sets crms_instance production' do
-          expect(babel_env).to include('CRMS_INSTANCE production')
+        it "sets crms_instance production" do
+          expect(babel_env).to include("CRMS_INSTANCE production")
         end
 
-        context('with prod_crms_instance set to false') do
+        context("with prod_crms_instance set to false") do
           let(:params) { base_params.merge(prod_crms_instance: false) }
 
-          it 'does not set CRMS_INSTANCE env var' do
+          it "does not set CRMS_INSTANCE env var" do
             expect(babel_env).not_to include(%r{^CRMS_INSTANCE})
           end
         end

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -3,10 +3,10 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require_relative '../../../support/contexts/with_mocked_nodes'
+require "spec_helper"
+require_relative "../../../support/contexts/with_mocked_nodes"
 
-describe 'nebula::profile::hathitrust::apache' do
+describe "nebula::profile::hathitrust::apache" do
   def multiline2re(string)
     Regexp.new(string.split("\n").map { |line| Regexp.escape(line.lstrip) }.join('\n\s*'))
   end
@@ -14,18 +14,18 @@ describe 'nebula::profile::hathitrust::apache' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:vhost_config) { 'babel.hathitrust.org ssl-directories' }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
-      let(:haproxy) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'haproxy' } }
-      let(:rolenode) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'rolenode' } }
+      let(:vhost_config) { "babel.hathitrust.org ssl-directories" }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
+      let(:haproxy) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "haproxy"} }
+      let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }
 
-      include_context 'with mocked puppetdb functions', 'somedc', %w[haproxy rolenode], 'nebula::profile::haproxy' => %w[haproxy]
+      include_context "with mocked puppetdb functions", "somedc", %w[haproxy rolenode], "nebula::profile::haproxy" => %w[haproxy]
 
-      it { is_expected.to contain_file('/usr/local/lib/cgi-bin/monitor/monitor.pl') }
+      it { is_expected.to contain_file("/usr/local/lib/cgi-bin/monitor/monitor.pl") }
 
-      it 'sends logs to loki' do
-        expect(subject).to contain_class('nebula::profile::loki')
-        expect(subject).to contain_file('/etc/alloy/apache.alloy')
+      it "sends logs to loki" do
+        expect(subject).to contain_class("nebula::profile::loki")
+        expect(subject).to contain_file("/etc/alloy/apache.alloy")
       end
 
       snippets = [
@@ -38,7 +38,7 @@ describe 'nebula::profile::hathitrust::apache' do
             </Files>
           </Directory>
         SNIPPET
-        <<~SNIPPET,
+        <<~SNIPPET
           <DirectoryMatch "^/htapps/babel/([^/]+)/cgi">
             Options +ExecCGI
             SetHandler cgi-script
@@ -51,109 +51,109 @@ describe 'nebula::profile::hathitrust::apache' do
       end
 
       it do
-        expect(subject).to contain_file('access_compat.load')
-          .with(path: '/etc/apache2/mods-available/access_compat.load',
-                content: %r{LoadModule access_compat_module /usr/lib/apache2/modules/mod_access_compat.so})
+        expect(subject).to contain_file("access_compat.load")
+          .with(path: "/etc/apache2/mods-available/access_compat.load",
+            content: %r{LoadModule access_compat_module /usr/lib/apache2/modules/mod_access_compat.so})
       end
 
       it do
-        expect(subject).to contain_file('access_compat.load symlink')
-          .with(ensure: 'link',
-                path: '/etc/apache2/mods-enabled/access_compat.load',
-                target: '/etc/apache2/mods-available/access_compat.load')
+        expect(subject).to contain_file("access_compat.load symlink")
+          .with(ensure: "link",
+            path: "/etc/apache2/mods-enabled/access_compat.load",
+            target: "/etc/apache2/mods-available/access_compat.load")
       end
 
       it do
-        expect(subject).to contain_file('/etc/logrotate.d/apache2')
+        expect(subject).to contain_file("/etc/logrotate.d/apache2")
       end
 
-      describe 'Production HT hostnames' do
+      describe "Production HT hostnames" do
         %w[babel catalog www crms-training.babel].each do |vhost|
           it {
             expect(subject).to contain_apache__vhost("#{vhost}.hathitrust.org ssl").with(
               servername: "#{vhost}.hathitrust.org",
               ssl: true,
-              ssl_protocol: '+TLSv1.2',
-              ssl_cipher: 'ECDHE-RSA-AES256-GCM-SHA384',
-              ssl_cert: '/etc/ssl/certs/www.hathitrust.org.crt',
-              ssl_key: '/etc/ssl/private/www.hathitrust.org.key',
+              ssl_protocol: "+TLSv1.2",
+              ssl_cipher: "ECDHE-RSA-AES256-GCM-SHA384",
+              ssl_cert: "/etc/ssl/certs/www.hathitrust.org.crt",
+              ssl_key: "/etc/ssl/private/www.hathitrust.org.key"
             )
           }
         end
       end
 
-      context 'with a domain and prefix specified' do
+      context "with a domain and prefix specified" do
         let(:params) do
           {
-            domain: 'example.org',
-            prefix: 'foo.',
+            domain: "example.org",
+            prefix: "foo."
           }
         end
 
-        it { is_expected.to contain_apache__vhost('foo.babel.example.org ssl').with_servername('foo.babel.example.org') }
-        it { is_expected.to contain_apache__vhost('foo.catalog.example.org ssl').with_servername('foo.catalog.example.org') }
-        it { is_expected.to contain_apache__vhost('foo.www.example.org ssl').with_servername('foo.www.example.org') }
+        it { is_expected.to contain_apache__vhost("foo.babel.example.org ssl").with_servername("foo.babel.example.org") }
+        it { is_expected.to contain_apache__vhost("foo.catalog.example.org ssl").with_servername("foo.catalog.example.org") }
+        it { is_expected.to contain_apache__vhost("foo.www.example.org ssl").with_servername("foo.www.example.org") }
 
         it {
-          expect(subject).to contain_apache__vhost('foo.babel.example.org non-ssl').with(
-            redirect_dest: 'https://foo.babel.example.org/',
-            servername: 'foo.babel.example.org',
+          expect(subject).to contain_apache__vhost("foo.babel.example.org non-ssl").with(
+            redirect_dest: "https://foo.babel.example.org/",
+            servername: "foo.babel.example.org"
           )
         }
       end
 
-      context 'with a domain and no prefix specified' do
+      context "with a domain and no prefix specified" do
         let(:params) do
           {
-            domain: 'example.org',
+            domain: "example.org"
           }
         end
 
-        it { is_expected.to contain_apache__vhost('babel.example.org ssl').with_servername('babel.example.org') }
+        it { is_expected.to contain_apache__vhost("babel.example.org ssl").with_servername("babel.example.org") }
 
         it {
-          expect(subject).to contain_apache__vhost('hathitrust canonical name redirection').with(
-            servername: 'example.org',
-            serveraliases: ['domain.one', 'domain.two', 'www.domain.one', 'www.domain.two'],
-            redirect_dest: 'https://www.example.org/',
+          expect(subject).to contain_apache__vhost("hathitrust canonical name redirection").with(
+            servername: "example.org",
+            serveraliases: ["domain.one", "domain.two", "www.domain.one", "www.domain.two"],
+            redirect_dest: "https://www.example.org/"
           )
         }
       end
 
       it do
-        expect(subject).to contain_concat_file('/usr/local/lib/cgi-bin/monitor/monitor_config.yaml')
+        expect(subject).to contain_concat_file("/usr/local/lib/cgi-bin/monitor/monitor_config.yaml")
       end
 
       it do
-        expect(subject).to contain_concat_fragment('monitor solr cores').with(tag: 'monitor_config',
-                                                                              content: { 'solr' => %w[solrcore1 solrcore2] }.to_yaml)
+        expect(subject).to contain_concat_fragment("monitor solr cores").with(tag: "monitor_config",
+          content: {"solr" => %w[solrcore1 solrcore2]}.to_yaml)
       end
 
       it do
-        expect(subject).to contain_concat_fragment('monitor mysql').with(tag: 'monitor_config',
-                                                                         content: { 'mysql' => { 'param1' => 'value1', 'param2' => 'value2' } }.to_yaml)
+        expect(subject).to contain_concat_fragment("monitor mysql").with(tag: "monitor_config",
+          content: {"mysql" => {"param1" => "value1", "param2" => "value2"}}.to_yaml)
       end
 
       it do
         # set via hiera
-        expect(subject).to contain_cron('purge caches')
-          .with_command('/htapps/babel/mdp-misc/scripts/managecache.sh /somewhere/whatever:1:2 /elsewhere/whatever:3:4')
+        expect(subject).to contain_cron("purge caches")
+          .with_command("/htapps/babel/mdp-misc/scripts/managecache.sh /somewhere/whatever:1:2 /elsewhere/whatever:3:4")
       end
 
-      describe 'monitoring user' do
+      describe "monitoring user" do
         it do
           expect(subject).to have_nebula__authzd_user_resource_count(0)
         end
 
-        context 'with specified key' do
+        context "with specified key" do
           let(:params) do
             {
-              monitoring_pubkey: {},
+              monitoring_pubkey: {}
             }
           end
 
           it do
-            expect(subject).to contain_nebula__authzd_user('haproxyctl')
+            expect(subject).to contain_nebula__authzd_user("haproxyctl")
           end
         end
       end

--- a/spec/classes/profile/hathitrust/babel_logs_spec.rb
+++ b/spec/classes/profile/hathitrust/babel_logs_spec.rb
@@ -3,20 +3,20 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../../support/contexts/with_htvm_setup'
+require_relative "../../../support/contexts/with_htvm_setup"
 
-describe 'nebula::profile::hathitrust::babel_logs' do
+describe "nebula::profile::hathitrust::babel_logs" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_file('/var/log/babel').with_owner('nobody') }
-      it { is_expected.to contain_file('/etc/alloy/babel.alloy').with_content(%r{/var/log/babel}) }
-      it { is_expected.to contain_file('/etc/logrotate.d/babel').with_content(%r{/var/log/babel}) }
+      it { is_expected.to contain_file("/var/log/babel").with_owner("nobody") }
+      it { is_expected.to contain_file("/etc/alloy/babel.alloy").with_content(%r{/var/log/babel}) }
+      it { is_expected.to contain_file("/etc/logrotate.d/babel").with_content(%r{/var/log/babel}) }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/cron/catalog_spec.rb
+++ b/spec/classes/profile/hathitrust/cron/catalog_spec.rb
@@ -3,42 +3,42 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::cron::catalog' do
+describe "nebula::profile::hathitrust::cron::catalog" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with default params' do
+      context "with default params" do
         let(:params) do
           {
-            mail_recipient: 'nobody@default.invalid',
+            mail_recipient: "nobody@default.invalid"
           }
         end
 
         it do
-          expect(subject).to contain_cron('clean sessions')
+          expect(subject).to contain_cron("clean sessions")
             .with(command: %r{.*perl /htapps/catalog/web/derived_data/clean_sessions\.pl},
-                  user: 'libadm',
-                  environment: ['MAILTO=nobody@default.invalid'])
+              user: "libadm",
+              environment: ["MAILTO=nobody@default.invalid"])
         end
       end
 
-      context 'with all params' do
+      context "with all params" do
         let(:params) do
           {
-            mail_recipient: 'somebody@default.invalid',
-            user: 'cronuser',
-            catalog_home: '/nowhere',
+            mail_recipient: "somebody@default.invalid",
+            user: "cronuser",
+            catalog_home: "/nowhere"
           }
         end
 
         it do
-          expect(subject).to contain_cron('clean sessions')
+          expect(subject).to contain_cron("clean sessions")
             .with(command: %r{.*perl /nowhere/derived_data/clean_sessions\.pl},
-                  user: 'cronuser',
-                  environment: ['MAILTO=somebody@default.invalid'])
+              user: "cronuser",
+              environment: ["MAILTO=somebody@default.invalid"])
         end
       end
     end

--- a/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
+++ b/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
@@ -3,58 +3,58 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::cron::mdp_misc' do
+describe "nebula::profile::hathitrust::cron::mdp_misc" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with default params' do
+      context "with default params" do
         let(:params) do
           {
-            mail_recipient: 'nobody@default.invalid',
+            mail_recipient: "nobody@default.invalid"
           }
         end
 
         it do
-          expect(subject).to contain_cron('manage mbook sessions')
+          expect(subject).to contain_cron("manage mbook sessions")
             .with(command: %r{/htapps/babel/mdp-misc/scripts/managembookssessions\.pl.*mail.*nobody@default\.invalid},
 
-                  user: 'libadm',
-                  environment: [
-                    'SDRROOT=/htapps/babel',
-                    'SDRDATAROOT=/sdr1',
-                    'HOME=/htapps/babel/mdp-misc',
-                    "MAILTO=''",
-                  ],
-                  minute: 5)
+              user: "libadm",
+              environment: [
+                "SDRROOT=/htapps/babel",
+                "SDRDATAROOT=/sdr1",
+                "HOME=/htapps/babel/mdp-misc",
+                "MAILTO=''"
+              ],
+              minute: 5)
         end
       end
 
-      context 'with all params' do
+      context "with all params" do
         let(:params) do
           {
-            mail_recipient: 'somebody@default.invalid',
-            user: 'cronuser',
-            sdr_root: '/somewhere',
-            sdr_data_root: '/elsewhere',
-            home: '/homewhere',
-            mdp_sessions_minute: 30,
+            mail_recipient: "somebody@default.invalid",
+            user: "cronuser",
+            sdr_root: "/somewhere",
+            sdr_data_root: "/elsewhere",
+            home: "/homewhere",
+            mdp_sessions_minute: 30
           }
         end
 
         it do
-          expect(subject).to contain_cron('manage mbook sessions')
+          expect(subject).to contain_cron("manage mbook sessions")
             .with(command: %r{.*/homewhere/scripts/managembookssessions\.pl.*mail.*somebody@default\.invalid},
-                  user: 'cronuser',
-                  environment: [
-                    'SDRROOT=/somewhere',
-                    'SDRDATAROOT=/elsewhere',
-                    'HOME=/homewhere',
-                    "MAILTO=''",
-                  ],
-                  minute: 30)
+              user: "cronuser",
+              environment: [
+                "SDRROOT=/somewhere",
+                "SDRDATAROOT=/elsewhere",
+                "HOME=/homewhere",
+                "MAILTO=''"
+              ],
+              minute: 30)
         end
       end
     end

--- a/spec/classes/profile/hathitrust/dependencies_spec.rb
+++ b/spec/classes/profile/hathitrust/dependencies_spec.rb
@@ -3,22 +3,22 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../../support/contexts/with_htvm_setup'
+require_relative "../../../support/contexts/with_htvm_setup"
 
-describe 'nebula::profile::hathitrust::dependencies' do
+describe "nebula::profile::hathitrust::dependencies" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
 
       it { is_expected.to compile }
 
-      if os == 'debian-11-x86_64'
-        it { is_expected.to contain_package('mariadb-client') }
+      if os == "debian-11-x86_64"
+        it { is_expected.to contain_package("mariadb-client") }
       end
 
-      it { is_expected.to contain_file('/usr/local/bin/catprocio') }
+      it { is_expected.to contain_file("/usr/local/bin/catprocio") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/hosts_spec.rb
+++ b/spec/classes/profile/hathitrust/hosts_spec.rb
@@ -3,57 +3,57 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::hosts' do
+describe "nebula::profile::hathitrust::hosts" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:my_ip) { Faker::Internet.ip_v4_address }
       let(:mysql_ip) { Faker::Internet.ip_v4_address }
       let(:solr_ips) { Array.new(3) { Faker::Internet.ip_v4_address } }
-      let(:hostname) { 'thisnode' }
+      let(:hostname) { "thisnode" }
       let(:fqdn) { "#{hostname}.umdl.umich.edu" }
 
       let(:params) do
         {
           mysql_sdr: mysql_ip,
-          mysql_htdev: '2.2.2.2',
-          apps_ht: '3.3.3.3',
+          mysql_htdev: "2.2.2.2",
+          apps_ht: "3.3.3.3",
           solr_search: solr_ips,
-          solr_catalog: '4.4.4.4',
-          solr_vufind_primary: '7.7.7.7',
-          solr_vufind_failover: '8.8.8.8',
+          solr_catalog: "4.4.4.4",
+          solr_vufind_primary: "7.7.7.7",
+          solr_vufind_failover: "8.8.8.8"
         }
       end
 
       let(:facts) do
         os_facts.deep_merge(
-          ipaddress: 'INVALID_DO_NOT_USE',
-          hostname: 'INVALID_DO_NOT_USE',
-          fqdn: 'INVALID_DO_NOT_USE',
+          ipaddress: "INVALID_DO_NOT_USE",
+          hostname: "INVALID_DO_NOT_USE",
+          fqdn: "INVALID_DO_NOT_USE",
           networking: {
-            'ip' => my_ip,
-            'hostname' => hostname,
-            'fqdn' => fqdn,
-          },
+            "ip" => my_ip,
+            "hostname" => hostname,
+            "fqdn" => fqdn
+          }
         )
       end
 
-      describe '/etc/hosts' do
-        let(:file) { '/etc/hosts' }
+      describe "/etc/hosts" do
+        let(:file) { "/etc/hosts" }
 
-        it 'maps the ip, fqdn, and hostname' do
+        it "maps the ip, fqdn, and hostname" do
           expect(subject).to contain_host(hostname).with_ip(my_ip)
           expect(subject).to contain_host(hostname).with_host_aliases([fqdn])
         end
 
-        it 'maps 1:1 aliases' do
-          expect(subject).to contain_host('mysql-sdr').with_ip(mysql_ip)
+        it "maps 1:1 aliases" do
+          expect(subject).to contain_host("mysql-sdr").with_ip(mysql_ip)
         end
 
-        it 'unpacks the many search aliases' do
-          expect(subject).to contain_host('solr-sdr-search-1').with_ip(solr_ips[0])
-          expect(subject).to contain_host('solr-sdr-search-2').with_ip(solr_ips[1])
+        it "unpacks the many search aliases" do
+          expect(subject).to contain_host("solr-sdr-search-1").with_ip(solr_ips[0])
+          expect(subject).to contain_host("solr-sdr-search-2").with_ip(solr_ips[1])
         end
       end
     end

--- a/spec/classes/profile/hathitrust/imgsrv_spec.rb
+++ b/spec/classes/profile/hathitrust/imgsrv_spec.rb
@@ -3,32 +3,32 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::imgsrv' do
+describe "nebula::profile::hathitrust::imgsrv" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) do
         {
           num_proc: 10,
-          sdrroot: '/sdrroot',
-          sdrview: 'sdrview',
-          sdrdataroot: '/sdrdataroot',
-          bind: '127.0.0.1:31028',
+          sdrroot: "/sdrroot",
+          sdrview: "sdrview",
+          sdrdataroot: "/sdrdataroot",
+          bind: "127.0.0.1:31028"
         }
       end
 
-      it { is_expected.to contain_service('imgsrv') }
-      it { is_expected.to contain_package('libfcgi-bin') }
+      it { is_expected.to contain_service("imgsrv") }
+      it { is_expected.to contain_package("libfcgi-bin") }
 
-      it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^SDRROOT=/sdrroot$}) }
-      it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^NPROC=10$}) }
-      it { is_expected.to contain_file('/usr/local/bin/startup_imgsrv').with_content(%r{^BIND=127.0.0.1:31028}) }
+      it { is_expected.to contain_file("/usr/local/bin/startup_imgsrv").with_content(%r{^SDRROOT=/sdrroot$}) }
+      it { is_expected.to contain_file("/usr/local/bin/startup_imgsrv").with_content(%r{^NPROC=10$}) }
+      it { is_expected.to contain_file("/usr/local/bin/startup_imgsrv").with_content(%r{^BIND=127.0.0.1:31028}) }
 
-      it { is_expected.to contain_file('/etc/systemd/system/imgsrv.service').with_content(%r{ExecStart=/usr/local/bin/startup_imgsrv}) }
+      it { is_expected.to contain_file("/etc/systemd/system/imgsrv.service").with_content(%r{ExecStart=/usr/local/bin/startup_imgsrv}) }
 
-      it { is_expected.to contain_file('/etc/sudoers.d/imgsrv-catprocio') }
+      it { is_expected.to contain_file("/etc/sudoers.d/imgsrv-catprocio") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -3,39 +3,39 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::mounts' do
+describe "nebula::profile::hathitrust::mounts" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:facts) { os_facts.merge(networking: {ip: Faker::Internet.ip_v4_address, interfaces: {}}) }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to contain_package('nfs-common') }
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
-      it { is_expected.to contain_nebula__nfs_mount('/sdr1') }
+      it { is_expected.to contain_package("nfs-common") }
+      it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3,ro") }
+      it { is_expected.to contain_nebula__nfs_mount("/sdr1") }
 
-      it { is_expected.to contain_mount('/htapps').that_requires('File[/etc/resolv.conf]') }
-      it { is_expected.to contain_mount('/htapps').that_requires('Service[bind9]') }
-      it { is_expected.to contain_nebula__nfs_mount('/htapps') }
+      it { is_expected.to contain_mount("/htapps").that_requires("File[/etc/resolv.conf]") }
+      it { is_expected.to contain_mount("/htapps").that_requires("Service[bind9]") }
+      it { is_expected.to contain_nebula__nfs_mount("/htapps") }
 
-      it { is_expected.to contain_file('/etc/resolv.conf').with_content(%r{nameserver 127.0.0.1}) }
-      it { is_expected.to contain_service('bind9') }
+      it { is_expected.to contain_file("/etc/resolv.conf").with_content(%r{nameserver 127.0.0.1}) }
+      it { is_expected.to contain_service("bind9") }
 
-      context 'with /htapps specified as a non-smartconnect mount' do
+      context "with /htapps specified as a non-smartconnect mount" do
         let(:params) do
           {
             smartconnect_mounts: [],
             other_nfs_mounts: {
-              '/htapps' => { 'remote_target' => 'somehost:/htapps' },
-            },
+              "/htapps" => {"remote_target" => "somehost:/htapps"}
+            }
           }
         end
 
         it do
-          expect(subject).to contain_mount('/htapps').with(
-            device: 'somehost:/htapps',
-            fstype: 'nfs',
+          expect(subject).to contain_mount("/htapps").with(
+            device: "somehost:/htapps",
+            fstype: "nfs"
           )
         end
       end

--- a/spec/classes/profile/hathitrust/perl_spec.rb
+++ b/spec/classes/profile/hathitrust/perl_spec.rb
@@ -3,17 +3,17 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../../support/contexts/with_htvm_setup'
+require_relative "../../../support/contexts/with_htvm_setup"
 
-describe 'nebula::profile::hathitrust::perl' do
+describe "nebula::profile::hathitrust::perl" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
 
       it { is_expected.to compile }
-      it { is_expected.to contain_nebula__cpan('EBook::EPUB').that_requires('Package[libmoose-perl]') }
+      it { is_expected.to contain_nebula__cpan("EBook::EPUB").that_requires("Package[libmoose-perl]") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/php_spec.rb
+++ b/spec/classes/profile/hathitrust/php_spec.rb
@@ -3,17 +3,17 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../../support/contexts/with_htvm_setup'
+require_relative "../../../support/contexts/with_htvm_setup"
 
-describe 'nebula::profile::hathitrust::php' do
+describe "nebula::profile::hathitrust::php" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
 
       it { is_expected.to compile }
-      it { is_expected.to contain_php__extension('File_MARC').with_provider('pear') }
+      it { is_expected.to contain_php__extension("File_MARC").with_provider("pear") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/slip_spec.rb
+++ b/spec/classes/profile/hathitrust/slip_spec.rb
@@ -3,18 +3,18 @@
 # Copyright (c) 2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::slip' do
+describe "nebula::profile::hathitrust::slip" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_nebula__usergroup('slip') }
+      it { is_expected.to contain_nebula__usergroup("slip") }
 
-      it { is_expected.to contain_file('/etc/sudoers.d/slip-catprocio') }
+      it { is_expected.to contain_file("/etc/sudoers.d/slip-catprocio") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::solr6::catalog' do
+describe "nebula::profile::hathitrust::solr6::catalog" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('nebula::profile::hathitrust::solr6') }
-      it { is_expected.to contain_file('/var/lib/solr/solr.in.sh').with_content(%r{SOLR_PORT=9033}) }
+      it { is_expected.to contain_class("nebula::profile::hathitrust::solr6") }
+      it { is_expected.to contain_file("/var/lib/solr/solr.in.sh").with_content(%r{SOLR_PORT=9033}) }
 
       it {
-        expect(subject).to contain_file('/usr/local/bin/index-release')
+        expect(subject).to contain_file("/usr/local/bin/index-release")
           .with_content(%r{BASE=/htsolr/catalog})
           .with_content(%r|^SNAP=".snapshot/htsolr-catalog_\${TODAY}"$|)
           .with_content(%r{CORES="catalog"})
@@ -28,43 +28,43 @@ describe 'nebula::profile::hathitrust::solr6::catalog' do
       }
 
       it {
-        expect(subject).to contain_cron('catalog solr index release')
+        expect(subject).to contain_cron("catalog solr index release")
           .with(command: "/usr/local/bin/index-release > /tmp/index-release.log 2>&1 || /usr/bin/mail -s 'foo catalog index release problem' anybody@default.invalid < /tmp/index-release.log")
       }
 
-      context 'when on primary site' do
+      context "when on primary site" do
         let(:params) do
-          { is_primary_site: true }
+          {is_primary_site: true}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release')
+          expect(subject).to contain_file("/usr/local/bin/index-release")
             .with_content(%r|^if ! curl -A SOLR -s --retry 5 --fail https://babel.hathitrust.org/flags/web/catalog-release-\${TODAY} --resolve "babel.hathitrust.org:443:6.5.4.3|)
         }
 
         it {
-          expect(subject).to contain_cron('catalog solr index release')
+          expect(subject).to contain_cron("catalog solr index release")
             .with(hour: 6, minute: 30)
         }
       end
 
-      context 'when on mirror site' do
+      context "when on mirror site" do
         let(:params) do
-          { is_primary_site: false }
+          {is_primary_site: false}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release')
+          expect(subject).to contain_file("/usr/local/bin/index-release")
             .without_content(%r{^if ! curl -A SOLR -s --retry 5 --fail https://babel.hathitrust.org})
         }
 
         it {
-          expect(subject).to contain_cron('catalog solr index release')
+          expect(subject).to contain_cron("catalog solr index release")
             .with(hour: 6, minute: 25)
         }
       end
 
-      it { is_expected.to contain_class('nebula::profile::loki') }
+      it { is_expected.to contain_class("nebula::profile::loki") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/solr6/classic_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/classic_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::solr6::classic' do
+describe "nebula::profile::hathitrust::solr6::classic" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('nebula::profile::loki') }
+      it { is_expected.to contain_class("nebula::profile::loki") }
     end
   end
 end

--- a/spec/classes/profile/hathitrust/solr6/lss_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/lss_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::solr6::lss' do
+describe "nebula::profile::hathitrust::solr6::lss" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('nebula::profile::hathitrust::solr6') }
-      it { is_expected.to contain_file('/var/lib/solr/solr.in.sh').with_content(%r{SOLR_PORT=8081}) }
+      it { is_expected.to contain_class("nebula::profile::hathitrust::solr6") }
+      it { is_expected.to contain_file("/var/lib/solr/solr.in.sh").with_content(%r{SOLR_PORT=8081}) }
 
       it {
-        expect(subject).to contain_file('/usr/local/bin/index-release')
+        expect(subject).to contain_file("/usr/local/bin/index-release")
           .with_content(%r{BASE=/htsolr/lss})
           .with_content(%r|^SNAP=".snapshot/htsolr-lss_\${TODAY}"$|)
           .with_content(%r{CORES="66 99"})
@@ -28,59 +28,59 @@ describe 'nebula::profile::hathitrust::solr6::lss' do
       }
 
       it {
-        expect(subject).to contain_cron('lss solr index release')
+        expect(subject).to contain_cron("lss solr index release")
           .with(command: "/usr/local/bin/index-release > /tmp/index-release.log 2>&1 || /usr/bin/mail -s 'foo lss index release problem' nobody@default.invalid < /tmp/index-release.log")
       }
 
-      context 'when on primary site' do
+      context "when on primary site" do
         let(:params) do
-          { is_primary_site: true }
+          {is_primary_site: true}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release')
+          expect(subject).to contain_file("/usr/local/bin/index-release")
             .with_content(%r|^if ! curl -A SOLR -s --retry 5 --fail https://babel.hathitrust.org/flags/web/lss-release-\${TODAY} --resolve "babel.hathitrust.org:443:5.4.3.2"|)
         }
 
         it {
-          expect(subject).to contain_cron('lss solr index release')
+          expect(subject).to contain_cron("lss solr index release")
             .with(hour: 6, minute: 0)
         }
       end
 
-      context 'when on mirror site' do
+      context "when on mirror site" do
         let(:params) do
-          { is_primary_site: false }
+          {is_primary_site: false}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release')
+          expect(subject).to contain_file("/usr/local/bin/index-release")
             .without_content(%r{^if ! curl -A SOLR -s --retry 5 --fail https://babel.hathitrust.org})
         }
 
         it {
-          expect(subject).to contain_cron('lss solr index release')
+          expect(subject).to contain_cron("lss solr index release")
             .with(hour: 5, minute: 55)
         }
       end
 
-      context 'when on primary node' do
+      context "when on primary node" do
         let(:params) do
-          { is_primary_node: true }
+          {is_primary_node: true}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release').with_content(%r|^touch /htapps/babel/flags/web/lss-release-\${TODAY}$|)
+          expect(subject).to contain_file("/usr/local/bin/index-release").with_content(%r|^touch /htapps/babel/flags/web/lss-release-\${TODAY}$|)
         }
       end
 
-      context 'when on non-primary node' do
+      context "when on non-primary node" do
         let(:params) do
-          { is_primary_node: false }
+          {is_primary_node: false}
         end
 
         it {
-          expect(subject).to contain_file('/usr/local/bin/index-release').without_content(%r|^touch /htapps/babel/flags/web/lss-release-\${TODAY}$|)
+          expect(subject).to contain_file("/usr/local/bin/index-release").without_content(%r|^touch /htapps/babel/flags/web/lss-release-\${TODAY}$|)
         }
       end
     end

--- a/spec/classes/profile/hathitrust/solr6_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::hathitrust::solr6' do
+describe "nebula::profile::hathitrust::solr6" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
       # solr and dependencies
-      it { is_expected.to contain_package('temurin-8-jre') }
-      it { is_expected.to contain_package('solr') }
-      it { is_expected.to contain_user('solr') }
-      it { is_expected.to contain_service('solr') }
+      it { is_expected.to contain_package("temurin-8-jre") }
+      it { is_expected.to contain_package("solr") }
+      it { is_expected.to contain_user("solr") }
+      it { is_expected.to contain_service("solr") }
 
       # solr config
-      it { is_expected.to contain_file('/etc/systemd/system/solr.service').with_content(%r{SOLR_INCLUDE=/s0lr/h0me/solr.in.sh}) }
-      it { is_expected.to contain_file('/s0lr/h0me/log4j.properties').with_content(%r{solr.log=/s0lr/h0me/logs}) }
-      it { is_expected.to contain_file('/s0lr/h0me/solr.xml') }
+      it { is_expected.to contain_file("/etc/systemd/system/solr.service").with_content(%r{SOLR_INCLUDE=/s0lr/h0me/solr.in.sh}) }
+      it { is_expected.to contain_file("/s0lr/h0me/log4j.properties").with_content(%r{solr.log=/s0lr/h0me/logs}) }
+      it { is_expected.to contain_file("/s0lr/h0me/solr.xml") }
 
       it {
-        expect(subject).to contain_file('/s0lr/h0me/solr.in.sh')
+        expect(subject).to contain_file("/s0lr/h0me/solr.in.sh")
           .with_content(%r{SOLR_PORT=2525})
           .with_content(%r{-Dsolr.lock.type=single})
           .with_content(%r{SOLR_HOME="/s0lr/h0me"})
@@ -29,8 +29,8 @@ describe 'nebula::profile::hathitrust::solr6' do
       }
 
       # firewall
-      it { is_expected.to contain_firewall('200 Solr - Private: foobar net').with(source: '192.168.99.0/24') }
-      it { is_expected.to contain_firewall('200 Solr - Staff: Net Two').with(source: '10.0.2.0/24') }
+      it { is_expected.to contain_firewall("200 Solr - Private: foobar net").with(source: "192.168.99.0/24") }
+      it { is_expected.to contain_firewall("200 Solr - Staff: Net Two").with(source: "10.0.2.0/24") }
     end
   end
 end

--- a/spec/classes/profile/http_fileserver_spec.rb
+++ b/spec/classes/profile/http_fileserver_spec.rb
@@ -3,71 +3,71 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::http_fileserver' do
+describe "nebula::profile::http_fileserver" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/deb_server_config.yaml' }
-      let(:node) { 'foo.example.com' } # see spec/default_facts.yml
+      let(:hiera_config) { "spec/fixtures/hiera/deb_server_config.yaml" }
+      let(:node) { "foo.example.com" } # see spec/default_facts.yml
 
       let(:params) do
-        { storage_path: 'somehost:/whatever' }
+        {storage_path: "somehost:/whatever"}
       end
 
-      it { is_expected.to contain_mount('/srv/www').with(fstype: 'nfs', device: 'somehost:/whatever') }
-      it { is_expected.to contain_file('/srv/www').with_ensure('directory') }
-      it { is_expected.to contain_file('/var/local/http').with_ensure('directory') }
+      it { is_expected.to contain_mount("/srv/www").with(fstype: "nfs", device: "somehost:/whatever") }
+      it { is_expected.to contain_file("/srv/www").with_ensure("directory") }
+      it { is_expected.to contain_file("/var/local/http").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_class('apache').with(
-          docroot: '/srv/www',
-          default_ssl_cert: '/etc/letsencrypt/live/foo.example.com/fullchain.pem',
-          default_ssl_key: '/etc/letsencrypt/live/foo.example.com/privkey.pem',
+        expect(subject).to contain_class("apache").with(
+          docroot: "/srv/www",
+          default_ssl_cert: "/etc/letsencrypt/live/foo.example.com/fullchain.pem",
+          default_ssl_key: "/etc/letsencrypt/live/foo.example.com/privkey.pem",
           default_vhost: false,
-          default_ssl_vhost: true,
+          default_ssl_vhost: true
         )
       end
 
       it do
-        expect(subject).to contain_apache__vhost('foo.example.com http')
-          .with_servername('foo.example.com')
+        expect(subject).to contain_apache__vhost("foo.example.com http")
+          .with_servername("foo.example.com")
           .with_port(80)
-          .with_docroot('/var/local/http')
-          .that_requires('File[/var/local/http]')
+          .with_docroot("/var/local/http")
+          .that_requires("File[/var/local/http]")
       end
 
       it do
-        expect(subject).to contain_nebula__cert('foo.example.com')
-          .with_webroot('/var/local/http')
-          .that_requires('File[/var/local/http]')
-          .that_requires('Apache::Vhost[foo.example.com http]')
+        expect(subject).to contain_nebula__cert("foo.example.com")
+          .with_webroot("/var/local/http")
+          .that_requires("File[/var/local/http]")
+          .that_requires("Apache::Vhost[foo.example.com http]")
       end
 
-      context 'with no existing certificate' do
-        let(:node) { 'nocert.example.com' }
+      context "with no existing certificate" do
+        let(:node) { "nocert.example.com" }
 
         it do
-          expect(subject).to contain_class('apache')
-            .with_docroot('/srv/www')
+          expect(subject).to contain_class("apache")
+            .with_docroot("/srv/www")
             .with_default_vhost(false)
             .with_default_ssl_vhost(false)
         end
 
         it do
-          expect(subject).to contain_apache__vhost('nocert.example.com http')
-            .with_servername('nocert.example.com')
+          expect(subject).to contain_apache__vhost("nocert.example.com http")
+            .with_servername("nocert.example.com")
             .with_port(80)
-            .with_docroot('/var/local/http')
-            .that_requires('File[/var/local/http]')
+            .with_docroot("/var/local/http")
+            .that_requires("File[/var/local/http]")
         end
 
         it do
-          expect(subject).to contain_nebula__cert('nocert.example.com')
-            .with_webroot('/var/local/http')
-            .that_requires('File[/var/local/http]')
-            .that_requires('Apache::Vhost[nocert.example.com http]')
+          expect(subject).to contain_nebula__cert("nocert.example.com")
+            .with_webroot("/var/local/http")
+            .that_requires("File[/var/local/http]")
+            .that_requires("Apache::Vhost[nocert.example.com http]")
         end
       end
     end

--- a/spec/classes/profile/https_to_port_spec.rb
+++ b/spec/classes/profile/https_to_port_spec.rb
@@ -3,40 +3,40 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::https_to_port' do
+describe "nebula::profile::https_to_port" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:server_name) { facts[:fqdn] }
       let(:letsencrypt_directory) { "/etc/letsencrypt/live/#{server_name}" }
 
-      context 'when port is set to 1234' do
-        let(:params) { { port: 1234 } }
+      context "when port is set to 1234" do
+        let(:params) { {port: 1234} }
 
         it { is_expected.to compile }
 
-        it { is_expected.to contain_class('nginx') }
+        it { is_expected.to contain_class("nginx") }
 
         it do
-          expect(subject).to contain_nginx__resource__server('letsencrypt-webroot')
+          expect(subject).to contain_nginx__resource__server("letsencrypt-webroot")
             .with_server_name([server_name])
             .with_listen_port(80)
-            .with_www_root('/var/www')
+            .with_www_root("/var/www")
         end
 
         it do
           expect(subject).to contain_nebula__cert(server_name)
-            .with_webroot('/var/www')
-            .that_requires('Nginx::Resource::Server[letsencrypt-webroot]')
+            .with_webroot("/var/www")
+            .that_requires("Nginx::Resource::Server[letsencrypt-webroot]")
         end
 
         it do
-          expect(subject).to contain_nginx__resource__server('https-forwarder')
+          expect(subject).to contain_nginx__resource__server("https-forwarder")
             .with_server_name([server_name])
             .with_listen_port(443)
-            .with_proxy('http://localhost:1234')
+            .with_proxy("http://localhost:1234")
             .with_ssl(true)
             .with_ssl_cert("#{letsencrypt_directory}/fullchain.pem")
             .with_ssl_key("#{letsencrypt_directory}/privkey.pem")
@@ -44,18 +44,18 @@ describe 'nebula::profile::https_to_port' do
         end
 
         it do
-          expect(subject).to contain_cron('restart nginx weekly to keep SSL keys up to date')
-            .with_command('/bin/systemctl restart nginx')
+          expect(subject).to contain_cron("restart nginx weekly to keep SSL keys up to date")
+            .with_command("/bin/systemctl restart nginx")
         end
 
-        context 'with server_name set to example.invalid' do
-          let(:server_name) { 'example.invalid' }
+        context "with server_name set to example.invalid" do
+          let(:server_name) { "example.invalid" }
           let(:params) do
             super().merge(server_name: server_name)
           end
 
           it do
-            expect(subject).to contain_nginx__resource__server('letsencrypt-webroot')
+            expect(subject).to contain_nginx__resource__server("letsencrypt-webroot")
               .with_server_name([server_name])
           end
 
@@ -64,7 +64,7 @@ describe 'nebula::profile::https_to_port' do
           end
 
           it do
-            expect(subject).to contain_nginx__resource__server('https-forwarder')
+            expect(subject).to contain_nginx__resource__server("https-forwarder")
               .with_server_name([server_name])
               .with_ssl_cert("#{letsencrypt_directory}/fullchain.pem")
               .with_ssl_key("#{letsencrypt_directory}/privkey.pem")
@@ -73,37 +73,37 @@ describe 'nebula::profile::https_to_port' do
         end
 
         context "with server_name set to something that doesn't have keys yet" do
-          let(:server_name) { 'nokeysyet.invalid' }
+          let(:server_name) { "nokeysyet.invalid" }
           let(:params) do
             super().merge(server_name: server_name)
           end
 
-          it { is_expected.not_to contain_nginx__resource__server('https-forwarder') }
+          it { is_expected.not_to contain_nginx__resource__server("https-forwarder") }
         end
 
-        context 'with webroot set to /opt/html' do
+        context "with webroot set to /opt/html" do
           let(:params) do
-            super().merge(webroot: '/opt/html')
+            super().merge(webroot: "/opt/html")
           end
 
           it do
-            expect(subject).to contain_nginx__resource__server('letsencrypt-webroot')
-              .with_www_root('/opt/html')
+            expect(subject).to contain_nginx__resource__server("letsencrypt-webroot")
+              .with_www_root("/opt/html")
           end
 
           it do
             expect(subject).to contain_nebula__cert(server_name)
-              .with_webroot('/opt/html')
+              .with_webroot("/opt/html")
           end
         end
       end
 
-      context 'when port is set to 2468' do
-        let(:params) { { port: 2468 } }
+      context "when port is set to 2468" do
+        let(:params) { {port: 2468} }
 
         it do
-          expect(subject).to contain_nginx__resource__server('https-forwarder')
-            .with_proxy('http://localhost:2468')
+          expect(subject).to contain_nginx__resource__server("https-forwarder")
+            .with_proxy("http://localhost:2468")
         end
       end
     end

--- a/spec/classes/profile/imagemagick_spec.rb
+++ b/spec/classes/profile/imagemagick_spec.rb
@@ -3,15 +3,15 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::imagemagick' do
+describe "nebula::profile::imagemagick" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('imagemagick') }
+      it { is_expected.to contain_package("imagemagick") }
 
       it do
         # I've chosen 1MP as an improvement to 16KP without much
@@ -20,9 +20,9 @@ describe 'nebula::profile::imagemagick' do
         # don't expect it to need to be different on different machines.
         #
         # Other values were taken from the default jessie config.
-        expect(subject).to contain_file('/etc/ImageMagick-6/policy.xml').with(
-          require: 'Package[imagemagick]',
-          content: %r{domain="resource" name="width" value="1MP"},
+        expect(subject).to contain_file("/etc/ImageMagick-6/policy.xml").with(
+          require: "Package[imagemagick]",
+          content: %r{domain="resource" name="width" value="1MP"}
         )
       end
     end

--- a/spec/classes/profile/known_host_public_keys_spec.rb
+++ b/spec/classes/profile/known_host_public_keys_spec.rb
@@ -3,45 +3,45 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::known_host_public_keys' do
+describe "nebula::profile::known_host_public_keys" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with fqdn of example.invalid and some ssh public keys' do
+      context "with fqdn of example.invalid and some ssh public keys" do
         let(:facts) do
           {
             networking: {
-              'fqdn' => 'example.invalid',
+              "fqdn" => "example.invalid"
             },
             ssh: {
-              'ecdsa' => {
-                'type' => 'ecdsa-sha2-nistp256',
-                'key' => 'ecdsa_key',
+              "ecdsa" => {
+                "type" => "ecdsa-sha2-nistp256",
+                "key" => "ecdsa_key"
               },
-              'rsa' => {
-                'type' => 'ssh-rsa',
-                'key' => 'rsa_key',
-              },
-            },
+              "rsa" => {
+                "type" => "ssh-rsa",
+                "key" => "rsa_key"
+              }
+            }
           }
         end
 
         it { is_expected.to compile }
 
-        it 'exports an ssh_known_hosts line for its ecdsa key' do
-          expect(exported_resources).to contain_concat_fragment('known host example.invalid ecdsa')
-            .with_target('/etc/ssh/ssh_known_hosts')
-            .with_tag('known_host_public_keys')
+        it "exports an ssh_known_hosts line for its ecdsa key" do
+          expect(exported_resources).to contain_concat_fragment("known host example.invalid ecdsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("known_host_public_keys")
             .with_content("example.invalid ecdsa-sha2-nistp256 ecdsa_key\n")
         end
 
-        it 'exports an ssh_known_hosts line for its rsa key' do
-          expect(exported_resources).to contain_concat_fragment('known host example.invalid rsa')
-            .with_target('/etc/ssh/ssh_known_hosts')
-            .with_tag('known_host_public_keys')
+        it "exports an ssh_known_hosts line for its rsa key" do
+          expect(exported_resources).to contain_concat_fragment("known host example.invalid rsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("known_host_public_keys")
             .with_content("example.invalid ssh-rsa rsa_key\n")
         end
       end

--- a/spec/classes/profile/krb5_spec.rb
+++ b/spec/classes/profile/krb5_spec.rb
@@ -3,30 +3,30 @@
 # Copyright (c) 2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::krb5' do
+describe "nebula::profile::krb5" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_package('krb5-user') }
-      it { is_expected.to contain_package('libpam-krb5') }
-      it { is_expected.to contain_class('nebula::profile::networking::keytab') }
+      it { is_expected.to contain_package("krb5-user") }
+      it { is_expected.to contain_package("libpam-krb5") }
+      it { is_expected.to contain_class("nebula::profile::networking::keytab") }
 
       it do
-        expect(subject).to contain_debconf('krb5-config/default_realm')
-          .with_type('string')
-          .with_value('REALM.DEFAULT.INVALID')
+        expect(subject).to contain_debconf("krb5-config/default_realm")
+          .with_type("string")
+          .with_value("REALM.DEFAULT.INVALID")
       end
 
-      context 'with a realm of EXAMPLE.COM' do
-        let(:params) { { realm: 'EXAMPLE.COM' } }
+      context "with a realm of EXAMPLE.COM" do
+        let(:params) { {realm: "EXAMPLE.COM"} }
 
         it do
-          expect(subject).to contain_debconf('krb5-config/default_realm')
-            .with_type('string')
-            .with_value('EXAMPLE.COM')
+          expect(subject).to contain_debconf("krb5-config/default_realm")
+            .with_type("string")
+            .with_value("EXAMPLE.COM")
         end
       end
     end

--- a/spec/classes/profile/kubelet_spec.rb
+++ b/spec/classes/profile/kubelet_spec.rb
@@ -3,96 +3,96 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubelet' do
+describe "nebula::profile::kubelet" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:params) { { kubelet_version: 'invalid-example-version' } }
+      let(:params) { {kubelet_version: "invalid-example-version"} }
 
       it { is_expected.to compile }
 
       # Prerequisites according to kubernetes documentation:
       # https://kubernetes.io/docs/setup/production-environment/container-runtimes/
-      it { is_expected.to contain_kmod__load('overlay') }
-      it { is_expected.to contain_kmod__load('br_netfilter') }
-      it { is_expected.to contain_file('/etc/sysctl.d/kubelet.conf').that_notifies('Service[procps]') }
+      it { is_expected.to contain_kmod__load("overlay") }
+      it { is_expected.to contain_kmod__load("br_netfilter") }
+      it { is_expected.to contain_file("/etc/sysctl.d/kubelet.conf").that_notifies("Service[procps]") }
 
-      ['net.bridge.bridge-nf-call-iptables',
-       'net.bridge.bridge-nf-call-ip6tables',
-       'net.ipv4.ip_forward'].each do |param|
+      ["net.bridge.bridge-nf-call-iptables",
+        "net.bridge.bridge-nf-call-ip6tables",
+        "net.ipv4.ip_forward"].each do |param|
         it do
-          expect(subject).to contain_file('/etc/sysctl.d/kubelet.conf')
+          expect(subject).to contain_file("/etc/sysctl.d/kubelet.conf")
             .with_content(%r{^#{param} *= *1$})
         end
       end
 
-      it { is_expected.to contain_service('containerd') }
+      it { is_expected.to contain_service("containerd") }
 
       it do
-        expect(subject).to contain_apt__source('kubernetes')
-          .with_location('https://pkgs.k8s.io/core:/stable:/vX.YZ/deb/')
-          .with_release('/')
+        expect(subject).to contain_apt__source("kubernetes")
+          .with_location("https://pkgs.k8s.io/core:/stable:/vX.YZ/deb/")
+          .with_release("/")
       end
 
       it do
-        expect(subject).to contain_package('kubelet')
-          .with_ensure('invalid-example-version')
-          .that_requires('Apt::Source[kubernetes]')
+        expect(subject).to contain_package("kubelet")
+          .with_ensure("invalid-example-version")
+          .that_requires("Apt::Source[kubernetes]")
       end
 
       it do
-        expect(subject).to contain_apt__pin('kubelet')
-          .with_packages(['kubelet'])
-          .with_version('invalid-example-version')
+        expect(subject).to contain_apt__pin("kubelet")
+          .with_packages(["kubelet"])
+          .with_version("invalid-example-version")
           .with_priority(999)
       end
 
       it do
-        expect(subject).to contain_service('kubelet')
-          .with_ensure('running')
+        expect(subject).to contain_service("kubelet")
+          .with_ensure("running")
           .with_enable(true)
-          .that_requires('Package[kubelet]')
+          .that_requires("Package[kubelet]")
       end
 
-      context 'with kubelet_version set to 1.2.3-00' do
-        let(:params) { { kubelet_version: '1.2.3-00' } }
+      context "with kubelet_version set to 1.2.3-00" do
+        let(:params) { {kubelet_version: "1.2.3-00"} }
 
-        it { is_expected.to contain_package('kubelet').with_ensure('1.2.3-00') }
-        it { is_expected.to contain_apt__pin('kubelet').with_version('1.2.3-00') }
+        it { is_expected.to contain_package("kubelet").with_ensure("1.2.3-00") }
+        it { is_expected.to contain_apt__pin("kubelet").with_version("1.2.3-00") }
       end
 
       it do
-        expect(subject).to contain_exec('kubelet reload daemon')
-          .that_notifies('Service[kubelet]')
+        expect(subject).to contain_exec("kubelet reload daemon")
+          .that_notifies("Service[kubelet]")
           .with_refreshonly(true)
-          .with_command('/bin/systemctl daemon-reload')
+          .with_command("/bin/systemctl daemon-reload")
       end
 
       it do
-        expect(subject).to contain_file('/etc/kubernetes/manifests')
-          .with_ensure('directory')
+        expect(subject).to contain_file("/etc/kubernetes/manifests")
+          .with_ensure("directory")
           .with_recurse(true)
           .with_purge(true)
-          .that_requires('Package[kubelet]')
+          .that_requires("Package[kubelet]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d')
-          .with_ensure('directory')
-          .that_requires('Package[kubelet]')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d")
+          .with_ensure("directory")
+          .that_requires("Package[kubelet]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf')
-          .that_requires('File[/etc/systemd/system/kubelet.service.d]')
-          .that_requires('Package[kubelet]')
-          .that_notifies('Exec[kubelet reload daemon]')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
+          .that_requires("File[/etc/systemd/system/kubelet.service.d]")
+          .that_requires("Package[kubelet]")
+          .that_notifies("Exec[kubelet reload daemon]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
           .with_content(%r{^Restart=always$})
       end
 
@@ -100,42 +100,42 @@ describe 'nebula::profile::kubelet' do
         # This is important because we're using this file to override
         # the contents of the original systemd file. Without this empty
         # line, systemd might ignore our preferred ExecStart.
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
           .with_content(%r{^ExecStart=$})
       end
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf")
           .with_content(%r{^ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet\.yaml$})
       end
 
       it do
-        expect(subject).to contain_file('/etc/kubernetes/kubelet.yaml')
+        expect(subject).to contain_file("/etc/kubernetes/kubelet.yaml")
           .with_content(%r{address:.*127.0.0.1})
           .with_content(%r{staticPodPath:.*/etc/kubernetes/manifests})
           .with_content(%r{cgroupDriver:.*systemd})
           .with_content(%r{containerRuntimeEndpoint:.*unix:///run/containerd/containerd.sock})
       end
 
-      context 'with pod_manifest_path set to /tmp/kubelet' do
-        let(:params) { { kubelet_version: '123', pod_manifest_path: '/tmp/kubelet' } }
+      context "with pod_manifest_path set to /tmp/kubelet" do
+        let(:params) { {kubelet_version: "123", pod_manifest_path: "/tmp/kubelet"} }
 
-        it { is_expected.not_to contain_file('/etc/kubernetes/manifests') }
-        it { is_expected.to contain_file('/tmp/kubelet') }
+        it { is_expected.not_to contain_file("/etc/kubernetes/manifests") }
+        it { is_expected.to contain_file("/tmp/kubelet") }
 
         it do
-          expect(subject).to contain_file('/etc/kubernetes/kubelet.yaml')
+          expect(subject).to contain_file("/etc/kubernetes/kubelet.yaml")
             .with_content(%r{staticPodPath:.*/tmp/kubelet})
         end
       end
 
-      context 'with manage_pods_with_puppet set to false' do
-        let(:params) { { kubelet_version: '123', manage_pods_with_puppet: false } }
+      context "with manage_pods_with_puppet set to false" do
+        let(:params) { {kubelet_version: "123", manage_pods_with_puppet: false} }
 
-        it { is_expected.not_to contain_file('/etc/kubernetes/manifests') }
-        it { is_expected.not_to contain_file('/etc/systemd/system/kubelet.service.d') }
-        it { is_expected.not_to contain_file('/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf') }
-        it { is_expected.not_to contain_exec('kubelet reload daemon') }
+        it { is_expected.not_to contain_file("/etc/kubernetes/manifests") }
+        it { is_expected.not_to contain_file("/etc/systemd/system/kubelet.service.d") }
+        it { is_expected.not_to contain_file("/etc/systemd/system/kubelet.service.d/20-containerd-and-manifest-dir.conf") }
+        it { is_expected.not_to contain_exec("kubelet reload daemon") }
       end
     end
   end

--- a/spec/classes/profile/kubernetes/apt_spec.rb
+++ b/spec/classes/profile/kubernetes/apt_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::apt' do
+describe "nebula::profile::kubernetes::apt" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      context 'with no kubernetes hiera config' do
+      context "with no kubernetes hiera config" do
         it do
-          expect(subject).to contain_apt__source('kubernetes')
-            .with_location('https://pkgs.k8s.io/core:/stable:/vX.YZ/deb/')
-            .with_release('/')
+          expect(subject).to contain_apt__source("kubernetes")
+            .with_location("https://pkgs.k8s.io/core:/stable:/vX.YZ/deb/")
+            .with_release("/")
         end
       end
 
-      context 'with a kubernetes hiera config' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      context "with a kubernetes hiera config" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_apt__source('kubernetes')
-            .with_location('https://pkgs.k8s.io/core:/stable:/v1.29/deb/')
-            .with_release('/')
+          expect(subject).to contain_apt__source("kubernetes")
+            .with_location("https://pkgs.k8s.io/core:/stable:/v1.29/deb/")
+            .with_release("/")
         end
       end
     end

--- a/spec/classes/profile/kubernetes/bootstrap/destination_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/destination_spec.rb
@@ -3,28 +3,28 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::bootstrap::destination' do
+describe "nebula::profile::kubernetes::bootstrap::destination" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/authorized_keys')
-          .with_owner('kubeadm_bootstrap')
+        expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/authorized_keys")
+          .with_owner("kubeadm_bootstrap")
           .with_content("first cluster public key value\n")
-          .that_requires('File[/var/lib/kubeadm_bootstrap/.ssh]')
+          .that_requires("File[/var/lib/kubeadm_bootstrap/.ssh]")
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/authorized_keys')
+          expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/authorized_keys")
             .with_content("general public key value\n")
         end
       end

--- a/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
@@ -3,47 +3,47 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::bootstrap::etcd_config' do
+describe "nebula::profile::kubernetes::bootstrap::etcd_config" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf')
+        expect(subject).to contain_file("/etc/systemd/system/kubelet.service.d/20-etcd-service-manager.conf")
           .with_content(%r{^ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet\.yaml$})
-          .that_notifies('Exec[kubelet reload daemon]')
-          .that_requires('Package[kubelet]')
-          .that_requires('File[/etc/systemd/system/kubelet.service.d]')
+          .that_notifies("Exec[kubelet reload daemon]")
+          .that_requires("Package[kubelet]")
+          .that_requires("File[/etc/systemd/system/kubelet.service.d]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/kubernetes/kubelet.yaml')
+        expect(subject).to contain_file("/etc/kubernetes/kubelet.yaml")
           .with_content(%r{address:.*127.0.0.1})
           .with_content(%r{staticPodPath:.*/etc/kubernetes/manifests})
           .with_content(%r{cgroupDriver:.*systemd})
           .with_content(%r{containerRuntimeEndpoint:.*unix:///run/containerd/containerd.sock})
       end
 
-      it { is_expected.to contain_file('/etc/systemd/system/kubelet.service.d').with_ensure('directory') }
+      it { is_expected.to contain_file("/etc/systemd/system/kubelet.service.d").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_exec('kubelet reload daemon')
-          .with_command('/bin/systemctl daemon-reload')
+        expect(subject).to contain_exec("kubelet reload daemon")
+          .with_command("/bin/systemctl daemon-reload")
           .with_refreshonly(true)
-          .that_notifies('Service[kubelet]')
+          .that_notifies("Service[kubelet]")
       end
 
-      it { is_expected.to contain_file('/tmp/etcd.yaml') }
+      it { is_expected.to contain_file("/tmp/etcd.yaml") }
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
-        it { is_expected.not_to contain_file('/tmp/etcd.yaml') }
+        it { is_expected.not_to contain_file("/tmp/etcd.yaml") }
       end
     end
   end

--- a/spec/classes/profile/kubernetes/bootstrap/source_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/source_spec.rb
@@ -3,41 +3,41 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::bootstrap::source' do
+describe "nebula::profile::kubernetes::bootstrap::source" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/id_rsa.pub')
-          .with_owner('kubeadm_bootstrap')
+        expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/id_rsa.pub")
+          .with_owner("kubeadm_bootstrap")
           .with_content("first cluster public key value\n")
-          .that_requires('File[/var/lib/kubeadm_bootstrap/.ssh]')
+          .that_requires("File[/var/lib/kubeadm_bootstrap/.ssh]")
       end
 
       it do
-        expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/id_rsa')
-          .with_owner('kubeadm_bootstrap')
-          .with_mode('0600')
+        expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/id_rsa")
+          .with_owner("kubeadm_bootstrap")
+          .with_mode("0600")
           .with_content("first cluster private key value\n")
-          .that_requires('File[/var/lib/kubeadm_bootstrap/.ssh]')
+          .that_requires("File[/var/lib/kubeadm_bootstrap/.ssh]")
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/id_rsa.pub')
+          expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/id_rsa.pub")
             .with_content("general public key value\n")
         end
 
         it do
-          expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh/id_rsa')
+          expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh/id_rsa")
             .with_content("general private key value\n")
         end
       end

--- a/spec/classes/profile/kubernetes/bootstrap/user_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/user_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::bootstrap::user' do
+describe "nebula::profile::kubernetes::bootstrap::user" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -13,23 +13,23 @@ describe 'nebula::profile::kubernetes::bootstrap::user' do
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_user('kubeadm_bootstrap')
-          .with_home('/var/lib/kubeadm_bootstrap')
+        expect(subject).to contain_user("kubeadm_bootstrap")
+          .with_home("/var/lib/kubeadm_bootstrap")
       end
 
       it do
-        expect(subject).to contain_file('/var/lib/kubeadm_bootstrap')
-          .with_ensure('directory')
-          .with_owner('kubeadm_bootstrap')
-          .that_requires('User[kubeadm_bootstrap]')
+        expect(subject).to contain_file("/var/lib/kubeadm_bootstrap")
+          .with_ensure("directory")
+          .with_owner("kubeadm_bootstrap")
+          .that_requires("User[kubeadm_bootstrap]")
       end
 
       it do
-        expect(subject).to contain_file('/var/lib/kubeadm_bootstrap/.ssh')
-          .with_ensure('directory')
-          .with_owner('kubeadm_bootstrap')
-          .with_mode('0700')
-          .that_requires('File[/var/lib/kubeadm_bootstrap]')
+        expect(subject).to contain_file("/var/lib/kubeadm_bootstrap/.ssh")
+          .with_ensure("directory")
+          .with_owner("kubeadm_bootstrap")
+          .with_mode("0700")
+          .that_requires("File[/var/lib/kubeadm_bootstrap]")
       end
     end
   end

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -3,40 +3,40 @@
 # Copyright (c) 2020, 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
 [
-  ['api',        6443, 'check check-ssl verify none'],
-  ['etcd',       2379, 'check'],
-  ['http',      30080, 'check send-proxy'],
-  ['https',     30443, 'check send-proxy'],
-  ['https_alt', 31443, 'check'],
-  ['gelf_tcp',  32201, 'check'],
+  ["api", 6443, "check check-ssl verify none"],
+  ["etcd", 2379, "check"],
+  ["http", 30080, "check send-proxy"],
+  ["https", 30443, "check send-proxy"],
+  ["https_alt", 31443, "check"],
+  ["gelf_tcp", 32201, "check"]
 ].each do |service, port, options|
   describe "nebula::profile::kubernetes::destination_port::#{service}" do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
         let(:facts) { os_facts }
 
         it { is_expected.to compile }
 
-        describe 'exported resources' do
+        describe "exported resources" do
           subject { exported_resources }
 
           it do
-            expect(subject).to contain_concat_fragment("haproxy kubernetes #{service.tr('_', ' ')} #{facts[:hostname]}")
+            expect(subject).to contain_concat_fragment("haproxy kubernetes #{service.tr("_", " ")} #{facts[:hostname]}")
               .with_target("/etc/haproxy/services.d/#{service}.cfg")
-              .with_order('02')
+              .with_order("02")
               .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} #{options}\n")
               .with_tag("first_cluster_haproxy_kubernetes_#{service}")
           end
 
-          if service == 'etcd'
+          if service == "etcd"
             it do
-              expect(subject).to contain_concat_fragment("prometheus #{service.tr('_', ' ')} service #{facts[:hostname]}")
+              expect(subject).to contain_concat_fragment("prometheus #{service.tr("_", " ")} service #{facts[:hostname]}")
                 .with_target("/etc/prometheus/#{service}.yml")
-                .with_tag('mydatacenter_prometheus_etcd_service_list')
+                .with_tag("mydatacenter_prometheus_etcd_service_list")
             end
           end
         end

--- a/spec/classes/profile/kubernetes/dns_client_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_client_spec.rb
@@ -3,61 +3,61 @@
 # Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::dns_client' do
+describe "nebula::profile::kubernetes::dns_client" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) do
         my_facts = os_facts.deep_merge(
           networking: {
-            'interfaces' => {
-              'ens4' => {
-                'ip' => '10.123.234.5',
-              },
+            "interfaces" => {
+              "ens4" => {
+                "ip" => "10.123.234.5"
+              }
             },
-            'ip' => '10.123.234.5',
-            'primary' => 'ens4',
-          },
+            "ip" => "10.123.234.5",
+            "primary" => "ens4"
+          }
         )
-        my_facts[:networking]['interfaces'].delete('eth0')
+        my_facts[:networking]["interfaces"].delete("eth0")
         my_facts
       end
 
       it { is_expected.to compile }
 
       it do
-        expect(exported_resources).to contain_concat_fragment("/etc/hosts ipv4 #{facts[:networking]['ip']}")
-          .with_target('/etc/hosts')
-          .with_order('04')
-          .with_content("#{facts[:networking]['ip']} #{facts[:fqdn]} #{facts[:hostname]}\n")
+        expect(exported_resources).to contain_concat_fragment("/etc/hosts ipv4 #{facts[:networking]["ip"]}")
+          .with_target("/etc/hosts")
+          .with_order("04")
+          .with_content("#{facts[:networking]["ip"]} #{facts[:fqdn]} #{facts[:hostname]}\n")
       end
 
       it do
-        expect(subject).to contain_file('/etc/resolv.conf')
+        expect(subject).to contain_file("/etc/resolv.conf")
           .with_content("search first.cluster\nnameserver 172.16.0.1\n")
       end
 
-      context 'with fqdn of default.invalid and an ssh-rsa public key' do
-        let(:node) { 'default.invalid' }
+      context "with fqdn of default.invalid and an ssh-rsa public key" do
+        let(:node) { "default.invalid" }
         let(:facts) do
           {
-            'ssh' => {
-              'rsa' => {
-                'type' => 'ssh-rsa',
-                'key' => 'abc123',
-              },
-            },
+            "ssh" => {
+              "rsa" => {
+                "type" => "ssh-rsa",
+                "key" => "abc123"
+              }
+            }
           }
         end
 
         it { is_expected.to compile }
 
-        it 'exports an ssh_known_hosts line for its rsa key' do
-          expect(exported_resources).to contain_concat_fragment('known first_cluster host default rsa')
-            .with_target('/etc/ssh/ssh_known_hosts')
-            .with_tag('first_cluster_known_host_public_keys')
+        it "exports an ssh_known_hosts line for its rsa key" do
+          expect(exported_resources).to contain_concat_fragment("known first_cluster host default rsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("first_cluster_known_host_public_keys")
             .with_content("default ssh-rsa abc123\n")
         end
       end

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -3,101 +3,101 @@
 # Copyright (c) 2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::dns_server' do
+describe "nebula::profile::kubernetes::dns_server" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      context 'with cluster set to first_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      context "with cluster set to first_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
         let(:facts) do
           os_facts.merge(
-            'networking' => {
-              'interfaces' => {
-                'ens4' => {
-                  'ip' => '10.123.234.5',
-                },
-              },
-            },
+            "networking" => {
+              "interfaces" => {
+                "ens4" => {
+                  "ip" => "10.123.234.5"
+                }
+              }
+            }
           )
         end
 
         it { is_expected.to compile }
 
-        it { is_expected.to contain_package('dnsmasq') }
-        it { is_expected.to contain_service('dnsmasq').that_requires('Package[dnsmasq]') }
+        it { is_expected.to contain_package("dnsmasq") }
+        it { is_expected.to contain_service("dnsmasq").that_requires("Package[dnsmasq]") }
 
-        it { is_expected.to contain_firewall('200 Nameserver (TCP)').with_proto('tcp') }
-        it { is_expected.to contain_firewall('200 Nameserver (UDP)').with_proto('udp') }
+        it { is_expected.to contain_firewall("200 Nameserver (TCP)").with_proto("tcp") }
+        it { is_expected.to contain_firewall("200 Nameserver (UDP)").with_proto("udp") }
 
         %w[TCP UDP].each do |proto|
           it do
             expect(subject).to contain_firewall("200 Nameserver (#{proto})")
               .with_dport(53)
-              .with_source('172.28.0.0/14')
-              .with_state('NEW')
-              .with_jump('accept')
+              .with_source("172.28.0.0/14")
+              .with_state("NEW")
+              .with_jump("accept")
           end
         end
 
-        it { is_expected.to contain_concat('/etc/hosts').that_notifies('Service[dnsmasq]') }
+        it { is_expected.to contain_concat("/etc/hosts").that_notifies("Service[dnsmasq]") }
 
         it do
-          expect(subject).to contain_concat_fragment('/etc/hosts ipv4 localhost')
-            .with_target('/etc/hosts')
-            .with_order('01')
+          expect(subject).to contain_concat_fragment("/etc/hosts ipv4 localhost")
+            .with_target("/etc/hosts")
+            .with_order("01")
             .with_content("127.0.0.1 localhost\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/etc/hosts ipv4 etcd-all')
-            .with_target('/etc/hosts')
-            .with_order('02')
+          expect(subject).to contain_concat_fragment("/etc/hosts ipv4 etcd-all")
+            .with_target("/etc/hosts")
+            .with_order("02")
             .with_content("172.16.0.6 etcd.first.cluster etcd\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/etc/hosts ipv4 kube-api')
-            .with_target('/etc/hosts')
-            .with_order('03')
+          expect(subject).to contain_concat_fragment("/etc/hosts ipv4 kube-api")
+            .with_target("/etc/hosts")
+            .with_order("03")
             .with_content("172.16.0.7 kube-api.first.cluster kube-api\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/etc/hosts ipv6 localhost')
-            .with_target('/etc/hosts')
-            .with_order('05')
+          expect(subject).to contain_concat_fragment("/etc/hosts ipv6 localhost")
+            .with_target("/etc/hosts")
+            .with_order("05")
             .with_content("::1 localhost ip6-localhost ip6-loopback\n")
         end
 
         it do
-          expect(subject).to contain_file('/etc/dnsmasq.d/smartconnect')
+          expect(subject).to contain_file("/etc/dnsmasq.d/smartconnect")
             .with_content("server=/sc.default.invalid/192.0.2.7\n")
         end
 
         it do
-          expect(subject).to contain_file('/etc/dnsmasq.d/local_domain')
+          expect(subject).to contain_file("/etc/dnsmasq.d/local_domain")
             .with_content("local=/first.cluster/\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('/etc/hosts ipv6 debian')
-            .with_target('/etc/hosts')
-            .with_order('06')
+          expect(subject).to contain_concat_fragment("/etc/hosts ipv6 debian")
+            .with_target("/etc/hosts")
+            .with_order("06")
             .with_content("ff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n")
         end
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
         let(:facts) { os_facts }
 
         it { is_expected.to compile }
 
-        it { is_expected.not_to contain_file('/etc/dnsmasq.d/smartconnect') }
+        it { is_expected.not_to contain_file("/etc/dnsmasq.d/smartconnect") }
 
         it do
-          expect(subject).to contain_file('/etc/dnsmasq.d/local_domain')
+          expect(subject).to contain_file("/etc/dnsmasq.d/local_domain")
             .with_content("local=/second.cluster/\n")
         end
       end

--- a/spec/classes/profile/kubernetes/etcdctl_spec.rb
+++ b/spec/classes/profile/kubernetes/etcdctl_spec.rb
@@ -3,29 +3,29 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::etcdctl' do
+describe "nebula::profile::kubernetes::etcdctl" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('etcd-client') }
-      it { is_expected.to contain_file('/etc/etcd').with_ensure('directory') }
-      it { is_expected.to contain_file('/etc/etcd/README') }
+      it { is_expected.to contain_package("etcd-client") }
+      it { is_expected.to contain_file("/etc/etcd").with_ensure("directory") }
+      it { is_expected.to contain_file("/etc/etcd/README") }
 
       it do
-        expect(subject).to contain_file('/etc/profile.d/etcdctl.sh')
+        expect(subject).to contain_file("/etc/profile.d/etcdctl.sh")
           .with_content(%r{ETCDCTL_ENDPOINTS="10.1.2.3:2379,10.2.4.6:2379,10.3.6.9:2379"})
       end
 
-      context 'when in the second cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "when in the second cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_file('/etc/profile.d/etcdctl.sh')
+          expect(subject).to contain_file("/etc/profile.d/etcdctl.sh")
             .with_content(%r{ETCDCTL_ENDPOINTS="192.168.2.3:2379,192.168.4.6:2379,192.168.6.9:2379"})
         end
       end

--- a/spec/classes/profile/kubernetes/filesystems_spec.rb
+++ b/spec/classes/profile/kubernetes/filesystems_spec.rb
@@ -3,32 +3,32 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::filesystems' do
+describe "nebula::profile::kubernetes::filesystems" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/default_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/default_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('nfs-common') }
+      it { is_expected.to contain_package("nfs-common") }
 
-      context 'when a cifs_mount is defined' do
+      context "when a cifs_mount is defined" do
         let(:params) do
           {
             cifs_mounts: {
-              'bad_thing' => {
-                'remote_target' => '//kubernetes.default.invalid/kubernetes',
-                'uid' => 'default',
-                'gid' => 'default',
-                'user' => 'kubernetes',
-              },
-            },
+              "bad_thing" => {
+                "remote_target" => "//kubernetes.default.invalid/kubernetes",
+                "uid" => "default",
+                "gid" => "default",
+                "user" => "kubernetes"
+              }
+            }
           }
         end
 
-        it { is_expected.to contain_nebula__cifs_mount('/mnt/legacy_cifs_bad_thing') }
+        it { is_expected.to contain_nebula__cifs_mount("/mnt/legacy_cifs_bad_thing") }
       end
     end
   end

--- a/spec/classes/profile/kubernetes/haproxy_spec.rb
+++ b/spec/classes/profile/kubernetes/haproxy_spec.rb
@@ -3,83 +3,83 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::haproxy' do
+describe "nebula::profile::kubernetes::haproxy" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('haproxy') }
-      it { is_expected.to contain_package('haproxyctl') }
+      it { is_expected.to contain_package("haproxy") }
+      it { is_expected.to contain_package("haproxyctl") }
 
       it do
-        expect(subject).to contain_service('haproxy')
-          .with_ensure('running')
+        expect(subject).to contain_service("haproxy")
+          .with_ensure("running")
           .with_enable(true)
-          .that_requires('Package[haproxy]')
+          .that_requires("Package[haproxy]")
       end
 
       it do
-        expect(subject).to contain_nebula__authzd_user('haproxyctl')
-          .with_gid('haproxy')
-          .with_home('/var/haproxyctl')
+        expect(subject).to contain_nebula__authzd_user("haproxyctl")
+          .with_gid("haproxy")
+          .with_home("/var/haproxyctl")
       end
 
-      describe '/etc/default/haproxy' do
-        let(:file) { '/etc/default/haproxy' }
+      describe "/etc/default/haproxy" do
+        let(:file) { "/etc/default/haproxy" }
 
         it do
           expect(subject).to contain_file(file)
             .with_content(%r{^CONFIG="/etc/haproxy/haproxy\.cfg"$})
             .with_content(%r{^EXTRAOPTS="-f /etc/haproxy/services\.d"$})
-            .that_notifies('Service[haproxy]')
+            .that_notifies("Service[haproxy]")
         end
       end
 
-      describe '/etc/haproxy/haproxy.cfg' do
-        let(:file) { '/etc/haproxy/haproxy.cfg' }
+      describe "/etc/haproxy/haproxy.cfg" do
+        let(:file) { "/etc/haproxy/haproxy.cfg" }
 
-        it { is_expected.to contain_file(file).that_notifies('Service[haproxy]') }
+        it { is_expected.to contain_file(file).that_notifies("Service[haproxy]") }
       end
 
-      describe '/etc/haproxy/services.d' do
-        let(:services) { '/etc/haproxy/services.d' }
+      describe "/etc/haproxy/services.d" do
+        let(:services) { "/etc/haproxy/services.d" }
 
-        it { is_expected.to contain_file('/etc/haproxy/services.d').with_ensure('directory') }
+        it { is_expected.to contain_file("/etc/haproxy/services.d").with_ensure("directory") }
 
         [
-          [:kube_api, 6443,  'api'],
-          [:etcd,     2379,  'etcd'],
-          [:public,   80,    'http'],
-          [:public,   443,   'https'],
-          [:private,  8443,  'https_alt'],
-          [:private,  12201, 'gelf_tcp'],
+          [:kube_api, 6443, "api"],
+          [:etcd, 2379, "etcd"],
+          [:public, 80, "http"],
+          [:public, 443, "https"],
+          [:private, 8443, "https_alt"],
+          [:private, 12201, "gelf_tcp"]
         ].each do |ip, port, service|
-          describe 'the firewall' do
+          describe "the firewall" do
             it do
               case ip
               when :public
                 expect(subject).to contain_firewall("200 public #{service}")
-                  .with_proto('tcp')
-                  .with_state('NEW')
-                  .with_jump('accept')
+                  .with_proto("tcp")
+                  .with_state("NEW")
+                  .with_jump("accept")
                   .with_dport(port)
                   .without_source
               when :private
                 expect(subject).to contain_nebula__exposed_port("200 private #{service}")
                   .with_port(port)
-                  .with_block('umich::networks::datacenter')
+                  .with_block("umich::networks::datacenter")
               else
                 expect(subject).to contain_firewall("200 private #{service}")
-                  .with_proto('tcp')
-                  .with_state('NEW')
-                  .with_jump('accept')
+                  .with_proto("tcp")
+                  .with_state("NEW")
+                  .with_jump("accept")
                   .with_dport(port)
-                  .with_source('172.28.0.0/14')
+                  .with_source("172.28.0.0/14")
               end
             end
           end
@@ -89,21 +89,21 @@ describe 'nebula::profile::kubernetes::haproxy' do
             let(:fragment) { "haproxy kubernetes #{service}" }
             let(:ip_address) do
               {
-                public: '10.0.0.1',
-                private: '10.0.0.1',
-                kube_api: '172.16.0.7',
-                etcd: '172.16.0.6',
+                public: "10.0.0.1",
+                private: "10.0.0.1",
+                kube_api: "172.16.0.7",
+                etcd: "172.16.0.6"
               }[ip]
             end
 
-            it { is_expected.to contain_concat(file).that_notifies('Service[haproxy]') }
+            it { is_expected.to contain_concat(file).that_notifies("Service[haproxy]") }
             it { is_expected.to contain_concat_fragment(fragment).with_target(file) }
-            it { is_expected.to contain_concat_fragment(fragment).with_order('01') }
+            it { is_expected.to contain_concat_fragment(fragment).with_order("01") }
 
             [
               %r{^frontend kubernetes-#{service.tr('_', '-')}-front$},
               %r{^backend kubernetes-#{service.tr('_', '-')}-back$},
-              %r{^  default_backend kubernetes-#{service.tr('_', '-')}-back$},
+              %r{^  default_backend kubernetes-#{service.tr('_', '-')}-back$}
             ].each do |line|
               it { is_expected.to contain_concat_fragment(fragment).with_content(line) }
             end
@@ -113,14 +113,14 @@ describe 'nebula::profile::kubernetes::haproxy' do
                 .with_content(%r{^  bind #{ip_address}:#{port}$})
             end
 
-            context 'with cluster set to second_cluster' do
-              let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+            context "with cluster set to second_cluster" do
+              let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
               let(:ip_address) do
                 {
-                  public: '10.0.0.2',
-                  private: '10.0.0.2',
-                  kube_api: '172.16.1.7',
-                  etcd: '172.16.1.6',
+                  public: "10.0.0.2",
+                  private: "10.0.0.2",
+                  kube_api: "172.16.1.7",
+                  etcd: "172.16.1.6"
                 }[ip]
               end
 

--- a/spec/classes/profile/kubernetes/keepalived_spec.rb
+++ b/spec/classes/profile/kubernetes/keepalived_spec.rb
@@ -3,53 +3,53 @@
 # Copyright (c) 2019-2020, 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::keepalived' do
+describe "nebula::profile::kubernetes::keepalived" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('Nebula::Profile::Networking::Sysctl') }
-      it { is_expected.to contain_package('keepalived') }
-      it { is_expected.to contain_package('ipset') }
+      it { is_expected.to contain_class("Nebula::Profile::Networking::Sysctl") }
+      it { is_expected.to contain_package("keepalived") }
+      it { is_expected.to contain_package("ipset") }
 
       it do
-        expect(subject).to contain_service('keepalived')
-          .with_ensure('running')
+        expect(subject).to contain_service("keepalived")
+          .with_ensure("running")
           .with_enable(true)
-          .that_requires(['Package[keepalived]', 'Package[ipset]'])
+          .that_requires(["Package[keepalived]", "Package[ipset]"])
       end
 
-      describe '/etc/keepalived/keepalived.conf' do
-        let(:file) { '/etc/keepalived/keepalived.conf' }
+      describe "/etc/keepalived/keepalived.conf" do
+        let(:file) { "/etc/keepalived/keepalived.conf" }
 
         it do
           expect(subject).to contain_concat(file)
-            .that_notifies('Service[keepalived]')
+            .that_notifies("Service[keepalived]")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('keepalived preamble')
+          expect(subject).to contain_concat_fragment("keepalived preamble")
             .with_target(file)
-            .with_order('01')
+            .with_order("01")
         end
 
-        it 'exports its ip address for first_cluster keepalived peers' do
+        it "exports its ip address for first_cluster keepalived peers" do
           expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:hostname]}")
             .with_target(file)
-            .with_order('02')
+            .with_order("02")
             .with_content(%r{^\s*#{os_facts[:ipaddress]}\s*$}m)
-            .with_tag('first_cluster_keepalived')
+            .with_tag("first_cluster_keepalived")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('keepalived postamble')
+          expect(subject).to contain_concat_fragment("keepalived postamble")
             .with_target(file)
-            .with_order('99')
+            .with_order("99")
         end
 
         [
@@ -61,21 +61,21 @@ describe 'nebula::profile::kubernetes::keepalived' do
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.1 dev ens4[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.6 dev ens4[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.7 dev ens4[^\}]*\}}m,
-          %r{virtual_ipaddress \{[^\}]*192\.168\.123\.234 dev ens4[^\}]*\}}m,
+          %r{virtual_ipaddress \{[^\}]*192\.168\.123\.234 dev ens4[^\}]*\}}m
         ].each do |content|
-          it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(content) }
+          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(content) }
         end
 
-        context 'when cluster is set to second_cluster' do
-          let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+        context "when cluster is set to second_cluster" do
+          let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
-          it 'exports its ip address for second_cluster keepalived peers' do
+          it "exports its ip address for second_cluster keepalived peers" do
             expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:hostname]}")
-              .with_tag('second_cluster_keepalived')
+              .with_tag("second_cluster_keepalived")
           end
 
           it do
-            expect(subject).to contain_concat_fragment('keepalived preamble')
+            expect(subject).to contain_concat_fragment("keepalived preamble")
               .with_content(%r{virtual_ipaddress \{[^\}]*10\.0\.0\.2[^\}]*\}}m)
               .with_content(%r{virtual_ipaddress \{[^\}]*172\.16\.1\.1 dev ens4[^\}]*\}}m)
               .with_content(%r{virtual_ipaddress \{[^\}]*172\.16\.1\.6 dev ens4[^\}]*\}}m)
@@ -83,48 +83,48 @@ describe 'nebula::profile::kubernetes::keepalived' do
           end
         end
 
-        context 'when master is true' do
-          let(:params) { { master: true } }
+        context "when master is true" do
+          let(:params) { {master: true} }
 
           [
             %r{state MASTER},
-            %r{priority 101},
+            %r{priority 101}
           ].each do |content|
-            it { is_expected.to contain_concat_fragment('keepalived preamble').with_content(content) }
+            it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(content) }
           end
         end
       end
 
-      describe '/etc/sysctl.d/keepalived.conf' do
-        let(:file) { '/etc/sysctl.d/keepalived.conf' }
+      describe "/etc/sysctl.d/keepalived.conf" do
+        let(:file) { "/etc/sysctl.d/keepalived.conf" }
 
         it do
           expect(subject).to contain_file(file)
             .with_content(%r{^net.ipv4.ip_nonlocal_bind = 1$})
-            .that_notifies(['Service[keepalived]', 'Service[procps]'])
+            .that_notifies(["Service[keepalived]", "Service[procps]"])
         end
       end
 
-      context 'with fqdn of default.invalid and an ssh-rsa public key' do
+      context "with fqdn of default.invalid and an ssh-rsa public key" do
         let(:facts) do
           {
-            fqdn: 'INVALID_DO_NOT_USE',
-            networking: { 'fqdn' => 'default.invalid' },
+            fqdn: "INVALID_DO_NOT_USE",
+            networking: {"fqdn" => "default.invalid"},
             ssh: {
-              'rsa' => {
-                'type' => 'ssh-rsa',
-                'key' => 'abc123',
-              },
-            },
+              "rsa" => {
+                "type" => "ssh-rsa",
+                "key" => "abc123"
+              }
+            }
           }
         end
 
         it { is_expected.to compile }
 
-        it 'exports an ssh_known_hosts line for its rsa key' do
-          expect(exported_resources).to contain_concat_fragment('known host public.first.cluster default.invalid rsa')
-            .with_target('/etc/ssh/ssh_known_hosts')
-            .with_tag('known_host_public_keys')
+        it "exports an ssh_known_hosts line for its rsa key" do
+          expect(exported_resources).to contain_concat_fragment("known host public.first.cluster default.invalid rsa")
+            .with_target("/etc/ssh/ssh_known_hosts")
+            .with_tag("known_host_public_keys")
             .with_content("public.first.cluster ssh-rsa abc123\n")
         end
       end

--- a/spec/classes/profile/kubernetes/kubeadm_config_spec.rb
+++ b/spec/classes/profile/kubernetes/kubeadm_config_spec.rb
@@ -3,15 +3,15 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::kubeadm_config' do
+describe "nebula::profile::kubernetes::kubeadm_config" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with cluster set to first_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      context "with cluster set to first_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
 
         it { is_expected.to compile }
 
@@ -27,22 +27,22 @@ describe 'nebula::profile::kubernetes::kubeadm_config' do
           %r{^ +endpoints: \['https://172\.16\.0\.6:2379'\]$},
           %r{^ +caFile: '/etc/kubernetes/pki/etcd/ca\.crt'$},
           %r{^ +certFile: '/etc/kubernetes/pki/apiserver-etcd-client\.crt'$},
-          %r{^ +keyFile: '/etc/kubernetes/pki/apiserver-etcd-client\.key'$},
+          %r{^ +keyFile: '/etc/kubernetes/pki/apiserver-etcd-client\.key'$}
         ].each do |line|
-          it { is_expected.to contain_file('/etc/kubeadm_config.yaml').with_content(line) }
+          it { is_expected.to contain_file("/etc/kubeadm_config.yaml").with_content(line) }
         end
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         [
           %r{^kubernetesVersion: '1\.11\.9'$},
           %r{^controlPlaneEndpoint: 'kube-api\.second\.cluster:6443'$},
           %r{^ +podSubnet: '10\.96\.0\.0/12'$},
-          %r{^ +serviceSubnet: '192\.168\.0\.0/16'$},
+          %r{^ +serviceSubnet: '192\.168\.0\.0/16'$}
         ].each do |line|
-          it { is_expected.to contain_file('/etc/kubeadm_config.yaml').with_content(line) }
+          it { is_expected.to contain_file("/etc/kubeadm_config.yaml").with_content(line) }
         end
       end
     end

--- a/spec/classes/profile/kubernetes/kubeadm_spec.rb
+++ b/spec/classes/profile/kubernetes/kubeadm_spec.rb
@@ -3,46 +3,46 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::kubeadm' do
+describe "nebula::profile::kubernetes::kubeadm" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with cluster set to first_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      context "with cluster set to first_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
 
         it { is_expected.to compile }
 
-        it { is_expected.to contain_package('kubeadm').with_ensure('1.14.2-1.1') }
-        it { is_expected.to contain_package('kubeadm').that_requires('Apt::Source[kubernetes]') }
+        it { is_expected.to contain_package("kubeadm").with_ensure("1.14.2-1.1") }
+        it { is_expected.to contain_package("kubeadm").that_requires("Apt::Source[kubernetes]") }
 
         it do
-          expect(subject).to contain_apt__pin('kubeadm').with(
-            packages: ['kubeadm'],
-            version: '1.14.2-1.1',
-            priority: 999,
+          expect(subject).to contain_apt__pin("kubeadm").with(
+            packages: ["kubeadm"],
+            version: "1.14.2-1.1",
+            priority: 999
           )
         end
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
-        it { is_expected.to contain_package('kubeadm').with_ensure('1.11.9-1.2') }
-        it { is_expected.to contain_apt__pin('kubeadm').with_version('1.11.9-1.2') }
+        it { is_expected.to contain_package("kubeadm").with_ensure("1.11.9-1.2") }
+        it { is_expected.to contain_apt__pin("kubeadm").with_version("1.11.9-1.2") }
 
         it do
-          expect(subject).to contain_file('/etc/sysctl.d/kubernetes_cluster.conf')
+          expect(subject).to contain_file("/etc/sysctl.d/kubernetes_cluster.conf")
             .with_content(%r{^fs\.inotify\.max_user_instances *= *8192$})
-            .that_notifies('Service[procps]')
+            .that_notifies("Service[procps]")
         end
 
         it do
-          expect(subject).to contain_file('/etc/sysctl.d/kubernetes_cluster.conf')
+          expect(subject).to contain_file("/etc/sysctl.d/kubernetes_cluster.conf")
             .with_content(%r{^fs\.inotify\.max_user_watches *= *524288$})
-            .that_notifies('Service[procps]')
+            .that_notifies("Service[procps]")
         end
       end
     end

--- a/spec/classes/profile/kubernetes/kubectl_spec.rb
+++ b/spec/classes/profile/kubernetes/kubectl_spec.rb
@@ -3,38 +3,38 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::kubectl' do
+describe "nebula::profile::kubernetes::kubectl" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('kubectl').that_requires('Apt::Source[kubernetes]') }
+      it { is_expected.to contain_package("kubectl").that_requires("Apt::Source[kubernetes]") }
 
-      it { is_expected.to contain_concat('/var/local/generate_pki.sh') }
+      it { is_expected.to contain_concat("/var/local/generate_pki.sh") }
 
       it do
-        expect(subject).to contain_concat_fragment('cluster pki preamble')
-          .with_target('/var/local/generate_pki.sh')
-          .with_order('01')
+        expect(subject).to contain_concat_fragment("cluster pki preamble")
+          .with_target("/var/local/generate_pki.sh")
+          .with_order("01")
           .with_content(%r{^KUBE_INTERNAL_IP='172\.16\.0\.1'$})
       end
 
       it do
-        expect(subject).to contain_concat_fragment('cluster pki functions')
-          .with_target('/var/local/generate_pki.sh')
-          .with_order('03')
+        expect(subject).to contain_concat_fragment("cluster pki functions")
+          .with_target("/var/local/generate_pki.sh")
+          .with_order("03")
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_concat_fragment('cluster pki preamble')
+          expect(subject).to contain_concat_fragment("cluster pki preamble")
             .with_content(%r{^KUBE_INTERNAL_IP='192\.168\.0\.1'$})
         end
       end

--- a/spec/classes/profile/kubernetes/kubelet_spec.rb
+++ b/spec/classes/profile/kubernetes/kubelet_spec.rb
@@ -3,116 +3,116 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::kubelet' do
+describe "nebula::profile::kubernetes::kubelet" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_kmod__load('br_netfilter') }
+      it { is_expected.to contain_kmod__load("br_netfilter") }
 
       it do
-        expect(subject).to contain_file('/etc/sysctl.d/kubelet.conf')
+        expect(subject).to contain_file("/etc/sysctl.d/kubelet.conf")
           .with_content(%r{^net.bridge.bridge-nf-call-ip6tables = 1\nnet.bridge.bridge-nf-call-iptables = 1\nnet.ipv4.ip_forward = 1})
-          .that_notifies('Service[procps]')
+          .that_notifies("Service[procps]")
       end
 
-      context 'with cluster unset' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/default_config.yaml' }
+      context "with cluster unset" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/default_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to one without a kubernetes version' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/implicit_kubernetes_version_config.yaml' }
+      context "with cluster set to one without a kubernetes version" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/implicit_kubernetes_version_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to one without a public ip address' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/implicit_public_address_config.yaml' }
+      context "with cluster set to one without a public ip address" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/implicit_public_address_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to one without a router ip address' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/implicit_router_address_config.yaml' }
+      context "with cluster set to one without a router ip address" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/implicit_router_address_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to one without an etcd ip address' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/implicit_etcd_address_config.yaml' }
+      context "with cluster set to one without an etcd ip address" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/implicit_etcd_address_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to one without a kube-api ip address' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/implicit_kube_api_address_config.yaml' }
+      context "with cluster set to one without a kube-api ip address" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/implicit_kube_api_address_config.yaml" }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with cluster set to first_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      context "with cluster set to first_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
 
-        it { is_expected.to contain_service('kubelet').with_ensure('running') }
-        it { is_expected.to contain_service('kubelet').with_enable(true) }
-        it { is_expected.to contain_service('kubelet').that_requires('Package[kubelet]') }
+        it { is_expected.to contain_service("kubelet").with_ensure("running") }
+        it { is_expected.to contain_service("kubelet").with_enable(true) }
+        it { is_expected.to contain_service("kubelet").that_requires("Package[kubelet]") }
 
-        it { is_expected.to contain_package('kubelet').with_ensure('1.14.2-1.1') }
-        it { is_expected.to contain_package('kubelet').that_requires('Apt::Source[kubernetes]') }
+        it { is_expected.to contain_package("kubelet").with_ensure("1.14.2-1.1") }
+        it { is_expected.to contain_package("kubelet").that_requires("Apt::Source[kubernetes]") }
 
         it do
-          expect(subject).to contain_apt__pin('kubelet').with(
-            packages: ['kubelet'],
-            version: '1.14.2-1.1',
-            priority: 999,
+          expect(subject).to contain_apt__pin("kubelet").with(
+            packages: ["kubelet"],
+            version: "1.14.2-1.1",
+            priority: 999
           )
         end
 
         it do
-          expect(subject).to contain_apt__source('kubernetes').with(
-            location: 'https://pkgs.k8s.io/core:/stable:/v1.29/deb/',
-            release: '/',
-            repos: '',
+          expect(subject).to contain_apt__source("kubernetes").with(
+            location: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/",
+            release: "/",
+            repos: "",
             key: {
-              'name' => 'k8s.io.asc',
-              'source' => 'puppet:///modules/nebula/apt/keyrings/k8s.io.asc',
-            },
+              "name" => "k8s.io.asc",
+              "source" => "puppet:///modules/nebula/apt/keyrings/k8s.io.asc"
+            }
           )
         end
 
         [
-          [22,                 'ssh',            'tcp'],
-          [179,                'BGP',            'tcp'],
-          [4789,               'VXLAN',          'udp'],
-          [%w[2379 2380 2381], 'etcd',           'tcp'],
-          [10250,              'kubelet',        'tcp'],
-          [6443,               'kubernetes API', 'tcp'],
+          [22, "ssh", "tcp"],
+          [179, "BGP", "tcp"],
+          [4789, "VXLAN", "udp"],
+          [%w[2379 2380 2381], "etcd", "tcp"],
+          [10250, "kubelet", "tcp"],
+          [6443, "kubernetes API", "tcp"],
           %w[30000:32767 NodePorts tcp],
-          [9100, 'Prometheus', 'tcp'],
+          [9100, "Prometheus", "tcp"]
         ].each do |ports, purpose, proto|
           it do
             expect(subject).to contain_firewall("200 Cluster #{purpose}")
               .with_proto(proto)
               .with_dport(ports)
-              .with_source('172.28.0.0/14')
-              .with_state('NEW')
-              .with_jump('accept')
+              .with_source("172.28.0.0/14")
+              .with_state("NEW")
+              .with_jump("accept")
           end
         end
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
-        it { is_expected.to contain_package('kubelet').with_ensure('1.11.9-1.2') }
-        it { is_expected.to contain_apt__pin('kubelet').with_version('1.11.9-1.2') }
-        it { is_expected.to contain_firewall('200 Cluster BGP').with_source('10.123.234.0/24') }
+        it { is_expected.to contain_package("kubelet").with_ensure("1.11.9-1.2") }
+        it { is_expected.to contain_apt__pin("kubelet").with_version("1.11.9-1.2") }
+        it { is_expected.to contain_firewall("200 Cluster BGP").with_source("10.123.234.0/24") }
       end
     end
   end

--- a/spec/classes/profile/kubernetes/prometheus_spec.rb
+++ b/spec/classes/profile/kubernetes/prometheus_spec.rb
@@ -3,22 +3,22 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::prometheus' do
+describe "nebula::profile::kubernetes::prometheus" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_file('/var/local/prometheus').with_ensure('directory') }
+      it { is_expected.to contain_file("/var/local/prometheus").with_ensure("directory") }
 
       it do
-        expect(subject).to contain_concat_file('/etc/prometheus/nodes.yml')
-          .with_path('/var/local/prometheus/nodes.yml')
-          .with_require('File[/var/local/prometheus]')
+        expect(subject).to contain_concat_file("/etc/prometheus/nodes.yml")
+          .with_path("/var/local/prometheus/nodes.yml")
+          .with_require("File[/var/local/prometheus]")
       end
     end
   end

--- a/spec/classes/profile/kubernetes/router_spec.rb
+++ b/spec/classes/profile/kubernetes/router_spec.rb
@@ -3,68 +3,68 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::kubernetes::router' do
+describe "nebula::profile::kubernetes::router" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_file('/etc/sysctl.d/router.conf')
+        expect(subject).to contain_file("/etc/sysctl.d/router.conf")
           .with_content(%r{^net\.ipv4\.ip_forward *= *1$})
-          .that_notifies('Service[procps]')
+          .that_notifies("Service[procps]")
       end
 
       it do
-        expect(subject).to contain_firewall('001 Do not NAT internal requests')
-          .with_table('nat')
-          .with_chain('POSTROUTING')
-          .with_jump('accept')
-          .with_proto('all')
-          .with_source('172.28.0.0/14')
-          .with_destination('172.28.0.0/14')
+        expect(subject).to contain_firewall("001 Do not NAT internal requests")
+          .with_table("nat")
+          .with_chain("POSTROUTING")
+          .with_jump("accept")
+          .with_proto("all")
+          .with_source("172.28.0.0/14")
+          .with_destination("172.28.0.0/14")
       end
 
       it do
-        expect(subject).to contain_firewall('002 Give internal requests our private IP')
-          .with_table('nat')
-          .with_chain('POSTROUTING')
-          .with_jump('SNAT')
-          .with_proto('all')
-          .with_source('172.28.0.0/14')
-          .with_tosource('192.168.123.234')
-          .with_destination('192.168.0.0/16')
+        expect(subject).to contain_firewall("002 Give internal requests our private IP")
+          .with_table("nat")
+          .with_chain("POSTROUTING")
+          .with_jump("SNAT")
+          .with_proto("all")
+          .with_source("172.28.0.0/14")
+          .with_tosource("192.168.123.234")
+          .with_destination("192.168.0.0/16")
       end
 
       it do
-        expect(subject).to contain_firewall('003 Give external requests our public IP')
-          .with_table('nat')
-          .with_chain('POSTROUTING')
-          .with_jump('SNAT')
-          .with_proto('all')
-          .with_source('172.28.0.0/14')
-          .with_tosource('10.0.0.1')
+        expect(subject).to contain_firewall("003 Give external requests our public IP")
+          .with_table("nat")
+          .with_chain("POSTROUTING")
+          .with_jump("SNAT")
+          .with_proto("all")
+          .with_source("172.28.0.0/14")
+          .with_tosource("10.0.0.1")
       end
 
-      context 'with cluster set to second_cluster' do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/second_cluster_config.yaml' }
+      context "with cluster set to second_cluster" do
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
         it do
-          expect(subject).to contain_firewall('001 Do not NAT internal requests')
-            .with_source('10.123.234.0/24')
-            .with_destination('10.123.234.0/24')
+          expect(subject).to contain_firewall("001 Do not NAT internal requests")
+            .with_source("10.123.234.0/24")
+            .with_destination("10.123.234.0/24")
         end
 
-        it { is_expected.not_to contain_firewall('002 Give internal requests our private IP') }
+        it { is_expected.not_to contain_firewall("002 Give internal requests our private IP") }
 
         it do
-          expect(subject).to contain_firewall('003 Give external requests our public IP')
-            .with_source('10.123.234.0/24')
-            .with_tosource('10.0.0.2')
+          expect(subject).to contain_firewall("003 Give external requests our public IP")
+            .with_source("10.123.234.0/24")
+            .with_tosource("10.0.0.2")
         end
       end
     end

--- a/spec/classes/profile/logrotate_spec.rb
+++ b/spec/classes/profile/logrotate_spec.rb
@@ -3,20 +3,20 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::logrotate' do
+describe "nebula::profile::logrotate" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it 'sets debian defaults in /etc/logrotate.conf' do
-        expect(subject).to contain_logrotate__conf('/etc/logrotate.conf').with(
+      it "sets debian defaults in /etc/logrotate.conf" do
+        expect(subject).to contain_logrotate__conf("/etc/logrotate.conf").with(
           create: true,
-          rotate_every: 'weekly',
-          rotate: 4,
+          rotate_every: "weekly",
+          rotate: 4
         )
       end
 
@@ -24,26 +24,26 @@ describe 'nebula::profile::logrotate' do
       # reason to stop doing that, although we switched them from
       # monthly to weekly, as they can get very large otherwise.
       it "contains debian's wtmp logrotate config" do
-        expect(subject).to contain_logrotate__rule('wtmp').with(
-          path: '/var/log/wtmp',
+        expect(subject).to contain_logrotate__rule("wtmp").with(
+          path: "/var/log/wtmp",
           missingok: true,
-          rotate_every: 'week',
-          create_mode: '0664',
-          create_owner: 'root',
-          create_group: 'utmp',
-          rotate: 4,
+          rotate_every: "week",
+          create_mode: "0664",
+          create_owner: "root",
+          create_group: "utmp",
+          rotate: 4
         )
       end
 
       it "contains debian's btmp logrotate config" do
-        expect(subject).to contain_logrotate__rule('btmp').with(
-          path: '/var/log/btmp',
+        expect(subject).to contain_logrotate__rule("btmp").with(
+          path: "/var/log/btmp",
           missingok: true,
-          rotate_every: 'week',
-          create_mode: '0660',
-          create_owner: 'root',
-          create_group: 'utmp',
-          rotate: 4,
+          rotate_every: "week",
+          create_mode: "0660",
+          create_owner: "root",
+          create_group: "utmp",
+          rotate: 4
         )
       end
     end

--- a/spec/classes/profile/loki_spec.rb
+++ b/spec/classes/profile/loki_spec.rb
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::loki' do
+describe "nebula::profile::loki" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_apt__source('grafana') }
-      it { is_expected.to contain_package('alloy') }
-      it { is_expected.to contain_service('alloy') }
+      it { is_expected.to contain_apt__source("grafana") }
+      it { is_expected.to contain_package("alloy") }
+      it { is_expected.to contain_service("alloy") }
 
-      it { is_expected.to contain_file('/var/lib/alloy/crt.pem') }
-      it { is_expected.to contain_file('/var/lib/alloy/crt.key').with_mode('0600').with_owner('alloy') }
+      it { is_expected.to contain_file("/var/lib/alloy/crt.pem") }
+      it { is_expected.to contain_file("/var/lib/alloy/crt.key").with_mode("0600").with_owner("alloy") }
 
-      it 'writes /etc/default/alloy to set up /etc/alloy/ as a drop-in config dir' do
-        expect(subject).to contain_file('/etc/default/alloy')
+      it "writes /etc/default/alloy to set up /etc/alloy/ as a drop-in config dir" do
+        expect(subject).to contain_file("/etc/default/alloy")
           .with_content(%r{CONFIG_FILE="/etc/alloy/"})
           .with_content(%r{managed by Puppet})
       end
 
-      it 'writes grafana alloy config' do
-        expect(subject).to contain_file('/etc/alloy/config.alloy')
+      it "writes grafana alloy config" do
+        expect(subject).to contain_file("/etc/alloy/config.alloy")
           .with_content(%r{managed by Puppet})
           .with_content(%r{stage.static_labels \{values = \{"hostname" = "})
           .with_content(%r{url = "https://loki-gateway.loki/loki/api/v1/push"})
       end
 
-      context('with loki url set') do
-        let(:params) { { endpoint_url: 'https://loki.example.com/loki/api/v1/push' } }
+      context("with loki url set") do
+        let(:params) { {endpoint_url: "https://loki.example.com/loki/api/v1/push"} }
 
-        it 'writes loki url to config.alloy' do
-          expect(subject).to contain_file('/etc/alloy/config.alloy')
+        it "writes loki url to config.alloy" do
+          expect(subject).to contain_file("/etc/alloy/config.alloy")
             .with_content(%r{url = "https://loki.example.com/loki/api/v1/push"})
         end
       end

--- a/spec/classes/profile/managed_known_hosts_spec.rb
+++ b/spec/classes/profile/managed_known_hosts_spec.rb
@@ -3,23 +3,23 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::managed_known_hosts' do
+describe "nebula::profile::managed_known_hosts" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_concat('/etc/ssh/ssh_known_hosts') }
+      it { is_expected.to contain_concat("/etc/ssh/ssh_known_hosts") }
 
-      context 'with static_host_keys set' do
-        let(:params) { { static_host_keys: { 'myhost' => { 'ssh-ed25519' => 'abc123==' } } } }
+      context "with static_host_keys set" do
+        let(:params) { {static_host_keys: {"myhost" => {"ssh-ed25519" => "abc123=="}}} }
 
         it do
-          expect(subject).to contain_concat_fragment('static known host myhost ssh-ed25519')
-            .with_tag('known_host_public_keys')
-            .with_target('/etc/ssh/ssh_known_hosts')
+          expect(subject).to contain_concat_fragment("static known host myhost ssh-ed25519")
+            .with_tag("known_host_public_keys")
+            .with_target("/etc/ssh/ssh_known_hosts")
             .with_content("myhost ssh-ed25519 abc123==\n")
         end
       end

--- a/spec/classes/profile/monitor_pl_spec.rb
+++ b/spec/classes/profile/monitor_pl_spec.rb
@@ -3,69 +3,69 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::monitor_pl' do
+describe "nebula::profile::monitor_pl" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:params) { { directory: '/somewhere' } }
-      let(:outfile) { '/somewhere/monitor_config.yaml' }
+      let(:params) { {directory: "/somewhere"} }
+      let(:outfile) { "/somewhere/monitor_config.yaml" }
 
-      it { is_expected.to contain_concat_file(outfile).with(format: 'yaml', tag: 'monitor_config') }
+      it { is_expected.to contain_concat_file(outfile).with(format: "yaml", tag: "monitor_config") }
 
-      context 'with default parameters' do
+      context "with default parameters" do
         it {
-          expect(subject).to contain_concat_fragment('monitor nfs mounts')
-            .with(tag: 'monitor_config', content: %r{nfs: \[\]})
+          expect(subject).to contain_concat_fragment("monitor nfs mounts")
+            .with(tag: "monitor_config", content: %r{nfs: \[\]})
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor solr cores')
-            .with(tag: 'monitor_config', content: %r{solr: \[\]})
+          expect(subject).to contain_concat_fragment("monitor solr cores")
+            .with(tag: "monitor_config", content: %r{solr: \[\]})
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor mysql')
-            .with(tag: 'monitor_config', content: %r{mysql:})
+          expect(subject).to contain_concat_fragment("monitor mysql")
+            .with(tag: "monitor_config", content: %r{mysql:})
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor shibboleth')
-            .with(tag: 'monitor_config', content: %r{shibd: false})
+          expect(subject).to contain_concat_fragment("monitor shibboleth")
+            .with(tag: "monitor_config", content: %r{shibd: false})
         }
       end
 
-      context 'with parameter values' do
+      context "with parameter values" do
         let(:params) do
           {
-            directory: '/somewhere',
-            nfs_mounts: ['/nfs1', '/nfs2'],
-            solr_cores: ['http://solr-something:8081/whatever'],
-            mysql: { 'host' => 'mysql-whatever', 'user' => 'someuser',
-                     'password' => 'something', 'database' => 'mydatabase' },
-            shibboleth: true,
+            directory: "/somewhere",
+            nfs_mounts: ["/nfs1", "/nfs2"],
+            solr_cores: ["http://solr-something:8081/whatever"],
+            mysql: {"host" => "mysql-whatever", "user" => "someuser",
+                    "password" => "something", "database" => "mydatabase"},
+            shibboleth: true
           }
         end
 
         it {
-          expect(subject).to contain_concat_fragment('monitor nfs mounts')
-            .with(tag: 'monitor_config', content: YAML.dump('nfs' => params[:nfs_mounts]))
+          expect(subject).to contain_concat_fragment("monitor nfs mounts")
+            .with(tag: "monitor_config", content: YAML.dump("nfs" => params[:nfs_mounts]))
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor solr cores')
-            .with(tag: 'monitor_config', content: YAML.dump('solr' => params[:solr_cores]))
+          expect(subject).to contain_concat_fragment("monitor solr cores")
+            .with(tag: "monitor_config", content: YAML.dump("solr" => params[:solr_cores]))
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor mysql')
-            .with(tag: 'monitor_config', content: YAML.dump('mysql' => params[:mysql]))
+          expect(subject).to contain_concat_fragment("monitor mysql")
+            .with(tag: "monitor_config", content: YAML.dump("mysql" => params[:mysql]))
         }
 
         it {
-          expect(subject).to contain_concat_fragment('monitor shibboleth')
-            .with(tag: 'monitor_config', content: YAML.dump('shibd' => params[:shibboleth]))
+          expect(subject).to contain_concat_fragment("monitor shibboleth")
+            .with(tag: "monitor_config", content: YAML.dump("shibd" => params[:shibboleth]))
         }
       end
     end

--- a/spec/classes/profile/mysql_spec.rb
+++ b/spec/classes/profile/mysql_spec.rb
@@ -3,13 +3,13 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::mysql' do
+describe "nebula::profile::mysql" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:params) { { password: 'some_password' } }
+      let(:params) { {password: "some_password"} }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
+++ b/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::firewall::http_datacenters' do
+describe "nebula::profile::networking::firewall::http_datacenters" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -14,32 +14,32 @@ describe 'nebula::profile::networking::firewall::http_datacenters' do
 
       it { is_expected.to have_firewall_resource_count(0) }
 
-      context 'with a CIDR range' do
-        let(:params) { { networks: [{ 'name' => 'somedc', 'block' => '10.1.2.0/24', 'datacenter' => 'somedc' }] } }
+      context "with a CIDR range" do
+        let(:params) { {networks: [{"name" => "somedc", "block" => "10.1.2.0/24", "datacenter" => "somedc"}]} }
 
-        it { is_expected.to contain_firewall('200 HTTP: somedc').with_source('10.1.2.0/24') }
+        it { is_expected.to contain_firewall("200 HTTP: somedc").with_source("10.1.2.0/24") }
       end
 
-      context 'with deeply-nested ranges and nodes in other datacenters' do
+      context "with deeply-nested ranges and nodes in other datacenters" do
         let(:params) do
           {
             networks: [
               [
-                { 'name' => 'test range 1-1', 'block' => '10.1.1.0/24', 'datacenter' => 'dc1' },
-                { 'name' => 'test range 1-2', 'block' => '10.1.2.0/24', 'datacenter' => 'dc2' },
+                {"name" => "test range 1-1", "block" => "10.1.1.0/24", "datacenter" => "dc1"},
+                {"name" => "test range 1-2", "block" => "10.1.2.0/24", "datacenter" => "dc2"}
               ],
               [
-                { 'name' => 'test range 2-1', 'block' => '10.2.1.0/24', 'datacenter' => 'dc2' },
-                { 'name' => 'test range 2-2', 'block' => '10.2.2.0/24', 'datacenter' => 'dc2' },
-              ],
-            ],
+                {"name" => "test range 2-1", "block" => "10.2.1.0/24", "datacenter" => "dc2"},
+                {"name" => "test range 2-2", "block" => "10.2.2.0/24", "datacenter" => "dc2"}
+              ]
+            ]
           }
         end
 
-        it { is_expected.to contain_firewall('200 HTTP: test range 1-1').with_source('10.1.1.0/24').with_dport([80, 443]) }
-        it { is_expected.to contain_firewall('200 HTTP: test range 1-2').with_source('10.1.2.0/24').with_dport([80, 443]) }
-        it { is_expected.to contain_firewall('200 HTTP: test range 2-1').with_source('10.2.1.0/24').with_dport([80, 443]) }
-        it { is_expected.to contain_firewall('200 HTTP: test range 2-2').with_source('10.2.2.0/24').with_dport([80, 443]) }
+        it { is_expected.to contain_firewall("200 HTTP: test range 1-1").with_source("10.1.1.0/24").with_dport([80, 443]) }
+        it { is_expected.to contain_firewall("200 HTTP: test range 1-2").with_source("10.1.2.0/24").with_dport([80, 443]) }
+        it { is_expected.to contain_firewall("200 HTTP: test range 2-1").with_source("10.2.1.0/24").with_dport([80, 443]) }
+        it { is_expected.to contain_firewall("200 HTTP: test range 2-2").with_source("10.2.2.0/24").with_dport([80, 443]) }
       end
     end
   end

--- a/spec/classes/profile/networking/firewall/private_ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/private_ssh_spec.rb
@@ -3,39 +3,39 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::firewall::private_ssh' do
+describe "nebula::profile::networking::firewall::private_ssh" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      context 'with cidrs set to 10.0.0.0/8' do
-        let(:params) { { cidrs: %w[10.0.0.0/8] } }
+      context "with cidrs set to 10.0.0.0/8" do
+        let(:params) { {cidrs: %w[10.0.0.0/8]} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_state('NEW') }
-        it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_jump('accept') }
-        it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_proto('tcp') }
-        it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_dport(22) }
-        it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_source('10.0.0.0/8') }
+        it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_state("NEW") }
+        it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_jump("accept") }
+        it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_proto("tcp") }
+        it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_dport(22) }
+        it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_source("10.0.0.0/8") }
 
-        context 'with port set to 8080' do
+        context "with port set to 8080" do
           let(:params) { super().merge(port: 8080) }
 
           it { is_expected.to compile }
-          it { is_expected.to contain_firewall('100 Private SSH: 10.0.0.0/8').with_dport(8080) }
+          it { is_expected.to contain_firewall("100 Private SSH: 10.0.0.0/8").with_dport(8080) }
         end
       end
 
-      context 'with cidrs set to 172.16.0.0/12 and 192.168.0.0/16' do
-        let(:params) { { cidrs: %w[172.16.0.0/12 192.168.0.0/16] } }
+      context "with cidrs set to 172.16.0.0/12 and 192.168.0.0/16" do
+        let(:params) { {cidrs: %w[172.16.0.0/12 192.168.0.0/16]} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_firewall('100 Private SSH: 172.16.0.0/12').with_source('172.16.0.0/12') }
-        it { is_expected.to contain_firewall('100 Private SSH: 192.168.0.0/16').with_source('192.168.0.0/16') }
+        it { is_expected.to contain_firewall("100 Private SSH: 172.16.0.0/12").with_source("172.16.0.0/12") }
+        it { is_expected.to contain_firewall("100 Private SSH: 192.168.0.0/16").with_source("192.168.0.0/16") }
       end
     end
   end

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -3,47 +3,47 @@
 # Copyright (c) 2018-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::firewall::ssh' do
+describe "nebula::profile::networking::firewall::ssh" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'when publicly accessible' do
+      context "when publicly accessible" do
         let(:facts) do
           super().merge(
-            'networking' => {
-              'interfaces' => { 'eth0' => { 'ip' => '123.45.67.89' } },
-            },
+            "networking" => {
+              "interfaces" => {"eth0" => {"ip" => "123.45.67.89"}}
+            }
           )
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_nebula__exposed_port('100 SSH').with(
+          expect(subject).to contain_nebula__exposed_port("100 SSH").with(
             port: 22,
-            block: 'umich::networks::all_trusted_machines',
+            block: "umich::networks::all_trusted_machines"
           )
         end
       end
 
-      context 'when publicly inaccessible' do
+      context "when publicly inaccessible" do
         let(:facts) do
           super().merge(
-            'networking' => {
-              'interfaces' => { 'eth0' => { 'ip' => '10.45.67.89' } },
-            },
+            "networking" => {
+              "interfaces" => {"eth0" => {"ip" => "10.45.67.89"}}
+            }
           )
         end
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_nebula__exposed_port('100 SSH').with(
+          expect(subject).to contain_nebula__exposed_port("100 SSH").with(
             port: 22,
-            block: 'umich::networks::all_trusted_machines',
+            block: "umich::networks::all_trusted_machines"
           )
         end
       end

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -3,122 +3,122 @@
 # Copyright (c) 2018-2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::profile::networking::firewall' do
+describe "nebula::profile::networking::firewall" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/firewall_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/firewall_config.yaml" }
 
       it do
-        expect(subject).to contain_firewall('001 accept related established rules').with(
-          proto: 'all',
+        expect(subject).to contain_firewall("001 accept related established rules").with(
+          proto: "all",
           state: %w[RELATED ESTABLISHED],
-          jump: 'accept',
+          jump: "accept"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('001 accept related established rules (v6)').with(
-          proto: 'all',
+        expect(subject).to contain_firewall("001 accept related established rules (v6)").with(
+          proto: "all",
           state: %w[RELATED ESTABLISHED],
-          jump: 'accept',
-          protocol: 'ip6tables',
+          jump: "accept",
+          protocol: "ip6tables"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('001 accept all to lo interface').with(
-          proto: 'all',
-          iniface: 'lo',
-          jump: 'accept',
+        expect(subject).to contain_firewall("001 accept all to lo interface").with(
+          proto: "all",
+          iniface: "lo",
+          jump: "accept"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('001 accept all to lo interface (v6)').with(
-          proto: 'all',
-          iniface: 'lo',
-          jump: 'accept',
-          protocol: 'ip6tables',
+        expect(subject).to contain_firewall("001 accept all to lo interface (v6)").with(
+          proto: "all",
+          iniface: "lo",
+          jump: "accept",
+          protocol: "ip6tables"
         )
       end
 
       it do
         # from hiera
-        expect(subject).to contain_firewall('200 HTTP: custom rule').with(
-          proto: 'tcp',
+        expect(subject).to contain_firewall("200 HTTP: custom rule").with(
+          proto: "tcp",
           dport: %w[8081 8082],
-          source: '10.2.3.4',
-          state: 'NEW',
-          jump: 'accept',
+          source: "10.2.3.4",
+          state: "NEW",
+          jump: "accept"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('200 NTP: custom rule').with(
-          proto: 'udp',
+        expect(subject).to contain_firewall("200 NTP: custom rule").with(
+          proto: "udp",
           dport: 123,
-          source: '10.4.5.6',
-          state: 'NEW',
-          jump: 'accept',
+          source: "10.4.5.6",
+          state: "NEW",
+          jump: "accept"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('900 port forwarding: an advanced rule').with(
-          table: 'nat',
-          proto: 'tcp',
-          dport: '4657',
-          jump: 'REDIRECT',
-          chain: 'PREROUTING',
-          toports: '1234',
+        expect(subject).to contain_firewall("900 port forwarding: an advanced rule").with(
+          table: "nat",
+          proto: "tcp",
+          dport: "4657",
+          jump: "REDIRECT",
+          chain: "PREROUTING",
+          toports: "1234"
         )
-        expect(subject).not_to contain_firewall('900 port forwarding: an advanced rule').with(
-          jump: 'accept',
-          state: 'NEW',
-        )
-      end
-
-      it do
-        expect(subject).to contain_firewall('999 drop all').with(
-          proto: 'all',
-          jump: 'drop',
+        expect(subject).not_to contain_firewall("900 port forwarding: an advanced rule").with(
+          jump: "accept",
+          state: "NEW"
         )
       end
 
       it do
-        expect(subject).to contain_firewall('999 drop all (v6)').with(
-          proto: 'all',
-          jump: 'drop',
-          protocol: 'ip6tables',
+        expect(subject).to contain_firewall("999 drop all").with(
+          proto: "all",
+          jump: "drop"
+        )
+      end
+
+      it do
+        expect(subject).to contain_firewall("999 drop all (v6)").with(
+          proto: "all",
+          jump: "drop",
+          protocol: "ip6tables"
         )
       end
 
       it { is_expected.to have_firewall_resource_count(9) }
 
-      it { is_expected.to contain_package('iptables-persistent') }
-      it { is_expected.to contain_package('netfilter-persistent') }
+      it { is_expected.to contain_package("iptables-persistent") }
+      it { is_expected.to contain_package("netfilter-persistent") }
 
-      it { is_expected.to contain_resources('firewall').with_purge(true) }
+      it { is_expected.to contain_resources("firewall").with_purge(true) }
 
-      context 'when internal_routing is set to kubernetes_calico' do
-        let(:params) { { internal_routing: 'kubernetes_calico' } }
+      context "when internal_routing is set to kubernetes_calico" do
+        let(:params) { {internal_routing: "kubernetes_calico"} }
 
-        it { is_expected.not_to contain_resources('firewall') }
+        it { is_expected.not_to contain_resources("firewall") }
 
         %w[INPUT OUTPUT FORWARD].each do |chain|
           it do
             expect(subject).to contain_firewallchain("#{chain}:filter:IPv4")
-              .with_ensure('present')
+              .with_ensure("present")
               .with_purge(false)
           end
 
           it do
             expect(subject).to contain_firewallchain("#{chain}:filter:IPv6")
-              .with_ensure('present')
+              .with_ensure("present")
               .with_purge(false)
           end
         end

--- a/spec/classes/profile/networking/keytab_spec.rb
+++ b/spec/classes/profile/networking/keytab_spec.rb
@@ -3,61 +3,61 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::keytab' do
+describe "nebula::profile::networking::keytab" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.not_to contain_file('/etc/krb5.keytab') }
+      it { is_expected.not_to contain_file("/etc/krb5.keytab") }
 
-      context 'when given an existing keytab file' do
-        let(:params) { { keytab: 'nebula/keytab.fake' } }
+      context "when given an existing keytab file" do
+        let(:params) { {keytab: "nebula/keytab.fake"} }
 
         it do
-          expect(subject).to contain_file('/etc/krb5.keytab').with(
-            mode: '0600',
-            content: %r{^This is not a real keytab.},
+          expect(subject).to contain_file("/etc/krb5.keytab").with(
+            mode: "0600",
+            content: %r{^This is not a real keytab.}
           )
         end
       end
 
-      context 'when given a nonexistent keytab file' do
-        let(:params) { { keytab: 'nebula/keytab.not_a_file' } }
+      context "when given a nonexistent keytab file" do
+        let(:params) { {keytab: "nebula/keytab.not_a_file"} }
 
-        it { is_expected.not_to contain_file('/etc/krb5.keytab') }
+        it { is_expected.not_to contain_file("/etc/krb5.keytab") }
       end
 
-      context 'when given a keytab source and no keytab' do
-        let(:params) { { keytab_source: 'alternate source' } }
+      context "when given a keytab source and no keytab" do
+        let(:params) { {keytab_source: "alternate source"} }
 
-        it { is_expected.not_to contain_file('/etc/krb5.keytab') }
+        it { is_expected.not_to contain_file("/etc/krb5.keytab") }
       end
 
-      context 'when given a keytab source and a nonexistent keytab' do
+      context "when given a keytab source and a nonexistent keytab" do
         let :params do
           {
-            keytab: 'nebula/keytab.not_a_file',
-            keytab_source: 'alternate source',
+            keytab: "nebula/keytab.not_a_file",
+            keytab_source: "alternate source"
           }
         end
 
-        it { is_expected.not_to contain_file('/etc/krb5.keytab') }
+        it { is_expected.not_to contain_file("/etc/krb5.keytab") }
       end
 
-      context 'when given a keytab source and a real keytab' do
+      context "when given a keytab source and a real keytab" do
         let :params do
           {
-            keytab: 'nebula/keytab.fake',
-            keytab_source: 'alternate source',
+            keytab: "nebula/keytab.fake",
+            keytab_source: "alternate source"
           }
         end
 
         it do
-          expect(subject).to contain_file('/etc/krb5.keytab').with(
-            mode: '0600',
-            source: 'alternate source',
+          expect(subject).to contain_file("/etc/krb5.keytab").with(
+            mode: "0600",
+            source: "alternate source"
           )
         end
       end

--- a/spec/classes/profile/networking/private_spec.rb
+++ b/spec/classes/profile/networking/private_spec.rb
@@ -3,28 +3,28 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::private' do
+describe "nebula::profile::networking::private" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
-        os_facts.merge(networking: { ip: '1.2.3.123' })
+        os_facts.merge(networking: {ip: "1.2.3.123"})
       end
 
-      context 'with fully-specified parameters' do
+      context "with fully-specified parameters" do
         let(:params) do
           {
-            address_template: '10.0.2.%s',
-            netmask: '255.255.0.0',
-            network: '10.0.0.0',
-            broadcast: '10.0.255.255',
-            interface: 'eth1',
+            address_template: "10.0.2.%s",
+            netmask: "255.255.0.0",
+            network: "10.0.0.0",
+            broadcast: "10.0.255.255",
+            interface: "eth1"
           }
         end
 
         it do
-          expect(subject).to contain_file('/etc/network/interfaces.d/private').with_content(<<~IFACE)
+          expect(subject).to contain_file("/etc/network/interfaces.d/private").with_content(<<~IFACE)
             auto eth1
             iface eth1 inet static
               address 10.0.2.123
@@ -35,24 +35,24 @@ describe 'nebula::profile::networking::private' do
         end
       end
 
-      context 'with no interface' do
-        it { is_expected.not_to contain_file('/etc/network/interfaces.d/private') }
+      context "with no interface" do
+        it { is_expected.not_to contain_file("/etc/network/interfaces.d/private") }
       end
 
-      if os == 'debian-9-x86_64'
-        context 'with ens4' do
+      if os == "debian-9-x86_64"
+        context "with ens4" do
           let(:facts) do
             os_facts.merge(
               networking: {
-                ip: '1.2.3.123',
-                interfaces: { 'ens4' => {} },
+                ip: "1.2.3.123",
+                interfaces: {"ens4" => {}}
               },
-              is_virtual: true,
+              is_virtual: true
             )
           end
 
           it do
-            expect(subject).to contain_file('/etc/network/interfaces.d/private')
+            expect(subject).to contain_file("/etc/network/interfaces.d/private")
               .with_content(%r{auto ens4\niface ens4 inet static}m)
           end
         end

--- a/spec/classes/profile/networking/sshd_group_mask_spec.rb
+++ b/spec/classes/profile/networking/sshd_group_mask_spec.rb
@@ -3,16 +3,16 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::sshd_group_umask' do
+describe "nebula::profile::networking::sshd_group_umask" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_concat_fragment('/etc/pam.d/sshd: group umask')
-          .with_target('/etc/pam.d/sshd')
+        expect(subject).to contain_concat_fragment("/etc/pam.d/sshd: group umask")
+          .with_target("/etc/pam.d/sshd")
           .with_content(%r{session    optional   pam_umask.so umask=0002})
       end
     end

--- a/spec/classes/profile/networking/sshd_spec.rb
+++ b/spec/classes/profile/networking/sshd_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::sshd' do
+describe "nebula::profile::networking::sshd" do
   def contain_sshd
-    contain_file('/etc/ssh/sshd_config')
+    contain_file("/etc/ssh/sshd_config")
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_sshd.that_notifies('Service[sshd]') }
+      it { is_expected.to contain_sshd.that_notifies("Service[sshd]") }
 
       it do
-        expect(subject).to contain_service('sshd').only_with(
-          ensure: 'running',
+        expect(subject).to contain_service("sshd").only_with(
+          ensure: "running",
           enable: true,
-          hasrestart: true,
+          hasrestart: true
         )
       end
 
@@ -38,36 +38,36 @@ describe 'nebula::profile::networking::sshd' do
         %r{^UsePrivilegeSeparation yes$},
         %r{^AcceptEnv LANG LC_\*$},
         %r{^Subsystem\s+sftp\s+/usr/lib/openssh/sftp-server$},
-        %r{^Match Address 10\.1\.1\.0/24,10\.2\.2\.0/24,!10\.2\.2\.2\n\s*PubkeyAuthentication yes$}m,
+        %r{^Match Address 10\.1\.1\.0/24,10\.2\.2\.0/24,!10\.2\.2\.2\n\s*PubkeyAuthentication yes$}m
       ].each do |line|
         it { is_expected.to contain_sshd.with_content(line) }
       end
 
       it "doesn't contain whitelist settings other than pubkey" do
         expect(subject).to contain_sshd.without_content(
-          %r{^Match Address [0-9.,/!]+\n\s*PubkeyAuthentication yes\n.}m,
+          %r{^Match Address [0-9.,/!]+\n\s*PubkeyAuthentication yes\n.}m
         )
       end
 
-      context 'when given no whitelist' do
-        let(:params) { { whitelist: [] } }
+      context "when given no whitelist" do
+        let(:params) { {whitelist: []} }
 
         it do
           expect(subject).to contain_sshd.without_content(
-            %r{^Match Address},
+            %r{^Match Address}
           )
         end
       end
 
-      context 'with no keytab' do
+      context "with no keytab" do
         it do
           expect(subject).not_to contain_sshd.with_content(
-            %r{^GSSAPIAuthentication yes$}m,
+            %r{^GSSAPIAuthentication yes$}m
           )
         end
       end
 
-      context 'with a keytab' do
+      context "with a keytab" do
         let(:pre_condition) do
           <<~KEYTAB
             class { 'nebula::profile::networking::keytab':
@@ -79,37 +79,37 @@ describe 'nebula::profile::networking::sshd' do
 
         it do
           expect(subject).to contain_sshd.with_content(
-            %r{^Match Address [0-9.,/!]+\n\s*PubkeyAuthentication yes\n\s*GSSAPIAuthentication yes$}m,
+            %r{^Match Address [0-9.,/!]+\n\s*PubkeyAuthentication yes\n\s*GSSAPIAuthentication yes$}m
           )
         end
       end
 
       it do
-        expect(subject).to contain_concat('/etc/ssh/ssh_config')
-        expect(subject).to contain_concat_fragment('main ssh client config')
-          .with_target('/etc/ssh/ssh_config')
+        expect(subject).to contain_concat("/etc/ssh/ssh_config")
+        expect(subject).to contain_concat_fragment("main ssh client config")
+          .with_target("/etc/ssh/ssh_config")
           .with_content(%r{^\s*SendEnv LANG LC_\*$})
       end
 
-      it { is_expected.to contain_file('/etc/pam.d/sshd-defaults') }
+      it { is_expected.to contain_file("/etc/pam.d/sshd-defaults") }
 
-      it { is_expected.to contain_concat_file('/etc/pam.d/sshd').with_path('/etc/pam.d/sshd') }
+      it { is_expected.to contain_concat_file("/etc/pam.d/sshd").with_path("/etc/pam.d/sshd") }
 
       it do
-        expect(subject).to contain_concat_fragment('/etc/pam.d/sshd: base')
-          .with_target('/etc/pam.d/sshd')
+        expect(subject).to contain_concat_fragment("/etc/pam.d/sshd: base")
+          .with_target("/etc/pam.d/sshd")
           .with_content(%r{@include sshd-defaults})
       end
 
-      context 'with port set to 44' do
-        let(:params) { { port: 44 } }
+      context "with port set to 44" do
+        let(:params) { {port: 44} }
 
         it { is_expected.not_to contain_sshd.with_content(%r{^#Port 22$}) }
         it { is_expected.to contain_sshd.with_content(%r{^Port 44$}) }
       end
 
-      context 'with port set to 333' do
-        let(:params) { { port: 333 } }
+      context "with port set to 333" do
+        let(:params) { {port: 333} }
 
         it { is_expected.not_to contain_sshd.with_content(%r{^#Port 22$}) }
         it { is_expected.to contain_sshd.with_content(%r{^Port 333$}) }

--- a/spec/classes/profile/networking/sysctl_spec.rb
+++ b/spec/classes/profile/networking/sysctl_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking::sysctl' do
+describe "nebula::profile::networking::sysctl" do
   def contain_sysctl
-    contain_file('/etc/sysctl.conf')
+    contain_file("/etc/sysctl.conf")
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_sysctl.that_notifies('Service[procps]') }
+      it { is_expected.to contain_sysctl.that_notifies("Service[procps]") }
 
       it do
-        expect(subject).to contain_service('procps').only_with(
-          ensure: 'running',
+        expect(subject).to contain_service("procps").only_with(
+          ensure: "running",
           enable: true,
-          hasrestart: true,
+          hasrestart: true
         )
       end
 
@@ -34,7 +34,7 @@ describe 'nebula::profile::networking::sysctl' do
         %r{^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$},
         %r{^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$},
         %r{^net\.ipv6\.conf\.all\.accept_source_route\s*=\s*0$},
-        %r{^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$},
+        %r{^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$}
       ].each do |line|
         it { is_expected.to contain_sysctl.with_content(line) }
       end
@@ -42,18 +42,18 @@ describe 'nebula::profile::networking::sysctl' do
       [
         %r{^net\.bridge\.bridge-nf-call-ip6tables\s*=\s*0$},
         %r{^net\.bridge\.bridge-nf-call-iptables\s*=\s*0$},
-        %r{^net\.bridge\.bridge-nf-call-arptables\s*=\s*0$},
+        %r{^net\.bridge\.bridge-nf-call-arptables\s*=\s*0$}
       ].each do |line|
         it { is_expected.to contain_sysctl.without_content(line) }
       end
 
-      context 'when called with bridge set to true' do
-        let(:params) { { bridge: true } }
+      context "when called with bridge set to true" do
+        let(:params) { {bridge: true} }
 
         [
           %r{^net\.bridge\.bridge-nf-call-ip6tables\s*=\s*0$},
           %r{^net\.bridge\.bridge-nf-call-iptables\s*=\s*0$},
-          %r{^net\.bridge\.bridge-nf-call-arptables\s*=\s*0$},
+          %r{^net\.bridge\.bridge-nf-call-arptables\s*=\s*0$}
         ].each do |line|
           it { is_expected.to contain_sysctl.with_content(line) }
         end

--- a/spec/classes/profile/networking_spec.rb
+++ b/spec/classes/profile/networking_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::networking' do
+describe "nebula::profile::networking" do
   def contain_network_class(name)
     contain_class("nebula::profile::networking::#{name}")
   end
@@ -14,16 +14,16 @@ describe 'nebula::profile::networking' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'when bridge==false' do
-        let(:params) { { bridge: false } }
+      context "when bridge==false" do
+        let(:params) { {bridge: false} }
 
-        it { is_expected.to contain_network_class('sysctl').with_bridge(false) }
+        it { is_expected.to contain_network_class("sysctl").with_bridge(false) }
       end
 
-      context 'when bridge==true' do
-        let(:params) { { bridge: true } }
+      context "when bridge==true" do
+        let(:params) { {bridge: true} }
 
-        it { is_expected.to contain_network_class('sysctl').with_bridge(true) }
+        it { is_expected.to contain_network_class("sysctl").with_bridge(true) }
       end
 
       # This is an ugly hack for fixing AEIM-1064. See base.pp for
@@ -31,7 +31,7 @@ describe 'nebula::profile::networking' do
       %w[procps sshd].each do |service|
         it do
           expect(subject).to contain_exec("/bin/systemctl status #{service}")
-            .that_subscribes_to(['Service[procps]', 'Service[sshd]'])
+            .that_subscribes_to(["Service[procps]", "Service[sshd]"])
             .with_refreshonly(true)
         end
       end

--- a/spec/classes/profile/ntp_spec.rb
+++ b/spec/classes/profile/ntp_spec.rb
@@ -3,44 +3,44 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::ntp' do
+describe "nebula::profile::ntp" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_service('ntp').with(
+        expect(subject).to contain_service("ntp").with(
           enable: true,
-          ensure: 'running',
+          ensure: "running"
         )
       end
 
-      it { is_expected.to contain_package('ntp') }
-      it { is_expected.to contain_package('ntpstat') }
+      it { is_expected.to contain_package("ntp") }
+      it { is_expected.to contain_package("ntpstat") }
 
-      it { is_expected.to contain_file('/etc/ntp.conf').with_content(%r{^server ntp.example.invalid$}m) }
+      it { is_expected.to contain_file("/etc/ntp.conf").with_content(%r{^server ntp.example.invalid$}m) }
 
-      it { is_expected.to contain_file('/etc/ntp.conf').that_notifies('Service[ntp]') }
+      it { is_expected.to contain_file("/etc/ntp.conf").that_notifies("Service[ntp]") }
 
-      context 'with ntp[123].realdomain.com' do
+      context "with ntp[123].realdomain.com" do
         let(:params) do
           {
             servers: [
-              'ntp1.realdomain.com',
-              'ntp2.realdomain.com',
-              'ntp3.realdomain.com',
-            ],
+              "ntp1.realdomain.com",
+              "ntp2.realdomain.com",
+              "ntp3.realdomain.com"
+            ]
           }
         end
 
         [
-          'ntp1.realdomain.com',
-          'ntp2.realdomain.com',
-          'ntp3.realdomain.com',
+          "ntp1.realdomain.com",
+          "ntp2.realdomain.com",
+          "ntp3.realdomain.com"
         ].each do |server|
-          it { is_expected.to contain_file('/etc/ntp.conf').with_content(%r{^server #{server}$}m) }
+          it { is_expected.to contain_file("/etc/ntp.conf").with_content(%r{^server #{server}$}m) }
         end
       end
     end

--- a/spec/classes/profile/postfix_spec.rb
+++ b/spec/classes/profile/postfix_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::postfix' do
+describe "nebula::profile::postfix" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
@@ -3,71 +3,71 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::prometheus::exporter::haproxy' do
+describe "nebula::profile::prometheus::exporter::haproxy" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(datacenter: 'mydatacenter') }
-      let(:params) { { master: false } }
+      let(:facts) { os_facts.merge(datacenter: "mydatacenter") }
+      let(:params) { {master: false} }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('prometheus-haproxy-exporter') }
+      it { is_expected.to contain_package("prometheus-haproxy-exporter") }
 
       it do
-        expect(subject).to contain_service('prometheus-haproxy-exporter')
-          .with_ensure('running')
+        expect(subject).to contain_service("prometheus-haproxy-exporter")
+          .with_ensure("running")
           .with_enable(true)
       end
 
-      it 'defines a systemd service' do
-        expect(subject).to contain_file('/etc/systemd/system/prometheus-haproxy-exporter.service')
-          .that_requires('Package[prometheus-haproxy-exporter]')
-          .that_notifies('Service[prometheus-haproxy-exporter]')
+      it "defines a systemd service" do
+        expect(subject).to contain_file("/etc/systemd/system/prometheus-haproxy-exporter.service")
+          .that_requires("Package[prometheus-haproxy-exporter]")
+          .that_notifies("Service[prometheus-haproxy-exporter]")
       end
 
-      it 'defines default file' do
-        expect(subject).to contain_file('/etc/default/prometheus-haproxy-exporter')
-          .that_requires('Package[prometheus-haproxy-exporter]')
-          .that_notifies('Service[prometheus-haproxy-exporter]')
+      it "defines default file" do
+        expect(subject).to contain_file("/etc/default/prometheus-haproxy-exporter")
+          .that_requires("Package[prometheus-haproxy-exporter]")
+          .that_notifies("Service[prometheus-haproxy-exporter]")
       end
 
-      it 'exports target data' do
+      it "exports target data" do
         expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
-          .with_target('/etc/prometheus/haproxy.yml')
-          .with_tag('mydatacenter_prometheus_haproxy_service_list')
+          .with_target("/etc/prometheus/haproxy.yml")
+          .with_tag("mydatacenter_prometheus_haproxy_service_list")
       end
 
-      context 'with master set to false' do
-        let(:params) { { master: false } }
+      context "with master set to false" do
+        let(:params) { {master: false} }
 
-        it 'exports target data with priority backup' do
+        it "exports target data with priority backup" do
           expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
             .with_content(%r{priority: 'backup'})
         end
       end
 
-      context 'with master set to true' do
-        let(:params) { { master: true } }
+      context "with master set to true" do
+        let(:params) { {master: true} }
 
-        it 'exports target data with priority primary' do
+        it "exports target data with priority primary" do
           expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
             .with_content(%r{priority: 'primary'})
         end
       end
 
-      context 'with master unset' do
+      context "with master unset" do
         let(:params) { {} }
 
         it { is_expected.not_to compile }
       end
 
-      context 'when at datacenter fakedatacenter' do
-        let(:facts) { os_facts.merge(datacenter: 'fakedatacenter') }
+      context "when at datacenter fakedatacenter" do
+        let(:facts) { os_facts.merge(datacenter: "fakedatacenter") }
 
         it do
           expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
-            .with_tag('fakedatacenter_prometheus_haproxy_service_list')
+            .with_tag("fakedatacenter_prometheus_haproxy_service_list")
         end
       end
     end

--- a/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
@@ -3,43 +3,43 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::prometheus::exporter::ipmi' do
+describe "nebula::profile::prometheus::exporter::ipmi" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {
-                         'public' => [os_facts[:ipaddress]],
-                         'private' => [],
-                       })
+          "public" => [os_facts[:ipaddress]],
+          "private" => []
+        })
       end
 
       it { is_expected.to compile }
-      it { is_expected.not_to contain_service('kubelet') }
-      it { is_expected.not_to contain_file('/etc/prometheus') }
-      it { is_expected.not_to contain_file('/etc/prometheus/ipmi.yaml') }
+      it { is_expected.not_to contain_service("kubelet") }
+      it { is_expected.not_to contain_file("/etc/prometheus") }
+      it { is_expected.not_to contain_file("/etc/prometheus/ipmi.yaml") }
       it { expect(exported_resources).not_to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}") }
 
-      context 'with an account set' do
+      context "with an account set" do
         let(:params) do
-          { accounts: {
-            'remote-ipmi.example' => {
-              'username' => 'myuser123',
-              'password' => '!!secret!!',
-            },
-          } }
+          {accounts: {
+            "remote-ipmi.example" => {
+              "username" => "myuser123",
+              "password" => "!!secret!!"
+            }
+          }}
         end
 
         it { is_expected.to compile }
-        it { is_expected.to contain_service('kubelet') }
-        it { is_expected.to contain_file('/etc/kubernetes/manifests/ipmi_exporter.yaml') }
+        it { is_expected.to contain_service("kubelet") }
+        it { is_expected.to contain_file("/etc/kubernetes/manifests/ipmi_exporter.yaml") }
 
-        it { is_expected.to contain_file('/etc/prometheus').with_ensure('directory') }
+        it { is_expected.to contain_file("/etc/prometheus").with_ensure("directory") }
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
-            .that_requires('File[/etc/prometheus]')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
+            .that_requires("File[/etc/prometheus]")
             .with_content(%r{remote-ipmi.example:\n *user: "myuser123"\n *pass: "!!secret!!"}m)
             .with_content(%r{^ *privilege: "user"$})
             .with_content(%r{^ *timeout: 20000$})
@@ -50,9 +50,9 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
 
         it do
           expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
-            .with_tag('mydatacenter_prometheus_ipmi_exporter')
-            .with_target('/etc/prometheus/ipmi.yml')
-            .with_order('02')
+            .with_tag("mydatacenter_prometheus_ipmi_exporter")
+            .with_target("/etc/prometheus/ipmi.yml")
+            .with_order("02")
             .with_content(%r{^ +- +"remote-ipmi.example"$})
             .with_content(%r{^ +datacenter: "mydatacenter"$})
             .with_content(%r{^ +via: "#{facts[:hostname]}"$})
@@ -60,27 +60,27 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
         end
       end
 
-      context 'with two accounts set' do
+      context "with two accounts set" do
         let(:params) do
-          { accounts: {
-            'ipmi-1.example' => {
-              'username' => 'myuser1',
-              'password' => 'mysecret1',
+          {accounts: {
+            "ipmi-1.example" => {
+              "username" => "myuser1",
+              "password" => "mysecret1"
             },
-            'ipmi-2.example' => {
-              'username' => 'myuser2',
-              'password' => 'mysecret2',
-            },
-          } }
+            "ipmi-2.example" => {
+              "username" => "myuser2",
+              "password" => "mysecret2"
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{ipmi-1.example:\n *user: "myuser1"\n *pass: "mysecret1"}m)
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{ipmi-2.example:\n *user: "myuser2"\n *pass: "mysecret2"}m)
         end
 
@@ -91,19 +91,19 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
         end
       end
 
-      context 'with overridden privilege' do
+      context "with overridden privilege" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'privilege' => 'admin',
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "privilege" => "admin"
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{^ *privilege: "admin"$})
         end
 
@@ -113,124 +113,124 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
         end
       end
 
-      context 'with overridden timeout' do
+      context "with overridden timeout" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'timeout' => 60_000,
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "timeout" => 60_000
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{^ *timeout: 60000$})
         end
       end
 
-      context 'with overridden driver' do
+      context "with overridden driver" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'driver' => 'LAN',
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "driver" => "LAN"
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{^ *driver: "LAN"$})
         end
       end
 
-      context 'with overridden collectors' do
+      context "with overridden collectors" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'collectors' => %w[ipmi sel dcmi],
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "collectors" => %w[ipmi sel dcmi]
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{collectors:\n *- "ipmi"\n *- "sel"\n *- "dcmi"}m)
         end
       end
 
-      context 'with no collectors' do
+      context "with no collectors" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'collectors' => [],
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "collectors" => []
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{^ *collectors: \[\]$})
         end
       end
 
-      context 'with some sensor ids excluded' do
+      context "with some sensor ids excluded" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'exclude_sensor_ids' => [2, 32, 29],
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "exclude_sensor_ids" => [2, 32, 29]
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .with_content(%r{ +exclude_sensor_ids:\n +- +2\n +- +32\n +- +29}m)
         end
       end
 
-      context 'with an empty list of sensor ids excluded' do
+      context "with an empty list of sensor ids excluded" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-              'exclude_sensor_ids' => [],
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!",
+              "exclude_sensor_ids" => []
+            }
+          }}
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/ipmi.yaml')
+          expect(subject).to contain_file("/etc/prometheus/ipmi.yaml")
             .without_content(%r{exclude_sensor_ids})
         end
       end
 
-      context 'with a basic LOM set' do
+      context "with a basic LOM set" do
         let(:params) do
-          { accounts: {
-            'ipmi.example' => {
-              'username' => 'abc123',
-              'password' => '!!secret!!',
-            },
-          } }
+          {accounts: {
+            "ipmi.example" => {
+              "username" => "abc123",
+              "password" => "!!secret!!"
+            }
+          }}
         end
 
-        context 'with a public IP address of 100.100.100.100' do
+        context "with a public IP address of 100.100.100.100" do
           let(:facts) do
             os_facts.merge(mlibrary_ip_addresses: {
-                             'public' => ['100.100.100.100'],
-                             'private' => [],
-                           })
+              "public" => ["100.100.100.100"],
+              "private" => []
+            })
           end
 
           it do
@@ -238,12 +238,12 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
               .with_content(%r{^ +replacement: "100.100.100.100:9290"$})
           end
 
-          context 'with a private IP address of 10.23.45.67' do
+          context "with a private IP address of 10.23.45.67" do
             let(:facts) do
               os_facts.merge(mlibrary_ip_addresses: {
-                               'public' => ['100.100.100.100'],
-                               'private' => ['10.23.45.67'],
-                             })
+                "public" => ["100.100.100.100"],
+                "private" => ["10.23.45.67"]
+              })
             end
 
             it do
@@ -253,15 +253,15 @@ describe 'nebula::profile::prometheus::exporter::ipmi' do
           end
         end
 
-        context 'with multiple public and private IP addresses' do
+        context "with multiple public and private IP addresses" do
           let(:facts) do
             os_facts.merge(mlibrary_ip_addresses: {
-                             'public' => ['100.100.100.100', '100.200.200.200'],
-                             'private' => ['192.168.0.100', '10.23.45.67'],
-                           })
+              "public" => ["100.100.100.100", "100.200.200.200"],
+              "private" => ["192.168.0.100", "10.23.45.67"]
+            })
           end
 
-          it 'chooses the first private IP address' do
+          it "chooses the first private IP address" do
             expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
               .with_content(%r{^ +replacement: "192.168.0.100:9290"$})
               .without_content(%r{100.100.100.100})

--- a/spec/classes/profile/prometheus/exporter/mysql_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/mysql_spec.rb
@@ -3,38 +3,38 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::prometheus::exporter::mysql' do
+describe "nebula::profile::prometheus::exporter::mysql" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(datacenter: 'mydatacenter') }
+      let(:facts) { os_facts.merge(datacenter: "mydatacenter") }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('prometheus-mysqld-exporter') }
+      it { is_expected.to contain_package("prometheus-mysqld-exporter") }
 
       it do
-        expect(subject).to contain_service('prometheus-mysqld-exporter')
-          .with_ensure('running')
+        expect(subject).to contain_service("prometheus-mysqld-exporter")
+          .with_ensure("running")
           .with_enable(true)
       end
 
-      it 'defines a systemd service' do
-        expect(subject).to contain_file('/etc/systemd/system/prometheus-mysqld-exporter.service')
-          .that_requires('Package[prometheus-mysqld-exporter]')
-          .that_notifies('Service[prometheus-mysqld-exporter]')
+      it "defines a systemd service" do
+        expect(subject).to contain_file("/etc/systemd/system/prometheus-mysqld-exporter.service")
+          .that_requires("Package[prometheus-mysqld-exporter]")
+          .that_notifies("Service[prometheus-mysqld-exporter]")
       end
 
-      it 'defines default file' do
-        expect(subject).to contain_file('/etc/default/prometheus-mysqld-exporter')
-          .that_requires('Package[prometheus-mysqld-exporter]')
-          .that_notifies('Service[prometheus-mysqld-exporter]')
+      it "defines default file" do
+        expect(subject).to contain_file("/etc/default/prometheus-mysqld-exporter")
+          .that_requires("Package[prometheus-mysqld-exporter]")
+          .that_notifies("Service[prometheus-mysqld-exporter]")
       end
 
       it "exports itself to the default datacenter's service discovery" do
         expect(exported_resources).to contain_concat_fragment("prometheus mysql service #{facts[:hostname]}")
-          .with_tag('mydatacenter_prometheus_mysql_service_list')
-          .with_target('/etc/prometheus/mysql.yml')
+          .with_tag("mydatacenter_prometheus_mysql_service_list")
+          .with_target("/etc/prometheus/mysql.yml")
           .with_content(%r{'#{facts[:ipaddress]}:9104'})
       end
     end

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -3,272 +3,272 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::prometheus::exporter::node' do
+describe "nebula::profile::prometheus::exporter::node" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_file('/etc/default/prometheus-node-exporter')
-          .that_notifies('Service[prometheus-node-exporter]')
-          .that_requires('Package[prometheus-node-exporter]')
+        expect(subject).to contain_file("/etc/default/prometheus-node-exporter")
+          .that_notifies("Service[prometheus-node-exporter]")
+          .that_requires("Package[prometheus-node-exporter]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/systemd/system/prometheus-node-exporter.service')
-          .that_notifies('Service[prometheus-node-exporter]')
-          .that_requires('Package[prometheus-node-exporter]')
+        expect(subject).to contain_file("/etc/systemd/system/prometheus-node-exporter.service")
+          .that_notifies("Service[prometheus-node-exporter]")
+          .that_requires("Package[prometheus-node-exporter]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/rsyslog.d/prometheus-node-exporter.conf')
-          .that_notifies('Service[prometheus-node-exporter]')
-          .that_notifies('Service[rsyslog]')
+        expect(subject).to contain_file("/etc/rsyslog.d/prometheus-node-exporter.conf")
+          .that_notifies("Service[prometheus-node-exporter]")
+          .that_notifies("Service[rsyslog]")
       end
 
       it do
-        expect(subject).to contain_file('/var/log/prometheus-node-exporter.log')
-          .with_owner('root')
-          .with_group('adm')
-          .with_mode('0640')
-          .with_content('')
+        expect(subject).to contain_file("/var/log/prometheus-node-exporter.log")
+          .with_owner("root")
+          .with_group("adm")
+          .with_mode("0640")
+          .with_content("")
       end
 
-      it { is_expected.to contain_service('prometheus-node-exporter') }
+      it { is_expected.to contain_service("prometheus-node-exporter") }
 
       it do
-        expect(subject).to contain_package('prometheus-node-exporter')
-          .that_requires('User[prometheus]')
-          .that_requires('File[/var/lib/prometheus/node-exporter]')
+        expect(subject).to contain_package("prometheus-node-exporter")
+          .that_requires("User[prometheus]")
+          .that_requires("File[/var/lib/prometheus/node-exporter]")
       end
 
-      context 'with no version set' do
-        it { is_expected.not_to contain_apt__pin('prometheus-node-exporter') }
+      context "with no version set" do
+        it { is_expected.not_to contain_apt__pin("prometheus-node-exporter") }
 
         it do
-          expect(subject).to contain_package('prometheus-node-exporter')
-            .with_ensure('installed')
+          expect(subject).to contain_package("prometheus-node-exporter")
+            .with_ensure("installed")
         end
       end
 
-      context 'with version set to v1.2.3' do
-        let(:params) { { version: 'v1.2.3' } }
+      context "with version set to v1.2.3" do
+        let(:params) { {version: "v1.2.3"} }
 
         it do
-          expect(subject).to contain_package('prometheus-node-exporter')
-            .with_ensure('v1.2.3')
+          expect(subject).to contain_package("prometheus-node-exporter")
+            .with_ensure("v1.2.3")
         end
 
         it do
-          expect(subject).to contain_apt__pin('prometheus-node-exporter')
-            .with_packages(['prometheus-node-exporter'])
-            .with_version('v1.2.3')
+          expect(subject).to contain_apt__pin("prometheus-node-exporter")
+            .with_packages(["prometheus-node-exporter"])
+            .with_version("v1.2.3")
             .with_priority(999)
         end
       end
 
       it do
-        expect(subject).to contain_file('/var/lib/prometheus/node-exporter')
-          .with_ensure('directory')
-          .with_mode('2775')
-          .with_owner('prometheus')
-          .with_group('prometheus')
-          .that_requires('User[prometheus]')
-          .that_requires('File[/var/lib/prometheus]')
+        expect(subject).to contain_file("/var/lib/prometheus/node-exporter")
+          .with_ensure("directory")
+          .with_mode("2775")
+          .with_owner("prometheus")
+          .with_group("prometheus")
+          .that_requires("User[prometheus]")
+          .that_requires("File[/var/lib/prometheus]")
       end
 
-      context 'with promfile_owner set to brlglph' do
-        let(:params) { { promfile_owner: 'brlglph' } }
+      context "with promfile_owner set to brlglph" do
+        let(:params) { {promfile_owner: "brlglph"} }
 
-        it { is_expected.to contain_file('/var/lib/prometheus/node-exporter').with_owner('brlglph') }
-        it { is_expected.to contain_file('/var/lib/prometheus/node-exporter').with_group('prometheus') }
+        it { is_expected.to contain_file("/var/lib/prometheus/node-exporter").with_owner("brlglph") }
+        it { is_expected.to contain_file("/var/lib/prometheus/node-exporter").with_group("prometheus") }
       end
 
       it do
-        expect(subject).to contain_file('/var/lib/prometheus')
-          .with_ensure('directory')
-          .with_mode('2775')
-          .with_owner('prometheus')
-          .with_group('prometheus')
-          .that_requires('User[prometheus]')
+        expect(subject).to contain_file("/var/lib/prometheus")
+          .with_ensure("directory")
+          .with_mode("2775")
+          .with_owner("prometheus")
+          .with_group("prometheus")
+          .that_requires("User[prometheus]")
       end
 
-      it { is_expected.to contain_package('curl') }
-      it { is_expected.to contain_package('jq') }
+      it { is_expected.to contain_package("curl") }
+      it { is_expected.to contain_package("jq") }
 
       it do
-        expect(subject).to contain_file('/usr/local/bin/pushgateway')
-          .with_mode('0755')
+        expect(subject).to contain_file("/usr/local/bin/pushgateway")
+          .with_mode("0755")
       end
 
       it "exports itself to the default datacenter's service discovery" do
         expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
-          .with_tag('default_prometheus_node_service_list')
-          .with_target('/etc/prometheus/nodes.yml')
+          .with_tag("default_prometheus_node_service_list")
+          .with_target("/etc/prometheus/nodes.yml")
           .with_content(%r{'#{facts[:ipaddress]}:9100'})
       end
 
       it "exports itself to the default datacenter's pushgateway" do
         expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} #{facts[:ipaddress]}")
-          .with_tag('default_pushgateway_node')
-          .with_proto('tcp')
+          .with_tag("default_pushgateway_node")
+          .with_proto("tcp")
           .with_dport(9091)
           .with_source(facts[:ipaddress])
-          .with_state('NEW')
-          .with_jump('accept')
+          .with_state("NEW")
+          .with_jump("accept")
       end
 
-      context 'with both public and private mlibrary_ip_addresses' do
+      context "with both public and private mlibrary_ip_addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           "public": ['100.100.100.100', '200.200.200.200'],
-                           "private": ['10.1.2.3', '10.4.5.6'],
-                         })
+            public: ["100.100.100.100", "200.200.200.200"],
+            private: ["10.1.2.3", "10.4.5.6"]
+          })
         end
 
         it "exports itself to the default datacenter's service discovery" do
           expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
-            .with_tag('default_prometheus_node_service_list')
-            .with_target('/etc/prometheus/nodes.yml')
+            .with_tag("default_prometheus_node_service_list")
+            .with_target("/etc/prometheus/nodes.yml")
             .with_content(%r{'100\.100\.100\.100:9100'})
         end
 
         it "exports itself[0] to the default datacenter's pushgateway" do
           expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
-            .with_tag('default_pushgateway_node')
-            .with_source('100.100.100.100')
+            .with_tag("default_pushgateway_node")
+            .with_source("100.100.100.100")
         end
 
         it "exports itself[1] to the default datacenter's pushgateway" do
           expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
-            .with_tag('default_pushgateway_node')
-            .with_source('200.200.200.200')
+            .with_tag("default_pushgateway_node")
+            .with_source("200.200.200.200")
         end
       end
 
-      context 'with only private ip addresses' do
+      context "with only private ip addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           "public": [],
-                           "private": ['10.1.2.3', '10.4.5.6'],
-                         })
+            public: [],
+            private: ["10.1.2.3", "10.4.5.6"]
+          })
         end
 
         it { is_expected.not_to compile }
       end
 
-      context 'when our datacenter is covered' do
-        let(:params) { { covered_datacenters: %w[mydatacenter] } }
+      context "when our datacenter is covered" do
+        let(:params) { {covered_datacenters: %w[mydatacenter]} }
 
         it "exports itself to its datacenter's service discovery" do
           expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
-            .with_tag('mydatacenter_prometheus_node_service_list')
+            .with_tag("mydatacenter_prometheus_node_service_list")
         end
 
         it "exports itself to its datacenter's pushgateway" do
           expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} #{facts[:ipaddress]}")
-            .with_tag('mydatacenter_pushgateway_node')
+            .with_tag("mydatacenter_pushgateway_node")
             .with_source(facts[:ipaddress])
         end
 
-        context 'with both public and private mlibrary_ip_addresses' do
+        context "with both public and private mlibrary_ip_addresses" do
           let(:facts) do
             os_facts.merge(mlibrary_ip_addresses: {
-                             "public": ['100.100.100.100', '200.200.200.200'],
-                             "private": ['10.1.2.3', '10.4.5.6'],
-                           })
+              public: ["100.100.100.100", "200.200.200.200"],
+              private: ["10.1.2.3", "10.4.5.6"]
+            })
           end
 
           it "exports itself to the default datacenter's service discovery" do
             expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
-              .with_tag('mydatacenter_prometheus_node_service_list')
-              .with_target('/etc/prometheus/nodes.yml')
+              .with_tag("mydatacenter_prometheus_node_service_list")
+              .with_target("/etc/prometheus/nodes.yml")
               .with_content(%r{'10\.1\.2\.3:9100'})
           end
 
           it "exports itself[0] to its datacenter's pushgateway" do
             expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.1.2.3")
-              .with_tag('mydatacenter_pushgateway_node')
-              .with_source('10.1.2.3')
+              .with_tag("mydatacenter_pushgateway_node")
+              .with_source("10.1.2.3")
           end
 
           it "exports itself[1] to its datacenter's pushgateway" do
             expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.4.5.6")
-              .with_tag('mydatacenter_pushgateway_node')
-              .with_source('10.4.5.6')
+              .with_tag("mydatacenter_pushgateway_node")
+              .with_source("10.4.5.6")
           end
         end
 
-        context 'with only public ip addresses' do
+        context "with only public ip addresses" do
           let(:facts) do
             os_facts.merge(mlibrary_ip_addresses: {
-                             "public": ['100.100.100.100', '200.200.200.200'],
-                             "private": [],
-                           })
+              public: ["100.100.100.100", "200.200.200.200"],
+              private: []
+            })
           end
 
           it "exports itself to the default datacenter's service discovery" do
             expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
-              .with_tag('mydatacenter_prometheus_node_service_list')
-              .with_target('/etc/prometheus/nodes.yml')
+              .with_tag("mydatacenter_prometheus_node_service_list")
+              .with_target("/etc/prometheus/nodes.yml")
               .with_content(%r{'100\.100\.100\.100:9100'})
           end
 
           it "exports itself[0] to the default datacenter's pushgateway" do
             expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
-              .with_tag('mydatacenter_pushgateway_node')
-              .with_source('100.100.100.100')
+              .with_tag("mydatacenter_pushgateway_node")
+              .with_source("100.100.100.100")
           end
 
           it "exports itself[1] to the default datacenter's pushgateway" do
             expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
-              .with_tag('mydatacenter_pushgateway_node')
-              .with_source('200.200.200.200')
+              .with_tag("mydatacenter_pushgateway_node")
+              .with_source("200.200.200.200")
           end
         end
       end
 
       it do
-        expect(subject).to contain_concat_file('/usr/local/bin/pushgateway_advanced')
-          .with_mode('0755')
+        expect(subject).to contain_concat_file("/usr/local/bin/pushgateway_advanced")
+          .with_mode("0755")
       end
 
       it do
-        expect(subject).to contain_concat_fragment('01 pushgateway advanced shebang')
-          .with_target('/usr/local/bin/pushgateway_advanced')
+        expect(subject).to contain_concat_fragment("01 pushgateway advanced shebang")
+          .with_target("/usr/local/bin/pushgateway_advanced")
           .with_content("#!/usr/bin/env bash\nset -eo pipefail\n\n")
       end
 
       it do
-        expect(subject).to contain_concat_fragment('03 main pushgateway advanced content')
-          .with_target('/usr/local/bin/pushgateway_advanced')
+        expect(subject).to contain_concat_fragment("03 main pushgateway advanced content")
+          .with_target("/usr/local/bin/pushgateway_advanced")
       end
 
-      context 'with the default domain' do
-        let(:node) { 'dogbone.default.invalid' }
+      context "with the default domain" do
+        let(:node) { "dogbone.default.invalid" }
 
-        it 'exports only its hostname to prometheus service discovery' do
-          expect(exported_resources).to contain_concat_fragment('prometheus node service dogbone')
+        it "exports only its hostname to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service dogbone")
             .with_content(%r{hostname: 'dogbone'})
         end
       end
 
-      context 'with a subdomain of the default domain' do
-        let(:node) { 'dogbone.doghouse.default.invalid' }
+      context "with a subdomain of the default domain" do
+        let(:node) { "dogbone.doghouse.default.invalid" }
 
-        it 'exports its full fqdn to prometheus service discovery' do
-          expect(exported_resources).to contain_concat_fragment('prometheus node service dogbone')
+        it "exports its full fqdn to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service dogbone")
             .with_content(%r{hostname: 'dogbone\.doghouse\.default\.invalid'})
         end
       end
 
-      context 'with a nondefault domain' do
-        let(:node) { 'world.of.dogs' }
+      context "with a nondefault domain" do
+        let(:node) { "world.of.dogs" }
 
-        it 'exports its full fqdn to prometheus service discovery' do
-          expect(exported_resources).to contain_concat_fragment('prometheus node service world')
+        it "exports its full fqdn to prometheus service discovery" do
+          expect(exported_resources).to contain_concat_fragment("prometheus node service world")
             .with_content(%r{hostname: 'world\.of\.dogs'})
         end
       end

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::prometheus' do
+describe "nebula::profile::prometheus" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -13,191 +13,191 @@ describe 'nebula::profile::prometheus' do
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_docker__run('prometheus')
-          .with_image('prom/prometheus:latest')
-          .with_net('host')
+        expect(subject).to contain_docker__run("prometheus")
+          .with_image("prom/prometheus:latest")
+          .with_net("host")
           .with_extra_parameters(%w[--restart=always])
-          .with_volumes(['/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml',
-                         '/etc/prometheus/rules.yml:/etc/prometheus/rules.yml',
-                         '/etc/prometheus/nodes.yml:/etc/prometheus/nodes.yml',
-                         '/etc/prometheus/haproxy.yml:/etc/prometheus/haproxy.yml',
-                         '/etc/prometheus/mysql.yml:/etc/prometheus/mysql.yml',
-                         '/etc/prometheus/ipmi.yml:/etc/prometheus/ipmi.yml',
-                         '/etc/prometheus/etcd.yml:/etc/prometheus/etcd.yml',
-                         '/etc/prometheus/tls:/tls',
-                         '/opt/prometheus:/prometheus'])
-          .that_requires('File[/opt/prometheus]')
+          .with_volumes(["/etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml",
+            "/etc/prometheus/rules.yml:/etc/prometheus/rules.yml",
+            "/etc/prometheus/nodes.yml:/etc/prometheus/nodes.yml",
+            "/etc/prometheus/haproxy.yml:/etc/prometheus/haproxy.yml",
+            "/etc/prometheus/mysql.yml:/etc/prometheus/mysql.yml",
+            "/etc/prometheus/ipmi.yml:/etc/prometheus/ipmi.yml",
+            "/etc/prometheus/etcd.yml:/etc/prometheus/etcd.yml",
+            "/etc/prometheus/tls:/tls",
+            "/opt/prometheus:/prometheus"])
+          .that_requires("File[/opt/prometheus]")
       end
 
-      context 'with version set to v2.11.1' do
-        let(:params) { { version: 'v2.11.1' } }
+      context "with version set to v2.11.1" do
+        let(:params) { {version: "v2.11.1"} }
 
         it do
-          expect(subject).to contain_docker__run('prometheus')
-            .with_image('prom/prometheus:v2.11.1')
+          expect(subject).to contain_docker__run("prometheus")
+            .with_image("prom/prometheus:v2.11.1")
         end
       end
 
       it do
-        expect(subject).to contain_docker__run('pushgateway')
-          .with_image('prom/pushgateway:latest')
-          .with_command('--persistence.file=/archive/pushgateway')
-          .with_net('host')
+        expect(subject).to contain_docker__run("pushgateway")
+          .with_image("prom/pushgateway:latest")
+          .with_command("--persistence.file=/archive/pushgateway")
+          .with_net("host")
           .with_extra_parameters(%w[--restart=always])
           .with_volumes(%w[/opt/pushgateway:/archive])
-          .that_requires('File[/opt/pushgateway]')
+          .that_requires("File[/opt/pushgateway]")
       end
 
-      context 'with pushgateway_version set to v2.11.1' do
-        let(:params) { { pushgateway_version: 'v2.11.1' } }
+      context "with pushgateway_version set to v2.11.1" do
+        let(:params) { {pushgateway_version: "v2.11.1"} }
 
         it do
-          expect(subject).to contain_docker__run('pushgateway')
-            .with_image('prom/pushgateway:v2.11.1')
+          expect(subject).to contain_docker__run("pushgateway")
+            .with_image("prom/pushgateway:v2.11.1")
         end
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/prometheus.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_file("/etc/prometheus/prometheus.yml")
+          .that_notifies("Docker::Run[prometheus]")
+          .that_requires("File[/etc/prometheus]")
       end
 
-      context 'with rules_variables set' do
+      context "with rules_variables set" do
         let(:params) do
           {
             rules_variables: {
-              darkblue_device: '//storage.invalid/volume',
-            },
+              darkblue_device: "//storage.invalid/volume"
+            }
           }
         end
 
         it do
-          expect(subject).to contain_file('/etc/prometheus/rules.yml')
-            .that_notifies('Docker::Run[prometheus]')
-            .that_requires('File[/etc/prometheus]')
+          expect(subject).to contain_file("/etc/prometheus/rules.yml")
+            .that_notifies("Docker::Run[prometheus]")
+            .that_requires("File[/etc/prometheus]")
             .with_content(%r{device="//storage.invalid/volume"})
         end
       end
 
       it do
-        expect(subject).to contain_concat_file('/etc/prometheus/nodes.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_concat_file("/etc/prometheus/nodes.yml")
+          .that_notifies("Docker::Run[prometheus]")
+          .that_requires("File[/etc/prometheus]")
       end
 
       it do
-        expect(subject).to contain_concat_file('/etc/prometheus/haproxy.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_concat_file("/etc/prometheus/haproxy.yml")
+          .that_notifies("Docker::Run[prometheus]")
+          .that_requires("File[/etc/prometheus]")
       end
 
       it do
-        expect(subject).to contain_concat_file('/etc/prometheus/mysql.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_concat_file("/etc/prometheus/mysql.yml")
+          .that_notifies("Docker::Run[prometheus]")
+          .that_requires("File[/etc/prometheus]")
       end
 
       it do
-        expect(subject).to contain_concat_file('/etc/prometheus/ipmi.yml')
-          .that_notifies('Docker::Run[prometheus]')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_concat_file("/etc/prometheus/ipmi.yml")
+          .that_notifies("Docker::Run[prometheus]")
+          .that_requires("File[/etc/prometheus]")
       end
 
       it do
-        expect(subject).to contain_concat_fragment('prometheus ipmi scrape config first line')
-          .with_target('/etc/prometheus/ipmi.yml')
-          .with_order('01')
+        expect(subject).to contain_concat_fragment("prometheus ipmi scrape config first line")
+          .with_target("/etc/prometheus/ipmi.yml")
+          .with_order("01")
           .with_content("scrape_configs:\n")
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus')
-          .with_ensure('directory')
+        expect(subject).to contain_file("/etc/prometheus")
+          .with_ensure("directory")
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/tls')
-          .with_ensure('directory')
-          .that_requires('File[/etc/prometheus]')
+        expect(subject).to contain_file("/etc/prometheus/tls")
+          .with_ensure("directory")
+          .that_requires("File[/etc/prometheus]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/tls/ca.crt')
-          .with_source('puppet:///ssl-certs/prometheus-pki/ca.crt')
-          .that_requires('File[/etc/prometheus/tls]')
+        expect(subject).to contain_file("/etc/prometheus/tls/ca.crt")
+          .with_source("puppet:///ssl-certs/prometheus-pki/ca.crt")
+          .that_requires("File[/etc/prometheus/tls]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/tls/client.crt')
+        expect(subject).to contain_file("/etc/prometheus/tls/client.crt")
           .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.crt")
-          .that_requires('File[/etc/prometheus/tls]')
+          .that_requires("File[/etc/prometheus/tls]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/tls/client.key')
+        expect(subject).to contain_file("/etc/prometheus/tls/client.key")
           .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.key")
-          .that_requires('File[/etc/prometheus/tls]')
+          .that_requires("File[/etc/prometheus/tls]")
       end
 
       %w[ca.crt client.crt client.key].each do |filename|
         it do
-          expect(subject).to contain_docker__run('prometheus')
+          expect(subject).to contain_docker__run("prometheus")
             .that_requires("File[/etc/prometheus/tls/#{filename}]")
         end
       end
 
       it do
-        expect(subject).to contain_file('/opt/prometheus')
-          .with_ensure('directory')
+        expect(subject).to contain_file("/opt/prometheus")
+          .with_ensure("directory")
           .with_owner(65_534)
           .with_group(65_534)
       end
 
       it do
-        expect(subject).to contain_file('/opt/pushgateway')
-          .with_ensure('directory')
+        expect(subject).to contain_file("/opt/pushgateway")
+          .with_ensure("directory")
           .with_owner(65_534)
           .with_group(65_534)
       end
 
       it do
-        expect(subject).to contain_class('nebula::profile::https_to_port')
+        expect(subject).to contain_class("nebula::profile::https_to_port")
           .with_port(9090)
       end
 
-      context 'with manage_https = false' do
-        let(:params) { { manage_https: false } }
+      context "with manage_https = false" do
+        let(:params) { {manage_https: false} }
 
         it do
-          expect(subject).not_to contain_class('nebula::profile::https_to_port')
+          expect(subject).not_to contain_class("nebula::profile::https_to_port")
         end
       end
 
       it do
-        expect(subject).to contain_nebula__exposed_port('010 Prometheus HTTPS')
+        expect(subject).to contain_nebula__exposed_port("010 Prometheus HTTPS")
           .with_port(443)
-          .with_block('umich::networks::all_trusted_machines')
+          .with_block("umich::networks::all_trusted_machines")
       end
 
-      [['haproxy', 9101],
-       ['mysql', 9104]].each do |exporter, port|
+      [["haproxy", 9101],
+        ["mysql", 9104]].each do |exporter, port|
         it "exports a firewall so that #{exporter} exporters can open #{port}" do
           expect(exported_resources).to contain_firewall("010 prometheus #{exporter} exporter #{facts[:hostname]}")
             .with_tag("mydatacenter_prometheus_#{exporter}_exporter")
-            .with_proto('tcp')
+            .with_proto("tcp")
             .with_dport(port)
             .with_source(facts[:ipaddress])
-            .with_state('NEW')
-            .with_jump('accept')
+            .with_state("NEW")
+            .with_jump("accept")
         end
       end
 
-      it 'does not export legacy port 9100 firewall resource' do
+      it "does not export legacy port 9100 firewall resource" do
         expect(exported_resources).not_to contain_firewall("010 prometheus legacy node exporter #{facts[:hostname]}")
       end
 
-      context 'with no mlibrary_ip_addresses fact' do
+      context "with no mlibrary_ip_addresses fact" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: nil)
         end
@@ -205,186 +205,186 @@ describe 'nebula::profile::prometheus' do
         it { is_expected.to compile }
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
         end
 
         it do
-          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+          expect(exported_resources).not_to contain_concat_fragment("02 pushgateway advanced private url mydatacenter")
         end
       end
 
-      context 'with a single public ip address in mlibrary_ip_addresses' do
+      context "with a single public ip address in mlibrary_ip_addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           'public' => ['100.100.100.100'],
-                           'private' => [],
-                         })
+            "public" => ["100.100.100.100"],
+            "private" => []
+          })
         end
 
         it do
           expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
-            .with_source('100.100.100.100')
-            .with_tag('mydatacenter_prometheus_public_node_exporter')
+            .with_source("100.100.100.100")
+            .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+          expect(exported_resources).not_to contain_concat_fragment("02 pushgateway advanced private url mydatacenter")
         end
       end
 
-      context 'with two public ip addresses in mlibrary_ip_addresses' do
+      context "with two public ip addresses in mlibrary_ip_addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           'public' => ['100.100.100.100', '200.200.200.200'],
-                           'private' => [],
-                         })
+            "public" => ["100.100.100.100", "200.200.200.200"],
+            "private" => []
+          })
         end
 
         it do
           expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
-            .with_source('100.100.100.100')
-            .with_tag('mydatacenter_prometheus_public_node_exporter')
+            .with_source("100.100.100.100")
+            .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
 
         it do
           expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 200.200.200.200")
-            .with_source('200.200.200.200')
-            .with_tag('mydatacenter_prometheus_public_node_exporter')
+            .with_source("200.200.200.200")
+            .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
+          expect(exported_resources).not_to contain_concat_fragment("02 pushgateway advanced private url mydatacenter")
         end
       end
 
-      context 'with a single private ip address in mlibrary_ip_addresses' do
+      context "with a single private ip address in mlibrary_ip_addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           'public' => [],
-                           'private' => ['10.1.2.3'],
-                         })
+            "public" => [],
+            "private" => ["10.1.2.3"]
+          })
         end
 
         it do
           expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.1.2.3")
-            .with_source('10.1.2.3')
-            .with_tag('mydatacenter_prometheus_private_node_exporter')
+            .with_source("10.1.2.3")
+            .with_tag("mydatacenter_prometheus_private_node_exporter")
         end
 
         it do
-          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
+          expect(exported_resources).not_to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
         end
 
         it do
-          expect(exported_resources).not_to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
+          expect(exported_resources).not_to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced private url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://10.1.2.3:9091'\n")
         end
       end
 
-      context 'with too many ip addresses in mlibrary_ip_addresses' do
+      context "with too many ip addresses in mlibrary_ip_addresses" do
         let(:facts) do
           os_facts.merge(mlibrary_ip_addresses: {
-                           'public' => ['100.100.100.100', '200.200.200.200'],
-                           'private' => ['10.1.2.3', '10.2.3.4', '10.3.4.5'],
-                         })
+            "public" => ["100.100.100.100", "200.200.200.200"],
+            "private" => ["10.1.2.3", "10.2.3.4", "10.3.4.5"]
+          })
         end
 
         [%w[public 100.100.100.100],
-         %w[public 200.200.200.200],
-         %w[private 10.1.2.3],
-         %w[private 10.2.3.4],
-         %w[private 10.3.4.5]].each do |network, ip_address|
-          [['node', 9100],
-           ['ipmi', 9290]].each do |exporter, port|
+          %w[public 200.200.200.200],
+          %w[private 10.1.2.3],
+          %w[private 10.2.3.4],
+          %w[private 10.3.4.5]].each do |network, ip_address|
+          [["node", 9100],
+            ["ipmi", 9290]].each do |exporter, port|
             it "exports a firewall so that #{exporter} exporters can open #{network} #{port} to #{ip_address}" do
               expect(exported_resources).to contain_firewall("010 prometheus #{network} #{exporter} exporter #{facts[:hostname]} #{ip_address}")
                 .with_tag("mydatacenter_prometheus_#{network}_#{exporter}_exporter")
-                .with_proto('tcp')
+                .with_proto("tcp")
                 .with_dport(port)
                 .with_source(ip_address)
-                .with_state('NEW')
-                .with_jump('accept')
+                .with_state("NEW")
+                .with_jump("accept")
             end
           end
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced public url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://100.100.100.100:9091'\n")
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment('02 pushgateway advanced private url mydatacenter')
-            .with_target('/usr/local/bin/pushgateway_advanced')
+          expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced private url mydatacenter")
+            .with_target("/usr/local/bin/pushgateway_advanced")
             .with_content("PUSHGATEWAY='http://10.1.2.3:9091'\n")
         end
       end
 
-      context 'with some static nodes set' do
-        let(:fragment) { 'prometheus node service static_host' }
+      context "with some static nodes set" do
+        let(:fragment) { "prometheus node service static_host" }
         let(:params) do
           {
             static_nodes: [
               {
-                'targets' => ['10.9.9.99:1234'],
-                'labels' => {
-                  'datacenter' => 'static_datacenter',
-                  'hostname' => 'static_host',
-                  'role' => 'static::role',
-                },
-              },
-            ],
+                "targets" => ["10.9.9.99:1234"],
+                "labels" => {
+                  "datacenter" => "static_datacenter",
+                  "hostname" => "static_host",
+                  "role" => "static::role"
+                }
+              }
+            ]
           }
         end
 
         it do
           expect(subject).to contain_concat_fragment(fragment)
-            .with_tag('mydatacenter_prometheus_node_service_list')
-            .with_target('/etc/prometheus/nodes.yml')
+            .with_tag("mydatacenter_prometheus_node_service_list")
+            .with_target("/etc/prometheus/nodes.yml")
         end
 
         [
@@ -392,40 +392,40 @@ describe 'nebula::profile::prometheus' do
           %r{^  labels:$},
           %r{^    datacenter: 'static_datacenter'$},
           %r{^    hostname: 'static_host'$},
-          %r{^    role: 'static::role'$},
+          %r{^    role: 'static::role'$}
         ].each do |content|
           it { is_expected.to contain_concat_fragment(fragment).with_content(content) }
         end
       end
 
       it do
-        expect(subject).to contain_file('/etc/prometheus/prometheus.yml')
+        expect(subject).to contain_file("/etc/prometheus/prometheus.yml")
           .without_content(%r{job_name: wmi})
       end
 
-      context 'with some static wmi nodes set' do
+      context "with some static wmi nodes set" do
         let(:params) do
           {
             static_wmi_nodes: [
               {
-                'targets' => ['10.11.12.13:9182'],
-                'labels' => {
-                  'datacenter' => 'windows_center',
-                  'hostname' => 'windows_host',
-                  'role' => 'windows::role',
-                },
-              },
-            ],
+                "targets" => ["10.11.12.13:9182"],
+                "labels" => {
+                  "datacenter" => "windows_center",
+                  "hostname" => "windows_host",
+                  "role" => "windows::role"
+                }
+              }
+            ]
           }
         end
 
         [
           "datacenter: 'windows_center'",
           "hostname: 'windows_host'",
-          "role: 'windows::role'",
+          "role: 'windows::role'"
         ].each do |label|
           it do
-            expect(subject).to contain_file('/etc/prometheus/prometheus.yml')
+            expect(subject).to contain_file("/etc/prometheus/prometheus.yml")
               .with_content(%r{job_name: wmi\n.*labels:\n.*#{label}}m)
           end
         end

--- a/spec/classes/profile/puppet/db_spec.rb
+++ b/spec/classes/profile/puppet/db_spec.rb
@@ -3,15 +3,15 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::puppet::db' do
+describe "nebula::profile::puppet::db" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).not_to contain_class('puppetdb')
+        expect(subject).not_to contain_class("puppetdb")
       end
     end
   end

--- a/spec/classes/profile/puppet/master_spec.rb
+++ b/spec/classes/profile/puppet/master_spec.rb
@@ -3,110 +3,110 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::puppet::master' do
+describe "nebula::profile::puppet::master" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_service('puppetserver').with(
-          ensure: 'running',
+        expect(subject).to contain_service("puppetserver").with(
+          ensure: "running",
           enable: true,
           hasrestart: true,
-          require: 'Exec[/opt/rbenv/shims/r10k deploy environment production]',
+          require: "Exec[/opt/rbenv/shims/r10k deploy environment production]"
         )
       end
 
       it do
         expect(subject).to contain_exec(
-          '/opt/rbenv/shims/r10k deploy environment production',
-        ).with_creates('/etc/puppetlabs/code/environments/production')
-          .that_requires('File[/etc/puppetlabs/r10k/r10k.yaml]')
-          .that_notifies('Exec[/opt/rbenv/shims/librarian-puppet update]')
+          "/opt/rbenv/shims/r10k deploy environment production"
+        ).with_creates("/etc/puppetlabs/code/environments/production")
+          .that_requires("File[/etc/puppetlabs/r10k/r10k.yaml]")
+          .that_notifies("Exec[/opt/rbenv/shims/librarian-puppet update]")
       end
 
       it do
-        expect(subject).to contain_exec('/opt/rbenv/shims/librarian-puppet update')
+        expect(subject).to contain_exec("/opt/rbenv/shims/librarian-puppet update")
           .with_refreshonly(true)
-          .with_cwd('/etc/puppetlabs/code/environments/production')
+          .with_cwd("/etc/puppetlabs/code/environments/production")
       end
 
       it do
-        expect(subject).to contain_file('/etc/puppetlabs/r10k/r10k.yaml')
-          .that_requires('File[/etc/puppetlabs/r10k]')
+        expect(subject).to contain_file("/etc/puppetlabs/r10k/r10k.yaml")
+          .that_requires("File[/etc/puppetlabs/r10k]")
           .with_content(%r{^cachedir: /var/cache/r10k$})
       end
 
       it do
-        expect(subject).to contain_file('/etc/puppetlabs/r10k')
-          .with_ensure('directory')
-          .that_requires('Package[puppetserver]')
+        expect(subject).to contain_file("/etc/puppetlabs/r10k")
+          .with_ensure("directory")
+          .that_requires("Package[puppetserver]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/puppetlabs/puppet/fileserver.conf')
+        expect(subject).to contain_file("/etc/puppetlabs/puppet/fileserver.conf")
           .with_content(%r{\[ssl-certs\]\n *path /default_invalid/etc/ssl}m)
           .with_content(%r{\[repos\]\n *path /default_invalid/opt/repos}m)
-          .that_requires('Package[puppetserver]')
+          .that_requires("Package[puppetserver]")
       end
 
       it do
-        expect(subject).to contain_file('/etc/puppetlabs/puppet/autosign.conf')
-          .that_requires('Package[puppetserver]')
+        expect(subject).to contain_file("/etc/puppetlabs/puppet/autosign.conf")
+          .that_requires("Package[puppetserver]")
           .without_content(%r{^[^#]})
       end
 
-      context 'when given some trusted certnames' do
-        let(:params) { { autosign_whitelist: %w[aaa bbb] } }
+      context "when given some trusted certnames" do
+        let(:params) { {autosign_whitelist: %w[aaa bbb]} }
 
         it do
-          expect(subject).to contain_file('/etc/puppetlabs/puppet/autosign.conf')
+          expect(subject).to contain_file("/etc/puppetlabs/puppet/autosign.conf")
             .with_content(%r{^aaa$})
             .with_content(%r{^bbb$})
         end
       end
 
       it do
-        expect(subject).to contain_package('puppetserver')
-          .that_requires(['Rbenv::Gem[r10k]', 'Rbenv::Gem[librarian-puppet]'])
+        expect(subject).to contain_package("puppetserver")
+          .that_requires(["Rbenv::Gem[r10k]", "Rbenv::Gem[librarian-puppet]"])
       end
 
       it do
-        expect(subject).to contain_rbenv__gem('r10k').with(
-          ruby_version: '2.4.3',
+        expect(subject).to contain_rbenv__gem("r10k").with(
+          ruby_version: "2.4.3",
           require: [
-            'Class[Nebula::Profile::Ruby]',
-            'Rbenv::Build[2.4.3]',
-          ],
+            "Class[Nebula::Profile::Ruby]",
+            "Rbenv::Build[2.4.3]"
+          ]
         )
       end
 
       it do
-        expect(subject).to contain_rbenv__gem('librarian-puppet').with(
-          ruby_version: '2.4.3',
+        expect(subject).to contain_rbenv__gem("librarian-puppet").with(
+          ruby_version: "2.4.3",
           require: [
-            'Class[Nebula::Profile::Ruby]',
-            'Rbenv::Build[2.4.3]',
-          ],
+            "Class[Nebula::Profile::Ruby]",
+            "Rbenv::Build[2.4.3]"
+          ]
         )
       end
 
       it do
         expect(subject).to contain_tidy(
-          '/opt/puppetlabs/server/data/puppetserver/reports',
+          "/opt/puppetlabs/server/data/puppetserver/reports"
         ).with(
-          age: '1h',
-          recurse: true,
+          age: "1h",
+          recurse: true
         )
       end
 
-      context 'when told reports live in /var/lib' do
-        let(:params) { { reports_dir: '/var/lib' } }
+      context "when told reports live in /var/lib" do
+        let(:params) { {reports_dir: "/var/lib"} }
 
-        it { is_expected.to contain_tidy('/var/lib').with_age('1h') }
-        it { is_expected.to contain_tidy('/var/lib').with_recurse(true) }
+        it { is_expected.to contain_tidy("/var/lib").with_age("1h") }
+        it { is_expected.to contain_tidy("/var/lib").with_recurse(true) }
       end
     end
   end

--- a/spec/classes/profile/puppet/query_spec.rb
+++ b/spec/classes/profile/puppet/query_spec.rb
@@ -3,25 +3,25 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::puppet::query' do
+describe "nebula::profile::puppet::query" do
   def contain_puppet_query
-    contain_file('/usr/local/sbin/puppet-query')
+    contain_file("/usr/local/sbin/puppet-query")
   end
 
   def contain_ssl_key_dir
-    contain_file('/etc/puppetlabs/puppet/ssl/private_keys')
-      .with_ensure('directory')
+    contain_file("/etc/puppetlabs/puppet/ssl/private_keys")
+      .with_ensure("directory")
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_package('curl') }
+      it { is_expected.to contain_package("curl") }
 
-      it { is_expected.to contain_puppet_query.with_mode('0755') }
+      it { is_expected.to contain_puppet_query.with_mode("0755") }
 
       it { is_expected.to contain_ssl_key_dir.without_group }
 
@@ -33,15 +33,15 @@ describe 'nebula::profile::puppet::query' do
         %r{--cert /etc/puppetlabs/puppet/ssl/certs/[^/]+\.pem},
         %r{--key /etc/puppetlabs/puppet/ssl/private_keys/[^/]+\.pem},
         %r{-H 'Content-Type:application/json'},
-        %r{-d "\$@"},
+        %r{-d "\$@"}
       ].each do |line|
         it { is_expected.to contain_puppet_query.with_content(line) }
       end
 
-      context 'with ssl_group set to cool_cat' do
-        let(:params) { { ssl_group: 'cool_cat' } }
+      context "with ssl_group set to cool_cat" do
+        let(:params) { {ssl_group: "cool_cat"} }
 
-        it { is_expected.to contain_ssl_key_dir.with_group('cool_cat') }
+        it { is_expected.to contain_ssl_key_dir.with_group("cool_cat") }
       end
     end
   end

--- a/spec/classes/profile/quod/prod/haproxy_spec.rb
+++ b/spec/classes/profile/quod/prod/haproxy_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-describe 'nebula::profile::quod::prod::haproxy' do
+require "spec_helper"
+describe "nebula::profile::quod::prod::haproxy" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.deep_merge(
-          datacenter: 'somedc',
+          datacenter: "somedc",
           networking: {
-            'hostname' => 'thisnode',
-          },
+            "hostname" => "thisnode"
+          }
         )
       end
 
       it { is_expected.to compile }
 
-      it 'exports a haproxy::binding resource for quod' do
-        expect(exported_resources).to contain_nebula__haproxy__binding('thisnode quod')
-          .with(service: 'quod', datacenter: 'somedc')
+      it "exports a haproxy::binding resource for quod" do
+        expect(exported_resources).to contain_nebula__haproxy__binding("thisnode quod")
+          .with(service: "quod", datacenter: "somedc")
       end
     end
   end

--- a/spec/classes/profile/redis_spec.rb
+++ b/spec/classes/profile/redis_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::redis' do
+describe "nebula::profile::redis" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/profile/root_ssh_private_keys_spec.rb
+++ b/spec/classes/profile/root_ssh_private_keys_spec.rb
@@ -3,65 +3,65 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::root_ssh_private_keys' do
+describe "nebula::profile::root_ssh_private_keys" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/ssh_keys_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_file('/var/local/ssh')
-          .with_ensure('directory')
+        expect(subject).to contain_file("/var/local/ssh")
+          .with_ensure("directory")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_normal_admin')
-          .with_ensure('directory')
-          .with_mode('0700')
-          .with_owner('invalid_normal_admin')
-          .that_requires('File[/var/local/ssh]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_normal_admin")
+          .with_ensure("directory")
+          .with_mode("0700")
+          .with_owner("invalid_normal_admin")
+          .that_requires("File[/var/local/ssh]")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_normal_admin/id_ecdsa')
-          .with_mode('0600')
-          .with_owner('invalid_normal_admin')
-          .with_source('puppet:///root-ssh-private-keys/invalid_normal_admin/id_ecdsa')
-          .that_requires('File[/var/local/ssh/invalid_normal_admin]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_normal_admin/id_ecdsa")
+          .with_mode("0600")
+          .with_owner("invalid_normal_admin")
+          .with_source("puppet:///root-ssh-private-keys/invalid_normal_admin/id_ecdsa")
+          .that_requires("File[/var/local/ssh/invalid_normal_admin]")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_normal_admin/id_ecdsa.pub')
-          .with_mode('0644')
-          .with_owner('invalid_normal_admin')
-          .with_source('puppet:///root-ssh-private-keys/invalid_normal_admin/id_ecdsa.pub')
-          .that_requires('File[/var/local/ssh/invalid_normal_admin]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_normal_admin/id_ecdsa.pub")
+          .with_mode("0644")
+          .with_owner("invalid_normal_admin")
+          .with_source("puppet:///root-ssh-private-keys/invalid_normal_admin/id_ecdsa.pub")
+          .that_requires("File[/var/local/ssh/invalid_normal_admin]")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_special_admin')
-          .with_ensure('directory')
-          .with_mode('0700')
-          .with_owner('invalid_special_admin')
-          .that_requires('File[/var/local/ssh]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_special_admin")
+          .with_ensure("directory")
+          .with_mode("0700")
+          .with_owner("invalid_special_admin")
+          .that_requires("File[/var/local/ssh]")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_special_admin/id_ecdsa')
-          .with_mode('0600')
-          .with_owner('invalid_special_admin')
-          .with_source('puppet:///root-ssh-private-keys/invalid_special_admin/id_ecdsa')
-          .that_requires('File[/var/local/ssh/invalid_special_admin]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_special_admin/id_ecdsa")
+          .with_mode("0600")
+          .with_owner("invalid_special_admin")
+          .with_source("puppet:///root-ssh-private-keys/invalid_special_admin/id_ecdsa")
+          .that_requires("File[/var/local/ssh/invalid_special_admin]")
       end
 
       it do
-        expect(subject).to contain_file('/var/local/ssh/invalid_special_admin/id_ecdsa.pub')
-          .with_mode('0644')
-          .with_owner('invalid_special_admin')
-          .with_source('puppet:///root-ssh-private-keys/invalid_special_admin/id_ecdsa.pub')
-          .that_requires('File[/var/local/ssh/invalid_special_admin]')
+        expect(subject).to contain_file("/var/local/ssh/invalid_special_admin/id_ecdsa.pub")
+          .with_mode("0644")
+          .with_owner("invalid_special_admin")
+          .with_source("puppet:///root-ssh-private-keys/invalid_special_admin/id_ecdsa.pub")
+          .that_requires("File[/var/local/ssh/invalid_special_admin]")
       end
     end
   end

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -3,29 +3,29 @@
 # Copyright (c) 2018, 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::ruby' do
+describe "nebula::profile::ruby" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_class('rbenv').with(
-          install_dir: '/opt/rbenv',
+        expect(subject).to contain_class("rbenv").with(
+          install_dir: "/opt/rbenv"
         )
       end
 
       [
-        'rbenv/rbenv-vars',
-        'rbenv/ruby-build',
-        'rbenv/rbenv-default-gems',
-        'tpope/rbenv-aliases',
+        "rbenv/rbenv-vars",
+        "rbenv/ruby-build",
+        "rbenv/rbenv-default-gems",
+        "tpope/rbenv-aliases"
       ].each do |plugin|
         it { is_expected.to contain_rbenv__plugin(plugin) }
       end
 
-      ['2.4.3', '2.5.0'].each do |version|
+      ["2.4.3", "2.5.0"].each do |version|
         it do
           expect(subject).to contain_rbenv__build(version)
         end
@@ -35,83 +35,83 @@ describe 'nebula::profile::ruby' do
             expect(subject).to contain_rbenv__gem("#{gem} #{version}").with(
               gem: gem,
               ruby_version: version,
-              require: "Rbenv::Build[#{version}]",
+              require: "Rbenv::Build[#{version}]"
             )
           end
         end
       end
 
       it do
-        expect(subject).to contain_exec('rbenv uninstall 2.4.2')
-          .with_command('rbenv uninstall -f 2.4.2')
-          .with_environment(['RBENV_ROOT=/opt/rbenv'])
-          .with_path('/opt/rbenv/shims:/opt/rbenv/bin:/usr/bin:/bin')
-          .that_requires('Rbenv::Build[2.4.3]')
+        expect(subject).to contain_exec("rbenv uninstall 2.4.2")
+          .with_command("rbenv uninstall -f 2.4.2")
+          .with_environment(["RBENV_ROOT=/opt/rbenv"])
+          .with_path("/opt/rbenv/shims:/opt/rbenv/bin:/usr/bin:/bin")
+          .that_requires("Rbenv::Build[2.4.3]")
       end
 
-      it { is_expected.not_to contain_exec('rbenv uninstall 2.5.0') }
+      it { is_expected.not_to contain_exec("rbenv uninstall 2.5.0") }
 
       case os
-      when 'debian-8-x86_64'
-        it { is_expected.to contain_rbenv__build('2.3.4').with_global(false) }
-      when 'debian-9-x86_64'
-        it { is_expected.not_to contain_rbenv__build('2.3.4') }
+      when "debian-8-x86_64"
+        it { is_expected.to contain_rbenv__build("2.3.4").with_global(false) }
+      when "debian-9-x86_64"
+        it { is_expected.not_to contain_rbenv__build("2.3.4") }
       end
 
-      it { is_expected.to contain_rbenv__build('2.4.3').with_global(true) }
-      it { is_expected.to contain_rbenv__build('2.5.0').with_global(false) }
+      it { is_expected.to contain_rbenv__build("2.4.3").with_global(true) }
+      it { is_expected.to contain_rbenv__build("2.5.0").with_global(false) }
 
-      it { is_expected.to contain_file('/etc/cron.daily/ruby-health-check') }
+      it { is_expected.to contain_file("/etc/cron.daily/ruby-health-check") }
 
-      context 'when given install_dir of /usr/local/rbenv' do
-        let(:params) { { install_dir: '/usr/local/rbenv' } }
+      context "when given install_dir of /usr/local/rbenv" do
+        let(:params) { {install_dir: "/usr/local/rbenv"} }
 
         it do
-          expect(subject).to contain_class('rbenv').with(
-            install_dir: '/usr/local/rbenv',
+          expect(subject).to contain_class("rbenv").with(
+            install_dir: "/usr/local/rbenv"
           )
         end
 
-        it { is_expected.to contain_rbenv__build('2.4.3').with_global(true) }
-        it { is_expected.to contain_file('/etc/cron.daily/ruby-health-check') }
+        it { is_expected.to contain_rbenv__build("2.4.3").with_global(true) }
+        it { is_expected.to contain_file("/etc/cron.daily/ruby-health-check") }
       end
 
-      context 'when given supported_versions of [2.4.1]' do
-        let(:params) { { supported_versions: ['2.4.1'] } }
+      context "when given supported_versions of [2.4.1]" do
+        let(:params) { {supported_versions: ["2.4.1"]} }
 
-        it { is_expected.to contain_rbenv__build('2.4.1') }
-        it { is_expected.not_to contain_rbenv__build('2.3.4') }
-        it { is_expected.not_to contain_rbenv__build('2.5.0') }
+        it { is_expected.to contain_rbenv__build("2.4.1") }
+        it { is_expected.not_to contain_rbenv__build("2.3.4") }
+        it { is_expected.not_to contain_rbenv__build("2.5.0") }
       end
 
       # AEIM-2776 - Confirm jruby-1.7 is blacklisted by default
-      context 'when given supported_versions of [jruby-1.7.anything]' do
-        let(:params) { { supported_versions: ['jruby-1.7.anything'] } }
+      context "when given supported_versions of [jruby-1.7.anything]" do
+        let(:params) { {supported_versions: ["jruby-1.7.anything"]} }
 
-        it { is_expected.not_to contain_rbenv__build('jruby-1.7.anything') }
+        it { is_expected.not_to contain_rbenv__build("jruby-1.7.anything") }
       end
 
       # AEIM-2776 - Confirm jruby-9.0 is blacklisted by default
-      context 'when given supported_versions of [jruby-9.0.anything]' do
-        let(:params) { { supported_versions: ['jruby-9.0.anything'] } }
+      context "when given supported_versions of [jruby-9.0.anything]" do
+        let(:params) { {supported_versions: ["jruby-9.0.anything"]} }
 
-        it { is_expected.not_to contain_rbenv__build('jruby-9.0.anything') }
+        it { is_expected.not_to contain_rbenv__build("jruby-9.0.anything") }
       end
 
       # AEIM-2776 - Confirm we can blacklist by param
-      context 'when supporting and blacklisting ree-0.0' do
-        let(:params) { { supported_versions: ['ree-0.0'], manage_blacklist: '^ree-0' } }
+      context "when supporting and blacklisting ree-0.0" do
+        let(:params) { {supported_versions: ["ree-0.0"], manage_blacklist: "^ree-0"} }
 
-        it { is_expected.not_to contain_rbenv__build('ree-0.0') }
+        it { is_expected.not_to contain_rbenv__build("ree-0.0") }
       end
 
-      context 'when given global_version of 2.4.1' do
-        let(:params) { { global_version: '2.4.1', bundler_version: '~>1.14' } }
+      context "when given global_version of 2.4.1" do
+        let(:params) { {global_version: "2.4.1", bundler_version: "~>1.14"} }
 
         it do
-          expect(subject).to contain_rbenv__build('2.4.1').with(
-            bundler_version: '~>1.14',
-            global: true,
+          expect(subject).to contain_rbenv__build("2.4.1").with(
+            bundler_version: "~>1.14",
+            global: true
           )
         end
       end
@@ -120,21 +120,21 @@ describe 'nebula::profile::ruby' do
         let(:params) do
           {
             gems: [
-              { gem: 'pry', version: '>= 0' },
-              { gem: 'json', version: '>= 0' },
-            ],
+              {gem: "pry", version: ">= 0"},
+              {gem: "json", version: ">= 0"}
+            ]
           }
         end
 
-        it { is_expected.to contain_rbenv__gem('pry 2.4.3') }
-        it { is_expected.to contain_rbenv__gem('pry 2.5.0') }
-        it { is_expected.to contain_rbenv__gem('json 2.4.3') }
-        it { is_expected.to contain_rbenv__gem('json 2.5.0') }
+        it { is_expected.to contain_rbenv__gem("pry 2.4.3") }
+        it { is_expected.to contain_rbenv__gem("pry 2.5.0") }
+        it { is_expected.to contain_rbenv__gem("json 2.4.3") }
+        it { is_expected.to contain_rbenv__gem("json 2.5.0") }
 
-        it { is_expected.not_to contain_rbenv__gem('puma 2.4.3') }
-        it { is_expected.not_to contain_rbenv__gem('puma 2.5.0') }
-        it { is_expected.not_to contain_rbenv__gem('rspec 2.4.3') }
-        it { is_expected.not_to contain_rbenv__gem('rspec 2.5.0') }
+        it { is_expected.not_to contain_rbenv__gem("puma 2.4.3") }
+        it { is_expected.not_to contain_rbenv__gem("puma 2.5.0") }
+        it { is_expected.not_to contain_rbenv__gem("rspec 2.4.3") }
+        it { is_expected.not_to contain_rbenv__gem("rspec 2.5.0") }
       end
     end
   end

--- a/spec/classes/profile/solr_spec.rb
+++ b/spec/classes/profile/solr_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018-2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::solr' do
+describe "nebula::profile::solr" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -14,50 +14,50 @@ describe 'nebula::profile::solr' do
 
       # Packages
       [
-        'openjdk-8-jre-headless',
-        'solr',
-        'lsof',
+        "openjdk-8-jre-headless",
+        "solr",
+        "lsof"
       ].each do |package|
         it { is_expected.to contain_package(package) }
       end
 
       # Service
       it do
-        expect(subject).to contain_service('solr').with(
+        expect(subject).to contain_service("solr").with(
           enable: true,
-          ensure: 'running',
+          ensure: "running"
         )
       end
 
-      context 'with default parameters' do
+      context "with default parameters" do
         # Directories
         [
-          '/var/lib/solr',
-          '/var/lib/solr/home',
-          '/var/lib/solr/logs',
+          "/var/lib/solr",
+          "/var/lib/solr/home",
+          "/var/lib/solr/logs"
         ].each do |path|
           it do
             expect(subject).to contain_file(path).with(
-              owner: 'solr',
-              group: 'solr',
-              ensure: 'directory',
-              mode: '0750',
+              owner: "solr",
+              group: "solr",
+              ensure: "directory",
+              mode: "0750"
             )
           end
         end
 
         # Files
         [
-          '/var/lib/solr/log4j.properties',
-          '/var/lib/solr/solr.in.sh',
-          '/var/lib/solr/home/solr.xml',
+          "/var/lib/solr/log4j.properties",
+          "/var/lib/solr/solr.in.sh",
+          "/var/lib/solr/home/solr.xml"
         ].each do |path|
           it do
             expect(subject).to contain_file(path).with(
-              owner: 'solr',
-              group: 'solr',
-              ensure: 'file',
-              mode: '0644',
+              owner: "solr",
+              group: "solr",
+              ensure: "file",
+              mode: "0644"
             )
           end
         end

--- a/spec/classes/profile/taghosts/index_spec.rb
+++ b/spec/classes/profile/taghosts/index_spec.rb
@@ -3,28 +3,28 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::taghosts::index' do
+describe "nebula::profile::taghosts::index" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_concat('/var/lib/ae/active-servers') }
-      it { is_expected.to contain_file('/usr/local/bin/taghosts') }
-      it { is_expected.to contain_file('/usr/local/bin/exechosts') }
+      it { is_expected.to contain_concat("/var/lib/ae/active-servers") }
+      it { is_expected.to contain_file("/usr/local/bin/taghosts") }
+      it { is_expected.to contain_file("/usr/local/bin/exechosts") }
 
-      context 'with a static server' do
-        let(:params) { { static_hosts: { 'myhost.default.invalid' => %w[abc def ghi] } } }
+      context "with a static server" do
+        let(:params) { {static_hosts: {"myhost.default.invalid" => %w[abc def ghi]}} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_concat__fragment('taghosts myhost.default.invalid 000') }
-        it { is_expected.to contain_concat__fragment('taghosts myhost.default.invalid 001 abc') }
-        it { is_expected.to contain_concat__fragment('taghosts myhost.default.invalid 002 def') }
-        it { is_expected.to contain_concat__fragment('taghosts myhost.default.invalid 003 ghi') }
-        it { is_expected.to contain_concat__fragment('taghosts myhost.default.invalid 999') }
+        it { is_expected.to contain_concat__fragment("taghosts myhost.default.invalid 000") }
+        it { is_expected.to contain_concat__fragment("taghosts myhost.default.invalid 001 abc") }
+        it { is_expected.to contain_concat__fragment("taghosts myhost.default.invalid 002 def") }
+        it { is_expected.to contain_concat__fragment("taghosts myhost.default.invalid 003 ghi") }
+        it { is_expected.to contain_concat__fragment("taghosts myhost.default.invalid 999") }
       end
     end
   end

--- a/spec/classes/profile/taghosts/tags_spec.rb
+++ b/spec/classes/profile/taghosts/tags_spec.rb
@@ -3,19 +3,19 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::taghosts::tags' do
+describe "nebula::profile::taghosts::tags" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_nebula__taghosts__tag('no-datacenter') }
-      it { is_expected.to contain_nebula__taghosts__tag('linux') }
-      it { is_expected.to contain_nebula__taghosts__tag(facts[:os]['name'].downcase) }
-      it { is_expected.to contain_nebula__taghosts__tag(facts[:os]['distro']['codename']) }
+      it { is_expected.to contain_nebula__taghosts__tag("no-datacenter") }
+      it { is_expected.to contain_nebula__taghosts__tag("linux") }
+      it { is_expected.to contain_nebula__taghosts__tag(facts[:os]["name"].downcase) }
+      it { is_expected.to contain_nebula__taghosts__tag(facts[:os]["distro"]["codename"]) }
     end
   end
 end

--- a/spec/classes/profile/tsm_spec.rb
+++ b/spec/classes/profile/tsm_spec.rb
@@ -3,25 +3,25 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::tsm' do
+describe "nebula::profile::tsm" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      let(:dsm_sys) { '/opt/tivoli/tsm/client/ba/bin/dsm.sys' }
-      let(:dsm_opt) { '/opt/tivoli/tsm/client/ba/bin/dsm.opt' }
-      let(:inclexcl) { '/etc/adsm/inclexcl' }
+      let(:dsm_sys) { "/opt/tivoli/tsm/client/ba/bin/dsm.sys" }
+      let(:dsm_opt) { "/opt/tivoli/tsm/client/ba/bin/dsm.opt" }
+      let(:inclexcl) { "/etc/adsm/inclexcl" }
 
       let(:params) do
         {
-          servername: 'tsmserver1',
-          serveraddress: 'tsmserver1.example.invalid',
+          servername: "tsmserver1",
+          serveraddress: "tsmserver1.example.invalid"
         }
       end
 
-      it { is_expected.to contain_package('tivsm-ba') }
+      it { is_expected.to contain_package("tivsm-ba") }
 
       it do
         expect(subject).to contain_file(dsm_sys)
@@ -39,49 +39,49 @@ describe 'nebula::profile::tsm' do
           .with_content(%r{\* No custom settings})
       end
 
-      it { is_expected.to contain_service('tsm') }
+      it { is_expected.to contain_service("tsm") }
 
       it do
-        expect(subject).to contain_service('dsmcad')
-          .with_ensure('stopped')
+        expect(subject).to contain_service("dsmcad")
+          .with_ensure("stopped")
           .with_enable(false)
       end
 
-      it { is_expected.to contain_file('/etc/systemd/system/tsm.service') }
+      it { is_expected.to contain_file("/etc/systemd/system/tsm.service") }
 
       it { is_expected.to contain_file(inclexcl) }
 
-      context 'with custom params' do
+      context "with custom params" do
         let(:params) do
           super().merge(
-            servername: 'otherserver',
-            serveraddress: 'somethingelse.default.invalid',
+            servername: "otherserver",
+            serveraddress: "somethingelse.default.invalid",
             encryption: true,
             port: 1234,
-            inclexcl: ['exclude.dir /foo', 'include /bar otherpolicy'],
-            domains: ['/baz', '/quux'],
-            virtualmountpoints: ['/vmount'],
-            exclude_dirs: ['/whatever'],
+            inclexcl: ["exclude.dir /foo", "include /bar otherpolicy"],
+            domains: ["/baz", "/quux"],
+            virtualmountpoints: ["/vmount"],
+            exclude_dirs: ["/whatever"],
             opt_settings: [
-              'first_setting first_value',
-              'second_setting "second_value"',
-            ],
+              "first_setting first_value",
+              'second_setting "second_value"'
+            ]
           )
         end
 
-        it 'adds domain settings to dsm.opt config file' do
+        it "adds domain settings to dsm.opt config file" do
           expect(subject).to contain_file(dsm_opt)
             .with_content(%r{^DOMAIN "/baz"$})
             .with_content(%r{^DOMAIN "/quux"$})
         end
 
-        it 'adds custom settings to dsm.opt config file' do
+        it "adds custom settings to dsm.opt config file" do
           expect(subject).to contain_file(dsm_opt)
             .with_content(%r{^first_setting first_value$})
             .with_content(%r{^second_setting "second_value"$})
         end
 
-        it 'adds custom settings to dsm.sys config file' do
+        it "adds custom settings to dsm.sys config file" do
           expect(subject).to contain_file(dsm_sys)
             .with_content(%r{^Servername otherserver}i)
             .with_content(%r{VIRTUALMOUNTPOINT /vmount})
@@ -91,7 +91,7 @@ describe 'nebula::profile::tsm' do
             .with_content(%r{EXCLUDE.DIR "/whatever"})
         end
 
-        it 'adds custom settings to inclexcl config file' do
+        it "adds custom settings to inclexcl config file" do
           expect(subject).to contain_file(inclexcl)
             .with_content(%r{^exclude.dir /foo$})
             .with_content(%r{^include /bar otherpolicy$})

--- a/spec/classes/profile/unattended_upgrades_spec.rb
+++ b/spec/classes/profile/unattended_upgrades_spec.rb
@@ -3,17 +3,17 @@
 # Copyright (c) 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::unattended_upgrades' do
+describe "nebula::profile::unattended_upgrades" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('apt') }
-      it { is_expected.to contain_class('unattended_upgrades').with(only_on_ac_power: false) }
-      it { is_expected.to contain_file('/etc/apt/apt.conf.d/51unattended-upgrades-extra') }
+      it { is_expected.to contain_class("apt") }
+      it { is_expected.to contain_class("unattended_upgrades").with(only_on_ac_power: false) }
+      it { is_expected.to contain_file("/etc/apt/apt.conf.d/51unattended-upgrades-extra") }
     end
   end
 end

--- a/spec/classes/profile/unison_spec.rb
+++ b/spec/classes/profile/unison_spec.rb
@@ -3,63 +3,63 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::unison' do
+describe "nebula::profile::unison" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/unison_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/unison_config.yaml" }
 
-      shared_examples_for 'logrotated unison' do
+      shared_examples_for "logrotated unison" do
         it do
-          expect(subject).to contain_logrotate__rule('unison').with(
-            path: '/var/log/unison*.log',
+          expect(subject).to contain_logrotate__rule("unison").with(
+            path: "/var/log/unison*.log",
             rotate: 7,
-            rotate_every: 'day',
+            rotate_every: "day",
             missingok: true,
             ifempty: false,
             delaycompress: true,
-            compress: true,
+            compress: true
           )
         end
 
-        it { is_expected.to contain_class('nebula::profile::logrotate') }
+        it { is_expected.to contain_class("nebula::profile::logrotate") }
       end
 
-      context 'when on server' do
-        let(:params) { { servers: %w[instance1 instance2] } }
+      context "when on server" do
+        let(:params) { {servers: %w[instance1 instance2]} }
 
         it { is_expected.to compile }
 
-        it_behaves_like 'logrotated unison'
+        it_behaves_like "logrotated unison"
 
         # both instances are configured via hiera
         it do
-          expect(subject).to contain_nebula__unison__server('instance1').with(
+          expect(subject).to contain_nebula__unison__server("instance1").with(
             port: 2647,
-            root: '/somewhere',
+            root: "/somewhere",
             paths: %w[something somethingelse],
-            filesystems: ['somewhere'],
+            filesystems: ["somewhere"]
           )
         end
 
         it do
-          expect(subject).to contain_nebula__unison__server('instance2').with(
+          expect(subject).to contain_nebula__unison__server("instance2").with(
             port: 2648,
-            root: '/elsewhere',
+            root: "/elsewhere",
             paths: %w[otherthing yetanotherthing],
-            filesystems: ['elsewhere'],
+            filesystems: ["elsewhere"]
           )
         end
       end
 
-      context 'when on client' do
-        let(:params) { { clients: %w[instance1 instance2] } }
+      context "when on client" do
+        let(:params) { {clients: %w[instance1 instance2]} }
 
         it { is_expected.to compile }
 
-        it_behaves_like 'logrotated unison'
+        it_behaves_like "logrotated unison"
 
         # can't test importing exported resources
       end

--- a/spec/classes/profile/users_spec.rb
+++ b/spec/classes/profile/users_spec.rb
@@ -3,50 +3,50 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::users' do
+describe "nebula::profile::users" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/ssh_keys_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }
 
-      it { is_expected.to contain_group('invalid_default_group').with_gid(1234) }
-      it { is_expected.to contain_group('invalid_special_group').with_gid(2468) }
+      it { is_expected.to contain_group("invalid_default_group").with_gid(1234) }
+      it { is_expected.to contain_group("invalid_special_group").with_gid(2468) }
 
       it do
-        expect(subject).to contain_user('invalid_normal_admin').with(
-          comment: 'Invalid normal admin',
-          gid: 'invalid_default_group',
+        expect(subject).to contain_user("invalid_normal_admin").with(
+          comment: "Invalid normal admin",
+          gid: "invalid_default_group",
           uid: 123_456,
-          home: '/home/invalid_normal_admin',
+          home: "/home/invalid_normal_admin",
           managehome: false,
-          shell: '/bin/bash',
-          groups: ['sudo'],
+          shell: "/bin/bash",
+          groups: ["sudo"]
         )
       end
 
       it do
-        expect(subject).to contain_user('invalid_special_admin').with(
-          comment: 'Invalid special admin',
-          gid: 'invalid_special_group',
+        expect(subject).to contain_user("invalid_special_admin").with(
+          comment: "Invalid special admin",
+          gid: "invalid_special_group",
           uid: 123_457,
-          home: '/home/invalid_special_admin',
+          home: "/home/invalid_special_admin",
           managehome: false,
-          shell: '/bin/bash',
-          groups: ['sudo'],
+          shell: "/bin/bash",
+          groups: ["sudo"]
         )
       end
 
       it do
-        expect(subject).to contain_user('invalid_noauth_admin').with(
-          comment: 'Invalid no-authorization admin',
-          gid: 'invalid_default_group',
+        expect(subject).to contain_user("invalid_noauth_admin").with(
+          comment: "Invalid no-authorization admin",
+          gid: "invalid_default_group",
           uid: 123_458,
-          home: '/home/invalid_noauth_admin',
+          home: "/home/invalid_noauth_admin",
           managehome: false,
-          shell: '/bin/bash',
-          groups: ['sudo'],
+          shell: "/bin/bash",
+          groups: ["sudo"]
         )
       end
     end

--- a/spec/classes/profile/vim_spec.rb
+++ b/spec/classes/profile/vim_spec.rb
@@ -3,29 +3,29 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::vim' do
+describe "nebula::profile::vim" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_package('vim') }
+      it { is_expected.to contain_package("vim") }
 
       it do
-        expect(subject).to contain_file('/etc/vim/vimrc')
-          .that_requires('Package[vim]')
+        expect(subject).to contain_file("/etc/vim/vimrc")
+          .that_requires("Package[vim]")
       end
 
       [
-        %r{^set mouse=$},
+        %r{^set mouse=$}
       ].each do |line|
-        it { is_expected.to contain_file('/etc/vim/vimrc').with_content(line) }
+        it { is_expected.to contain_file("/etc/vim/vimrc").with_content(line) }
       end
 
-      it 'never enables any mouse usage of any kind' do
-        expect(subject).to contain_file('/etc/vim/vimrc').without_content(
-          %r{^set mouse=.+$},
+      it "never enables any mouse usage of any kind" do
+        expect(subject).to contain_file("/etc/vim/vimrc").without_content(
+          %r{^set mouse=.+$}
         )
       end
     end

--- a/spec/classes/profile/vmhost/host_spec.rb
+++ b/spec/classes/profile/vmhost/host_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::profile::vmhost::host' do
+describe "nebula::profile::vmhost::host" do
   def contain_vm(name)
     contain_nebula__virtual_machine(name)
   end
@@ -15,191 +15,191 @@ describe 'nebula::profile::vmhost::host' do
       let(:facts) { os_facts }
 
       it do
-        expect(subject).to contain_file('/etc/default/libvirt-guests')
+        expect(subject).to contain_file("/etc/default/libvirt-guests")
       end
 
-      context 'when given nothing' do
-        it { is_expected.not_to contain_vm('vmname') }
+      context "when given nothing" do
+        it { is_expected.not_to contain_vm("vmname") }
       end
 
-      context 'when given bridge network interfaces' do
+      context "when given bridge network interfaces" do
         let(:params) do
           {
-            internet_bridge: 'internet_bridge',
-            lan_bridge: 'lan_bridge',
+            internet_bridge: "internet_bridge",
+            lan_bridge: "lan_bridge",
             vms: {
-              'vmname' => {
-                'addr' => '1.2.3.4',
-              },
-            },
+              "vmname" => {
+                "addr" => "1.2.3.4"
+              }
+            }
           }
         end
 
-        it { is_expected.to contain_vm('vmname').with_internet_bridge('internet_bridge') }
-        it { is_expected.to contain_vm('vmname').with_lan_bridge('lan_bridge') }
+        it { is_expected.to contain_vm("vmname").with_internet_bridge("internet_bridge") }
+        it { is_expected.to contain_vm("vmname").with_lan_bridge("lan_bridge") }
       end
 
-      context 'when given a single hostname with an ip' do
+      context "when given a single hostname with an ip" do
         let(:params) do
           {
             vms: {
-              'vmname' => {
-                'addr' => '1.2.3.4',
-              },
-            },
+              "vmname" => {
+                "addr" => "1.2.3.4"
+              }
+            }
           }
         end
 
-        it { is_expected.to contain_vm('vmname').with_build('bullseye') }
-        it { is_expected.to contain_vm('vmname').with_cpus(0) }
-        it { is_expected.to contain_vm('vmname').with_disk(0) }
-        it { is_expected.to contain_vm('vmname').with_ram(0) }
-        it { is_expected.to contain_vm('vmname').with_domain('default.domain.invalid') }
-        it { is_expected.to contain_vm('vmname').with_filehost('default.filehost.invalid') }
-        it { is_expected.to contain_vm('vmname').with_image_dir('default.image_dir.invalid') }
-        it { is_expected.to contain_vm('vmname').with_net_interface('default.iface.invalid') }
-        it { is_expected.to contain_vm('vmname').with_internet_bridge('br0') }
-        it { is_expected.to contain_vm('vmname').with_lan_bridge('br1') }
-        it { is_expected.to contain_vm('vmname').with_netmask('0.0.0.0') }
-        it { is_expected.to contain_vm('vmname').with_gateway('10.1.2.3') }
-        it { is_expected.to contain_vm('vmname').with_nameservers(['5.5.5.5', '4.4.4.4']) }
+        it { is_expected.to contain_vm("vmname").with_build("bullseye") }
+        it { is_expected.to contain_vm("vmname").with_cpus(0) }
+        it { is_expected.to contain_vm("vmname").with_disk(0) }
+        it { is_expected.to contain_vm("vmname").with_ram(0) }
+        it { is_expected.to contain_vm("vmname").with_domain("default.domain.invalid") }
+        it { is_expected.to contain_vm("vmname").with_filehost("default.filehost.invalid") }
+        it { is_expected.to contain_vm("vmname").with_image_dir("default.image_dir.invalid") }
+        it { is_expected.to contain_vm("vmname").with_net_interface("default.iface.invalid") }
+        it { is_expected.to contain_vm("vmname").with_internet_bridge("br0") }
+        it { is_expected.to contain_vm("vmname").with_lan_bridge("br1") }
+        it { is_expected.to contain_vm("vmname").with_netmask("0.0.0.0") }
+        it { is_expected.to contain_vm("vmname").with_gateway("10.1.2.3") }
+        it { is_expected.to contain_vm("vmname").with_nameservers(["5.5.5.5", "4.4.4.4"]) }
 
-        context 'with a random number of cpus' do
-          let(:cpus)   { Faker::Number.between(from: 1, to: 12).to_i }
+        context "with a random number of cpus" do
+          let(:cpus) { Faker::Number.between(from: 1, to: 12).to_i }
           let(:params) { super().merge(cpus: cpus) }
 
-          it { is_expected.to contain_vm('vmname').with_cpus(cpus) }
+          it { is_expected.to contain_vm("vmname").with_cpus(cpus) }
         end
 
-        context 'with a random amount of disk space' do
-          let(:disk)   { Faker::Number.between(from: 8, to: 200).to_i }
+        context "with a random amount of disk space" do
+          let(:disk) { Faker::Number.between(from: 8, to: 200).to_i }
           let(:params) { super().merge(disk: disk) }
 
-          it { is_expected.to contain_vm('vmname').with_disk(disk) }
+          it { is_expected.to contain_vm("vmname").with_disk(disk) }
         end
 
-        context 'with a random amount of ram' do
-          let(:ram)    { Faker::Number.between(from: 1, to: 64).to_i }
+        context "with a random amount of ram" do
+          let(:ram) { Faker::Number.between(from: 1, to: 64).to_i }
           let(:params) { super().merge(ram: ram) }
 
-          it { is_expected.to contain_vm('vmname').with_ram(ram) }
+          it { is_expected.to contain_vm("vmname").with_ram(ram) }
         end
 
-        context 'with a random domain' do
+        context "with a random domain" do
           let(:domain) { Faker::Internet.domain_name }
           let(:params) { super().merge(domain: domain) }
 
-          it { is_expected.to contain_vm('vmname').with_domain(domain) }
+          it { is_expected.to contain_vm("vmname").with_domain(domain) }
         end
 
-        context 'with a random filehost' do
+        context "with a random filehost" do
           let(:domain) { Faker::Internet.domain_name }
           let(:params) { super().merge(filehost: domain) }
 
-          it { is_expected.to contain_vm('vmname').with_filehost(domain) }
+          it { is_expected.to contain_vm("vmname").with_filehost(domain) }
         end
 
-        context 'with a net_interface of eth3' do
-          let(:params) { super().merge(net_interface: 'eth3') }
+        context "with a net_interface of eth3" do
+          let(:params) { super().merge(net_interface: "eth3") }
 
-          it { is_expected.to contain_vm('vmname').with_net_interface('eth3') }
+          it { is_expected.to contain_vm("vmname").with_net_interface("eth3") }
         end
 
-        context 'with a random netmask' do
-          let(:ip)     { Faker::Internet.ip_v4_address }
+        context "with a random netmask" do
+          let(:ip) { Faker::Internet.ip_v4_address }
           let(:params) { super().merge(netmask: ip) }
 
-          it { is_expected.to contain_vm('vmname').with_netmask(ip) }
+          it { is_expected.to contain_vm("vmname").with_netmask(ip) }
         end
 
-        context 'with a random gateway' do
-          let(:ip)     { Faker::Internet.ip_v4_address }
+        context "with a random gateway" do
+          let(:ip) { Faker::Internet.ip_v4_address }
           let(:params) { super().merge(gateway: ip) }
 
-          it { is_expected.to contain_vm('vmname').with_gateway(ip) }
+          it { is_expected.to contain_vm("vmname").with_gateway(ip) }
         end
 
-        context 'with some random nameservers' do
+        context "with some random nameservers" do
           let(:nameservers) { Array.new(Faker::Number.between(from: 2, to: 4)) { Faker::Internet.ip_v4_address } }
-          let(:params)      { super().merge(nameservers: nameservers) }
+          let(:params) { super().merge(nameservers: nameservers) }
 
-          it { is_expected.to contain_vm('vmname').with_nameservers(nameservers) }
+          it { is_expected.to contain_vm("vmname").with_nameservers(nameservers) }
         end
 
-        context 'with an image_dir of /virt_imgs' do
-          let(:params) { super().merge(image_dir: '/virt_imgs') }
+        context "with an image_dir of /virt_imgs" do
+          let(:params) { super().merge(image_dir: "/virt_imgs") }
 
-          it { is_expected.to contain_vm('vmname').with_image_dir('/virt_imgs') }
+          it { is_expected.to contain_vm("vmname").with_image_dir("/virt_imgs") }
 
-          context 'with a vm with an image_dir of /special_img' do
+          context "with a vm with an image_dir of /special_img" do
             let(:params) do
               super().merge(
                 vms: {
-                  'normalvm' => {
-                    'addr' => '1.2.3.2',
+                  "normalvm" => {
+                    "addr" => "1.2.3.2"
                   },
-                  'specialvm' => {
-                    'addr' => '1.2.3.3',
-                    'image_dir' => '/special_img',
-                  },
-                },
+                  "specialvm" => {
+                    "addr" => "1.2.3.3",
+                    "image_dir" => "/special_img"
+                  }
+                }
               )
             end
 
-            it { is_expected.to contain_vm('normalvm').with_image_dir('/virt_imgs') }
-            it { is_expected.to contain_vm('specialvm').with_image_dir('/special_img') }
+            it { is_expected.to contain_vm("normalvm").with_image_dir("/virt_imgs") }
+            it { is_expected.to contain_vm("specialvm").with_image_dir("/special_img") }
           end
         end
       end
 
-      context 'when given a different hostname with an ip' do
+      context "when given a different hostname with an ip" do
         let(:params) do
           {
             vms: {
-              'secondvm' => {
-                'addr' => '1.2.3.5',
-              },
-            },
+              "secondvm" => {
+                "addr" => "1.2.3.5"
+              }
+            }
           }
         end
 
-        it { is_expected.to contain_vm('secondvm') }
+        it { is_expected.to contain_vm("secondvm") }
       end
 
-      context 'without local storage' do
+      context "without local storage" do
         let(:params) do
           {
             vms: {
-              'itsavm' => {
-                'addr' => '1.2.3.4',
-              },
-            },
+              "itsavm" => {
+                "addr" => "1.2.3.4"
+              }
+            }
           }
         end
 
-        it { is_expected.not_to contain_mount('') }
-        it { is_expected.not_to contain_logical_volume('vmimages') }
-        it { is_expected.not_to contain_filesystem('/dev/mapper/internal-vmimages') }
+        it { is_expected.not_to contain_mount("") }
+        it { is_expected.not_to contain_logical_volume("vmimages") }
+        it { is_expected.not_to contain_filesystem("/dev/mapper/internal-vmimages") }
       end
 
-      context 'when given a local storage size' do
+      context "when given a local storage size" do
         let(:params) do
           {
             vms: {
-              'itsavm' => {
-                'addr' => '1.2.3.4',
-              },
+              "itsavm" => {
+                "addr" => "1.2.3.4"
+              }
             },
-            local_storage_size: '42G',
-            local_storage: "/#{Faker::Lorem.word}",
+            local_storage_size: "42G",
+            local_storage: "/#{Faker::Lorem.word}"
           }
         end
 
-        it { is_expected.to contain_vm('itsavm').that_requires("Mount[#{params[:local_storage]}]") }
-        it { is_expected.to contain_file(params[:local_storage]).with_ensure('directory') }
+        it { is_expected.to contain_vm("itsavm").that_requires("Mount[#{params[:local_storage]}]") }
+        it { is_expected.to contain_file(params[:local_storage]).with_ensure("directory") }
         it { is_expected.to contain_mount(params[:local_storage]) }
-        it { is_expected.to contain_logical_volume('vmimages').with_size('42G') }
-        it { is_expected.to contain_filesystem('/dev/mapper/internal-vmimages').with_fs_type('ext4') }
+        it { is_expected.to contain_logical_volume("vmimages").with_size("42G") }
+        it { is_expected.to contain_filesystem("/dev/mapper/internal-vmimages").with_fs_type("ext4") }
       end
     end
   end

--- a/spec/classes/profile/www_lib/cron_spec.rb
+++ b/spec/classes/profile/www_lib/cron_spec.rb
@@ -3,42 +3,42 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-describe 'nebula::profile::www_lib::cron' do
+require "spec_helper"
+describe "nebula::profile::www_lib::cron" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/www_lib_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/www_lib_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
       context 'with user set to "cron_friend"' do
-        let(:params) { { user: 'cron_friend' } }
+        let(:params) { {user: "cron_friend"} }
 
-        it { is_expected.to contain_cron('staff.lib parse').with_user('cron_friend') }
+        it { is_expected.to contain_cron("staff.lib parse").with_user("cron_friend") }
       end
 
       context 'with mailto set to "crons@umich.edu"' do
-        let(:params) { { mailto: 'crons@umich.edu' } }
+        let(:params) { {mailto: "crons@umich.edu"} }
 
-        it { is_expected.to contain_cron('staff.lib parse').with_environment(['MAILTO=crons@umich.edu']) }
+        it { is_expected.to contain_cron("staff.lib parse").with_environment(["MAILTO=crons@umich.edu"]) }
       end
 
       context 'with an additional cronjob to echo "hello" at 1:23 daily' do
-        let(:params) { { extra_jobs: extra_jobs } }
+        let(:params) { {extra_jobs: extra_jobs} }
         let(:extra_jobs) do
           {
-            'my_title' => {
-              'hour' => 1,
-              'minute' => 23,
-              'command' => 'echo hello',
-            },
+            "my_title" => {
+              "hour" => 1,
+              "minute" => 23,
+              "command" => "echo hello"
+            }
           }
         end
 
-        it { is_expected.to contain_cron('my_title').with_hour(1) }
-        it { is_expected.to contain_cron('my_title').with_minute(23) }
-        it { is_expected.to contain_cron('my_title').with_command('echo hello') }
+        it { is_expected.to contain_cron("my_title").with_hour(1) }
+        it { is_expected.to contain_cron("my_title").with_minute(23) }
+        it { is_expected.to contain_cron("my_title").with_command("echo hello") }
       end
     end
   end

--- a/spec/classes/profile/www_lib/php_spec.rb
+++ b/spec/classes/profile/www_lib/php_spec.rb
@@ -3,8 +3,8 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-describe 'nebula::profile::www_lib::php' do
+require "spec_helper"
+describe "nebula::profile::www_lib::php" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
+++ b/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
@@ -3,37 +3,37 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-describe 'nebula::profile::www_lib::register_for_load_balancing' do
+require "spec_helper"
+describe "nebula::profile::www_lib::register_for_load_balancing" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      describe 'exported resources' do
+      describe "exported resources" do
         subject { exported_resources }
 
-        context 'with services set to www-lib' do
-          let(:params) { { services: ['www-lib'] } }
+        context "with services set to www-lib" do
+          let(:params) { {services: ["www-lib"]} }
 
           it do
             expect(subject).to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib")
-              .with_service('www-lib')
+              .with_service("www-lib")
           end
 
           it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:hostname]} deepblue") }
         end
 
-        context 'with services set to www-lib and deepblue' do
-          let(:params) { { services: %w[www-lib deepblue] } }
+        context "with services set to www-lib and deepblue" do
+          let(:params) { {services: %w[www-lib deepblue]} }
 
           it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib") }
           it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} deepblue") }
         end
 
-        context 'with services set to www-lib-testing' do
-          let(:params) { { services: ['www-lib-testing'] } }
+        context "with services set to www-lib-testing" do
+          let(:params) { {services: ["www-lib-testing"]} }
 
           it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib-testing") }
           it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib") }

--- a/spec/classes/resolv_conf_spec.rb
+++ b/spec/classes/resolv_conf_spec.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::resolv_conf' do
+describe "nebula::resolv_conf" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it 'removes resolvconf package if present' do
-        expect(subject).to contain_package('resolvconf').with_ensure('absent')
+      it "removes resolvconf package if present" do
+        expect(subject).to contain_package("resolvconf").with_ensure("absent")
       end
 
-      it 'contains expected resolv.conf file' do
-        expect(subject).to contain_file('/etc/resolv.conf')
-          .with_owner('root')
-          .with_group('root')
-          .with_mode('0644')
+      it "contains expected resolv.conf file" do
+        expect(subject).to contain_file("/etc/resolv.conf")
+          .with_owner("root")
+          .with_group("root")
+          .with_mode("0644")
           .with_content(%r{^#.*puppet})
           .with_content(%r{^search searchpath\.default\.invalid$})
           .with_content(%r{^nameserver 5.5.5.5\nnameserver 4.4.4.4$})
       end
 
-      context 'with different nameservers' do
-        let(:params) { { nameservers: ['3.3.3.3', '2.2.2.2', '1.1.1.1'] } }
+      context "with different nameservers" do
+        let(:params) { {nameservers: ["3.3.3.3", "2.2.2.2", "1.1.1.1"]} }
 
         it do
-          expect(subject).to contain_file('/etc/resolv.conf')
+          expect(subject).to contain_file("/etc/resolv.conf")
             .with_content(%r{^#.*puppet})
             .with_content(%r{^search searchpath\.default\.invalid$})
             .with_content(%r{^nameserver 3.3.3.3\nnameserver 2.2.2.2\nnameserver 1.1.1.1$})
         end
       end
 
-      context 'with searchpath set to []' do
-        let(:params) { { searchpath: [] } }
+      context "with searchpath set to []" do
+        let(:params) { {searchpath: []} }
 
         it do
-          expect(subject).to contain_file('/etc/resolv.conf')
+          expect(subject).to contain_file("/etc/resolv.conf")
             .with_content(%r{^#.*puppet})
             .without_content(%r{^search})
             .with_content(%r{^nameserver 5.5.5.5\nnameserver 4.4.4.4$})
         end
       end
 
-      context 'with custom file mode' do
-        let(:params) { { mode: '0664' } }
+      context "with custom file mode" do
+        let(:params) { {mode: "0664"} }
 
         it do
-          expect(subject).to contain_file('/etc/resolv.conf')
+          expect(subject).to contain_file("/etc/resolv.conf")
             .with_content(%r{^#.*puppet})
-            .with_mode('0664')
+            .with_mode("0664")
         end
       end
     end

--- a/spec/classes/role/aleph_marcedit_spec.rb
+++ b/spec/classes/role/aleph_marcedit_spec.rb
@@ -3,19 +3,19 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::role::aleph::marcedit' do
+describe "nebula::role::aleph::marcedit" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('nebula::profile::krb5') }
-      it { is_expected.to contain_class('nebula::profile::afs') }
-      it { is_expected.to contain_class('nebula::profile::users') }
+      it { is_expected.to contain_class("nebula::profile::krb5") }
+      it { is_expected.to contain_class("nebula::profile::afs") }
+      it { is_expected.to contain_class("nebula::profile::users") }
     end
   end
 end

--- a/spec/classes/role/app_host_dev_spec.rb
+++ b/spec/classes/role/app_host_dev_spec.rb
@@ -3,19 +3,19 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::role::app_host::dev' do
+describe "nebula::role::app_host::dev" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('nebula::profile::krb5') }
-      it { is_expected.to contain_class('nebula::profile::afs') }
-      it { is_expected.to contain_class('nebula::profile::users') }
+      it { is_expected.to contain_class("nebula::profile::krb5") }
+      it { is_expected.to contain_class("nebula::profile::afs") }
+      it { is_expected.to contain_class("nebula::profile::users") }
     end
   end
 end

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -3,17 +3,17 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::chipmunk' do
+describe "nebula::role::chipmunk" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/chipmunk_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/chipmunk_config.yaml" }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('nebula::profile::networking::sshd_group_umask') }
+      it { is_expected.to contain_class("nebula::profile::networking::sshd_group_umask") }
     end
   end
 end

--- a/spec/classes/role/cron_runner_spec.rb
+++ b/spec/classes/role/cron_runner_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::cron_runner' do
+describe "nebula::role::cron_runner" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/role/deb_server_spec.rb
+++ b/spec/classes/role/deb_server_spec.rb
@@ -3,14 +3,14 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::role::deb_server' do
+describe "nebula::role::deb_server" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.deep_merge(networking: { ip: Faker::Internet.ip_v4_address, interfaces: {} }) }
-      let(:hiera_config) { 'spec/fixtures/hiera/deb_server_config.yaml' }
+      let(:facts) { os_facts.deep_merge(networking: {ip: Faker::Internet.ip_v4_address, interfaces: {}}) }
+      let(:hiera_config) { "spec/fixtures/hiera/deb_server_config.yaml" }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/role/fulcrum_app_host_spec.rb
+++ b/spec/classes/role/fulcrum_app_host_spec.rb
@@ -3,13 +3,13 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::fulcrum::app_host' do
+describe "nebula::role::fulcrum::app_host" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/fulcrum_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/fulcrum_config.yaml" }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/role/fulcrum_standalone_spec.rb
+++ b/spec/classes/role/fulcrum_standalone_spec.rb
@@ -3,13 +3,13 @@
 # Copyright (c) 2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::fulcrum::standalone' do
+describe "nebula::role::fulcrum::standalone" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/fulcrum_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/fulcrum_config.yaml" }
 
       it { is_expected.to compile }
     end

--- a/spec/classes/role/fulcrum_www_and_app_spec.rb
+++ b/spec/classes/role/fulcrum_www_and_app_spec.rb
@@ -3,52 +3,52 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_mocked_nodes'
+require_relative "../../support/contexts/with_mocked_nodes"
 
-describe 'nebula::role::webhost::fulcrum_www_and_app' do
+describe "nebula::role::webhost::fulcrum_www_and_app" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(hostname: 'thisnode', datacenter: 'somedc') }
-      let(:rolenode) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'rolenode' } }
-      let(:hiera_config) { 'spec/fixtures/hiera/fulcrum_config.yaml' }
+      let(:facts) { os_facts.merge(hostname: "thisnode", datacenter: "somedc") }
+      let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }
+      let(:hiera_config) { "spec/fixtures/hiera/fulcrum_config.yaml" }
 
-      include_context 'with mocked puppetdb functions', 'somedc', %w[rolenode], 'nebula::profile::haproxy' => %w[]
+      include_context "with mocked puppetdb functions", "somedc", %w[rolenode], "nebula::profile::haproxy" => %w[]
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('nebula::profile::fulcrum::app') }
+      it { is_expected.to contain_class("nebula::profile::fulcrum::app") }
 
-      it { is_expected.to contain_class('Nebula::Profile::Www_lib::Register_for_load_balancing') }
+      it { is_expected.to contain_class("Nebula::Profile::Www_lib::Register_for_load_balancing") }
 
-      it { is_expected.to contain_class('nebula::profile::networking::firewall::http') }
+      it { is_expected.to contain_class("nebula::profile::networking::firewall::http") }
 
-      it { is_expected.to contain_class('nebula::profile::apache') }
+      it { is_expected.to contain_class("nebula::profile::apache") }
 
-      it 'configures shibboleth' do
-        expect(subject).to contain_class('nebula::profile::shibboleth')
+      it "configures shibboleth" do
+        expect(subject).to contain_class("nebula::profile::shibboleth")
           .with(startup_timeout: 900)
-          .with(watchdog_minutes: '*/30')
+          .with(watchdog_minutes: "*/30")
       end
 
       it do
-        expect(subject).to contain_file('/etc/apache2/mods-available/shib2.conf')
+        expect(subject).to contain_file("/etc/apache2/mods-available/shib2.conf")
           .with_content(%r{SetHandler shib-handler})
       end
 
       it do
-        expect(subject).to contain_file('/etc/apache2/mods-enabled/shib2.conf')
-          .with_ensure('link')
-          .with_target('/etc/apache2/mods-available/shib2.conf')
+        expect(subject).to contain_file("/etc/apache2/mods-enabled/shib2.conf")
+          .with_ensure("link")
+          .with_target("/etc/apache2/mods-available/shib2.conf")
       end
 
       # from hiera
-      it { is_expected.to contain_host('mysql-web').with_ip('10.0.0.123') }
+      it { is_expected.to contain_host("mysql-web").with_ip("10.0.0.123") }
 
-      it { is_expected.to contain_cron('purge apache access logs 1/2') }
-      it { is_expected.to contain_cron('purge apache access logs 2/2') }
-      it { is_expected.to contain_cron('shibd existence check') }
+      it { is_expected.to contain_cron("purge apache access logs 1/2") }
+      it { is_expected.to contain_cron("purge apache access logs 2/2") }
+      it { is_expected.to contain_cron("shibd existence check") }
     end
   end
 end

--- a/spec/classes/role/hathitrust/solr/catalog_spec.rb
+++ b/spec/classes/role/hathitrust/solr/catalog_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::hathitrust::solr::catalog' do
+describe "nebula::role::hathitrust::solr::catalog" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('nebula::role::hathitrust') }
-      it { is_expected.to contain_class('nebula::profile::loki') }
-      it { is_expected.not_to contain_package('openafs-client') }
+      it { is_expected.to contain_class("nebula::role::hathitrust") }
+      it { is_expected.to contain_class("nebula::profile::loki") }
+      it { is_expected.not_to contain_package("openafs-client") }
     end
   end
 end

--- a/spec/classes/role/hathitrust/solr/lss_spec.rb
+++ b/spec/classes/role/hathitrust/solr/lss_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::hathitrust::solr::lss' do
+describe "nebula::role::hathitrust::solr::lss" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_class('nebula::role::hathitrust') }
-      it { is_expected.not_to contain_package('openafs-client') }
+      it { is_expected.to contain_class("nebula::role::hathitrust") }
+      it { is_expected.not_to contain_package("openafs-client") }
     end
   end
 end

--- a/spec/classes/role/hathitrust_spec.rb
+++ b/spec/classes/role/hathitrust_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::hathitrust' do
+describe "nebula::role::hathitrust" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_package('openafs-client') }
+      it { is_expected.to contain_package("openafs-client") }
 
-      context 'when $afs is false' do
-        let(:params) { { afs: false } }
+      context "when $afs is false" do
+        let(:params) { {afs: false} }
 
-        it { is_expected.not_to contain_package('openafs-client') }
+        it { is_expected.not_to contain_package("openafs-client") }
       end
     end
   end

--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -3,48 +3,48 @@
 # Copyright (c) 2018,2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::role::hathitrust::datasets' do
+describe "nebula::role::hathitrust::datasets" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('nfs-common') }
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3,ro') }
-      it { is_expected.to contain_mount('/htprep') }
+      it { is_expected.to contain_package("nfs-common") }
+      it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3,ro") }
+      it { is_expected.to contain_mount("/htprep") }
 
-      describe 'unencrypted rsync' do
-        it { is_expected.to contain_package('rsync') }
-        it { is_expected.to contain_service('rsync').with_enable(true) }
+      describe "unencrypted rsync" do
+        it { is_expected.to contain_package("rsync") }
+        it { is_expected.to contain_service("rsync").with_enable(true) }
 
-        it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 1, University of East Westtestland, testuser1@default.invalid').with_source('192.0.2.102') }
-        it { is_expected.to contain_firewall('200 rsync: dataset dataset1 - Test User 2, University of West Easttestland, testuser2@default.invalid').with_source('198.51.100.10') }
-        it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid').with_source('192.0.2.108') }
-        it { is_expected.to contain_firewall('200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid').with_source('198.51.100.15') }
+        it { is_expected.to contain_firewall("200 rsync: dataset dataset1 - Test User 1, University of East Westtestland, testuser1@default.invalid").with_source("192.0.2.102") }
+        it { is_expected.to contain_firewall("200 rsync: dataset dataset1 - Test User 2, University of West Easttestland, testuser2@default.invalid").with_source("198.51.100.10") }
+        it { is_expected.to contain_firewall("200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid").with_source("192.0.2.108") }
+        it { is_expected.to contain_firewall("200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid").with_source("198.51.100.15") }
 
-        it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
-        it { is_expected.to contain_file('/etc/rsyncd.conf').with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
+        it { is_expected.to contain_file("/etc/rsyncd.conf").with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
+        it { is_expected.to contain_file("/etc/rsyncd.conf").with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
       end
 
-      describe 'encrypted rsync' do
-        it { is_expected.to contain_package('stunnel4') }
-        it { is_expected.to contain_service('secure-rsync').with_enable(true) }
-        it { is_expected.to contain_file('/etc/systemd/system/secure-rsync.service').with_content(%r{ExecStart=/usr/bin/stunnel /etc/secure-rsync/stunnel.conf}) }
-        it { is_expected.to contain_file('/etc/secure-rsync') }
-        it { is_expected.to contain_file('/etc/secure-rsync/stunnel.conf').with_content(%r{rsync.*/etc/secure-rsync/rsyncd.conf.*CAfile=/etc/secure-rsync/client.crt}m) }
-        it { is_expected.to contain_file('/etc/secure-rsync/rsyncd.conf').with_content(%r{/datasets/secure_dataset}m) }
-        it { is_expected.to contain_file('/etc/secure-rsync/server.key') }
-        it { is_expected.to contain_file('/etc/secure-rsync/server.crt') }
-        it { is_expected.to contain_file('/etc/secure-rsync/client.crt') }
+      describe "encrypted rsync" do
+        it { is_expected.to contain_package("stunnel4") }
+        it { is_expected.to contain_service("secure-rsync").with_enable(true) }
+        it { is_expected.to contain_file("/etc/systemd/system/secure-rsync.service").with_content(%r{ExecStart=/usr/bin/stunnel /etc/secure-rsync/stunnel.conf}) }
+        it { is_expected.to contain_file("/etc/secure-rsync") }
+        it { is_expected.to contain_file("/etc/secure-rsync/stunnel.conf").with_content(%r{rsync.*/etc/secure-rsync/rsyncd.conf.*CAfile=/etc/secure-rsync/client.crt}m) }
+        it { is_expected.to contain_file("/etc/secure-rsync/rsyncd.conf").with_content(%r{/datasets/secure_dataset}m) }
+        it { is_expected.to contain_file("/etc/secure-rsync/server.key") }
+        it { is_expected.to contain_file("/etc/secure-rsync/server.crt") }
+        it { is_expected.to contain_file("/etc/secure-rsync/client.crt") }
 
-        it { is_expected.to contain_firewall('200 secure-rsync Net One').with_source('10.0.1.0/24') }
-        it { is_expected.to contain_firewall('200 secure-rsync VPN').with_source('10.0.3.0/24') }
-        it { is_expected.to contain_firewall('200 secure-rsync secure network').with_src_range('192.0.2.1-192.0.2.4') }
+        it { is_expected.to contain_firewall("200 secure-rsync Net One").with_source("10.0.1.0/24") }
+        it { is_expected.to contain_firewall("200 secure-rsync VPN").with_source("10.0.3.0/24") }
+        it { is_expected.to contain_firewall("200 secure-rsync secure network").with_src_range("192.0.2.1-192.0.2.4") }
       end
     end
   end

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -3,35 +3,35 @@
 # Copyright (c) 2018,2021 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::role::hathitrust::ingest_indexing' do
+describe "nebula::role::hathitrust::ingest_indexing" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('nfs-common') }
-      it { is_expected.to contain_mount('/sdr1').with_options('auto,hard,nfsvers=3') }
+      it { is_expected.to contain_package("nfs-common") }
+      it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3") }
       # causes a warning if concat fragment is included but monitor_pl isn't
       # (which we don't need on ingest servers)
-      it { is_expected.not_to contain_concat_fragment('monitor nfs /sdr1') }
-      it { is_expected.to contain_mount('/htprep') }
+      it { is_expected.not_to contain_concat_fragment("monitor nfs /sdr1") }
+      it { is_expected.to contain_mount("/htprep") }
 
       # default from hiera
-      it { is_expected.to contain_host('mysql-sdr').with_ip('10.1.2.4') }
+      it { is_expected.to contain_host("mysql-sdr").with_ip("10.1.2.4") }
 
       # not specified explicitly as a usergroup, just brought in as part of 'all groups'
-      it { is_expected.to contain_group('htprod') }
-      it { is_expected.to contain_group('htingest') }
+      it { is_expected.to contain_group("htprod") }
+      it { is_expected.to contain_group("htingest") }
       # not specified explicitly - realized through Nebula::Usergroup[htingest]
-      it { is_expected.to contain_user('htingest') }
-      it { is_expected.not_to contain_user('htweb') }
+      it { is_expected.to contain_user("htingest") }
+      it { is_expected.not_to contain_user("htweb") }
 
-      it { is_expected.to contain_file('/etc/logrotate.d/babel') }
+      it { is_expected.to contain_file("/etc/logrotate.d/babel") }
     end
   end
 end

--- a/spec/classes/role/htvm_global_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_global_primary_webhost_spec.rb
@@ -3,25 +3,25 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_htvm_setup'
+require_relative "../../support/contexts/with_htvm_setup"
 
-describe 'nebula::role::webhost::htvm::global_primary' do
+describe "nebula::role::webhost::htvm::global_primary" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
       it { is_expected.to compile }
 
       # includes cron jobs that run on only one node in cluster
-      it { is_expected.to contain_class('nebula::profile::hathitrust::cron::catalog') }
-      it { is_expected.to contain_class('nebula::role::webhost::htvm::site_primary') }
+      it { is_expected.to contain_class("nebula::profile::hathitrust::cron::catalog") }
+      it { is_expected.to contain_class("nebula::role::webhost::htvm::site_primary") }
 
       it do
-        expect(subject).to contain_cron('wordpress cron')
-          .with(user: 'nobody',
-                command: %r{.*wp-cron.php.*},
-                minute: 0)
+        expect(subject).to contain_cron("wordpress cron")
+          .with(user: "nobody",
+            command: %r{.*wp-cron.php.*},
+            minute: 0)
       end
     end
   end

--- a/spec/classes/role/htvm_prod_webhost_spec.rb
+++ b/spec/classes/role/htvm_prod_webhost_spec.rb
@@ -3,19 +3,19 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_htvm_setup'
+require_relative "../../support/contexts/with_htvm_setup"
 
-describe 'nebula::role::webhost::htvm::prod' do
+describe "nebula::role::webhost::htvm::prod" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
       it { is_expected.to compile }
 
-      it 'exports a haproxy::binding resource for hathitrust' do
-        expect(exported_resources).to contain_nebula__haproxy__binding('thisnode hathitrust')
-          .with(service: 'hathitrust', datacenter: 'somedc')
+      it "exports a haproxy::binding resource for hathitrust" do
+        expect(exported_resources).to contain_nebula__haproxy__binding("thisnode hathitrust")
+          .with(service: "hathitrust", datacenter: "somedc")
       end
     end
   end

--- a/spec/classes/role/htvm_site_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_site_primary_webhost_spec.rb
@@ -3,21 +3,21 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_htvm_setup'
+require_relative "../../support/contexts/with_htvm_setup"
 
-describe 'nebula::role::webhost::htvm::site_primary' do
+describe "nebula::role::webhost::htvm::site_primary" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
       it { is_expected.to compile }
 
       # includes cron jobs that run at each site
-      it { is_expected.to contain_class('nebula::profile::hathitrust::cron::mdp_misc') }
+      it { is_expected.to contain_class("nebula::profile::hathitrust::cron::mdp_misc") }
       # sets cache parameters
       #
-      it { is_expected.to contain_package('rdist') }
+      it { is_expected.to contain_package("rdist") }
     end
   end
 end

--- a/spec/classes/role/htvm_test_webhost_spec.rb
+++ b/spec/classes/role/htvm_test_webhost_spec.rb
@@ -3,15 +3,15 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require_relative '../../support/contexts/with_htvm_setup'
+require "spec_helper"
+require_relative "../../support/contexts/with_htvm_setup"
 
-describe 'nebula::role::webhost::htvm::test' do
+describe "nebula::role::webhost::htvm::test" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
       it { is_expected.to compile }
-      it { is_expected.to contain_package('nodejs') }
+      it { is_expected.to contain_package("nodejs") }
     end
   end
 end

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -3,78 +3,78 @@
 # Copyright (c) 2018, 2023 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_htvm_setup'
+require_relative "../../support/contexts/with_htvm_setup"
 
-describe 'nebula::role::webhost::htvm' do
+describe "nebula::role::webhost::htvm" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      include_context 'with setup for htvm node', os_facts
+      include_context "with setup for htvm node", os_facts
       # binding.irb
       it { is_expected.to compile }
 
       it do
-        expect(subject).to contain_class('nebula::profile::shibboleth')
+        expect(subject).to contain_class("nebula::profile::shibboleth")
           .with(startup_timeout: 1800)
-          .with(watchdog_minutes: '*/30')
+          .with(watchdog_minutes: "*/30")
       end
 
       it do
-        expect(subject).to contain_class('nebula::profile::hathitrust::dependencies')
-        expect(subject).to contain_class('nebula::profile::hathitrust::hosts')
-        expect(subject).to contain_class('nebula::profile::hathitrust::mounts')
-        expect(subject).to contain_class('nebula::profile::hathitrust::perl')
-        expect(subject).to contain_class('nebula::profile::hathitrust::php')
+        expect(subject).to contain_class("nebula::profile::hathitrust::dependencies")
+        expect(subject).to contain_class("nebula::profile::hathitrust::hosts")
+        expect(subject).to contain_class("nebula::profile::hathitrust::mounts")
+        expect(subject).to contain_class("nebula::profile::hathitrust::perl")
+        expect(subject).to contain_class("nebula::profile::hathitrust::php")
       end
 
       it do
-        expect(subject).to contain_concat_fragment('monitor nfs /sdr1')
-          .with(tag: 'monitor_config', content: { 'nfs' => ['/sdr1'] }.to_yaml)
+        expect(subject).to contain_concat_fragment("monitor nfs /sdr1")
+          .with(tag: "monitor_config", content: {"nfs" => ["/sdr1"]}.to_yaml)
       end
 
       it do
-        expect(subject).to contain_concat_fragment('monitor nfs /htapps')
-          .with(tag: 'monitor_config', content: { 'nfs' => ['/htapps'] }.to_yaml)
+        expect(subject).to contain_concat_fragment("monitor nfs /htapps")
+          .with(tag: "monitor_config", content: {"nfs" => ["/htapps"]}.to_yaml)
       end
 
-      context 'with ens4' do
+      context "with ens4" do
         let(:facts) do
           os_facts.deep_merge(
             networking: {
-              'ip' => '1.2.3.123',
-              'interfaces' => { 'ens4' => {} },
+              "ip" => "1.2.3.123",
+              "interfaces" => {"ens4" => {}}
             },
-            is_virtual: true,
+            is_virtual: true
           )
         end
 
-        it { is_expected.to contain_mount('/htapps').that_requires('Exec[ifup ens4]') }
-        it { is_expected.to contain_mount('/sdr1').that_requires('Exec[ifup ens4]') }
-        it { is_expected.to contain_service('bind9').that_requires('Exec[ifup ens4]') }
+        it { is_expected.to contain_mount("/htapps").that_requires("Exec[ifup ens4]") }
+        it { is_expected.to contain_mount("/sdr1").that_requires("Exec[ifup ens4]") }
+        it { is_expected.to contain_service("bind9").that_requires("Exec[ifup ens4]") }
       end
 
-      it { is_expected.to contain_class('nebula::profile::networking::firewall') }
+      it { is_expected.to contain_class("nebula::profile::networking::firewall") }
 
-      it { is_expected.to contain_class('nebula::profile::krb5') }
-      it { is_expected.to contain_class('nebula::profile::afs') }
-      it { is_expected.to contain_class('nebula::profile::users') }
+      it { is_expected.to contain_class("nebula::profile::krb5") }
+      it { is_expected.to contain_class("nebula::profile::afs") }
+      it { is_expected.to contain_class("nebula::profile::users") }
 
-      if os == 'debian-11-x86_64'
-        it { is_expected.not_to contain_package('php5-common') }
-        it { is_expected.not_to contain_package('php5-dev') }
-        it { is_expected.to contain_package('libapache2-mod-shib') }
-        it { is_expected.not_to contain_package('libapache2-mod-shib2') }
+      if os == "debian-11-x86_64"
+        it { is_expected.not_to contain_package("php5-common") }
+        it { is_expected.not_to contain_package("php5-dev") }
+        it { is_expected.to contain_package("libapache2-mod-shib") }
+        it { is_expected.not_to contain_package("libapache2-mod-shib2") }
       end
 
       # not specified explicitly as a usergroup, just brought in as part of 'all groups'
-      it { is_expected.to contain_group('htprod') }
-      it { is_expected.to contain_group('htingest') }
+      it { is_expected.to contain_group("htprod") }
+      it { is_expected.to contain_group("htingest") }
       # not specified explicitly - realized through Nebula::Usergroup[htprod]
-      it { is_expected.to contain_user('htingest') }
-      it { is_expected.to contain_user('htweb') }
+      it { is_expected.to contain_user("htingest") }
+      it { is_expected.to contain_user("htweb") }
 
-      it { is_expected.to contain_nebula__cpan('Prometheus::Tiny::Shared') }
+      it { is_expected.to contain_nebula__cpan("Prometheus::Tiny::Shared") }
     end
   end
 end

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -3,34 +3,34 @@
 # Copyright (c) 2019-2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
 %w[primary backup].each do |tier|
   describe "nebula::role::kubernetes::#{tier}_gateway" do
     on_supported_os.each do |os, os_facts|
-      next if os == 'debian-8-x86_64'
+      next if os == "debian-8-x86_64"
 
       context "on #{os}" do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
         let(:facts) do
           my_facts = os_facts.deep_merge(
             networking: {
-              'interfaces' => {
-                'ens4' => {
-                  'ip' => '10.123.234.5',
-                },
+              "interfaces" => {
+                "ens4" => {
+                  "ip" => "10.123.234.5"
+                }
               },
-              'ip' => '10.123.234.5',
-              'primary' => 'ens4',
-            },
+              "ip" => "10.123.234.5",
+              "primary" => "ens4"
+            }
           )
-          my_facts[:networking]['interfaces'].delete('eth0')
+          my_facts[:networking]["interfaces"].delete("eth0")
           my_facts
         end
 
-        it { is_expected.to contain_class('Nebula::Profile::Ntp') }
+        it { is_expected.to contain_class("Nebula::Profile::Ntp") }
 
-        it { is_expected.to contain_service('haproxy').that_notifies('Service[keepalived]') }
+        it { is_expected.to contain_service("haproxy").that_notifies("Service[keepalived]") }
       end
     end
   end
@@ -39,88 +39,88 @@ end
 %w[controller etcd worker].each do |role|
   describe "nebula::role::kubernetes::#{role}" do
     on_supported_os.each do |os, os_facts|
-      next if os == 'debian-8-x86_64'
+      next if os == "debian-8-x86_64"
 
       context "on #{os}" do
-        let(:hiera_config) { 'spec/fixtures/hiera/kubernetes/first_cluster_config.yaml' }
+        let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
         let(:facts) do
           my_facts = os_facts.deep_merge(
             networking: {
-              'interfaces' => {
-                'ens4' => {
-                  'ip' => '10.123.234.5',
-                },
+              "interfaces" => {
+                "ens4" => {
+                  "ip" => "10.123.234.5"
+                }
               },
-              'ip' => '10.123.234.5',
-              'primary' => 'ens4',
-            },
+              "ip" => "10.123.234.5",
+              "primary" => "ens4"
+            }
           )
-          my_facts[:networking]['interfaces'].delete('eth0')
+          my_facts[:networking]["interfaces"].delete("eth0")
           my_facts
         end
 
-        it { is_expected.to contain_class('Nebula::Profile::Ntp') }
+        it { is_expected.to contain_class("Nebula::Profile::Ntp") }
 
-        it { is_expected.not_to contain_resources('firewall').with_purge(false) }
+        it { is_expected.not_to contain_resources("firewall").with_purge(false) }
 
         it do
-          expect(subject).to contain_firewallchain('INPUT:filter:IPv4').with(
-            ensure: 'present',
+          expect(subject).to contain_firewallchain("INPUT:filter:IPv4").with(
+            ensure: "present",
             purge: false,
-            ignore: ['-j cali-INPUT',
-                     '-j KUBE-FIREWALL',
-                     '-j KUBE-SERVICES',
-                     '-j KUBE-EXTERNAL-SERVICES'],
+            ignore: ["-j cali-INPUT",
+              "-j KUBE-FIREWALL",
+              "-j KUBE-SERVICES",
+              "-j KUBE-EXTERNAL-SERVICES"]
           )
         end
 
         it do
-          expect(subject).to contain_firewallchain('OUTPUT:filter:IPv4').with(
-            ensure: 'present',
+          expect(subject).to contain_firewallchain("OUTPUT:filter:IPv4").with(
+            ensure: "present",
             purge: false,
-            ignore: ['-j cali-OUTPUT',
-                     '-j KUBE-FIREWALL',
-                     '-j KUBE-SERVICES'],
+            ignore: ["-j cali-OUTPUT",
+              "-j KUBE-FIREWALL",
+              "-j KUBE-SERVICES"]
           )
         end
 
         it do
-          expect(subject).to contain_firewallchain('FORWARD:filter:IPv4').with(
-            ensure: 'present',
+          expect(subject).to contain_firewallchain("FORWARD:filter:IPv4").with(
+            ensure: "present",
             purge: false,
-            ignore: ['-j cali-FORWARD',
-                     '-j KUBE-FORWARD',
-                     '-j KUBE-SERVICES'],
+            ignore: ["-j cali-FORWARD",
+              "-j KUBE-FORWARD",
+              "-j KUBE-SERVICES"]
           )
         end
 
         case role
-        when 'etcd'
+        when "etcd"
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
-              .with_tag('first_cluster_pki_generation')
-              .with_target('/var/local/generate_pki.sh')
-              .with_order('02')
-              .with_content("ETCD_NODES=(\"${ETCD_NODES[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]["hostname"]}")
+              .with_tag("first_cluster_pki_generation")
+              .with_target("/var/local/generate_pki.sh")
+              .with_order("02")
+              .with_content("ETCD_NODES=(\"${ETCD_NODES[@]}\" \"#{facts[:networking]["hostname"]}/#{facts[:networking]["ip"]}\")\n")
           end
-        when 'controller'
+        when "controller"
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
-              .with_tag('first_cluster_pki_generation')
-              .with_target('/var/local/generate_pki.sh')
-              .with_order('02')
-              .with_content("KUBE_CONTROLLERS=(\"${KUBE_CONTROLLERS[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]["hostname"]}")
+              .with_tag("first_cluster_pki_generation")
+              .with_target("/var/local/generate_pki.sh")
+              .with_order("02")
+              .with_content("KUBE_CONTROLLERS=(\"${KUBE_CONTROLLERS[@]}\" \"#{facts[:networking]["hostname"]}/#{facts[:networking]["ip"]}\")\n")
           end
-        when 'worker'
+        when "worker"
           it do
-            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]['hostname']}")
-              .with_tag('first_cluster_pki_generation')
-              .with_target('/var/local/generate_pki.sh')
-              .with_order('02')
-              .with_content("KUBE_WORKERS=(\"${KUBE_WORKERS[@]}\" \"#{facts[:networking]['hostname']}/#{facts[:networking]['ip']}\")\n")
+            expect(exported_resources).to contain_concat_fragment("cluster pki for #{facts[:networking]["hostname"]}")
+              .with_tag("first_cluster_pki_generation")
+              .with_target("/var/local/generate_pki.sh")
+              .with_order("02")
+              .with_content("KUBE_WORKERS=(\"${KUBE_WORKERS[@]}\" \"#{facts[:networking]["hostname"]}/#{facts[:networking]["ip"]}\")\n")
           end
 
-          it { is_expected.to contain_package('lvm2') }
+          it { is_expected.to contain_package("lvm2") }
         end
       end
     end

--- a/spec/classes/role/load_balancer_spec.rb
+++ b/spec/classes/role/load_balancer_spec.rb
@@ -3,41 +3,41 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require_relative '../../support/contexts/with_mocked_nodes'
+require "spec_helper"
+require_relative "../../support/contexts/with_mocked_nodes"
 
-describe 'nebula::role::load_balancer' do
+describe "nebula::role::load_balancer" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:my_ip) { Faker::Internet.ip_v4_address }
 
       let(:facts) do
         os_facts.merge(
-          datacenter: 'somedc',
+          datacenter: "somedc",
           networking: {
             ip: my_ip,
-            primary: 'eth0',
+            primary: "eth0"
           },
-          hostname: 'thisnode',
+          hostname: "thisnode"
         )
       end
 
-      let(:default_file) { '/etc/default/haproxy' }
-      let(:haproxy_conf) { '/etc/haproxy/haproxy.cfg' }
-      let(:keepalived_conf) { '/etc/keepalived/keepalived.conf' }
-      let(:service) { 'keepalived' }
+      let(:default_file) { "/etc/default/haproxy" }
+      let(:haproxy_conf) { "/etc/haproxy/haproxy.cfg" }
+      let(:keepalived_conf) { "/etc/keepalived/keepalived.conf" }
+      let(:service) { "keepalived" }
 
-      let(:thisnode) { { 'ip' => facts[:networking][:ip], 'hostname' => facts[:hostname] } }
-      let(:haproxy_2) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'haproxy2' } }
-      let(:scotch) { { 'ip' => '111.111.111.123', 'hostname' => 'scotch' } }
-      let(:soda)   { { 'ip' => '222.222.222.234', 'hostname' => 'soda' } }
-      let(:third_server) { { 'ip' => '333.333.333.345', 'hostname' => 'third_server' } }
+      let(:thisnode) { {"ip" => facts[:networking][:ip], "hostname" => facts[:hostname]} }
+      let(:haproxy_2) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "haproxy2"} }
+      let(:scotch) { {"ip" => "111.111.111.123", "hostname" => "scotch"} }
+      let(:soda) { {"ip" => "222.222.222.234", "hostname" => "soda"} }
+      let(:third_server) { {"ip" => "333.333.333.345", "hostname" => "third_server"} }
 
-      include_context 'with mocked puppetdb functions', 'somedc', %w[thisnode haproxy_2 scotch soda third_server], 'nebula::profile::haproxy' => %w[thisnode haproxy2]
+      include_context "with mocked puppetdb functions", "somedc", %w[thisnode haproxy_2 scotch soda third_server], "nebula::profile::haproxy" => %w[thisnode haproxy2]
 
       before(:each) do
-        stub('balanced_frontends') do |d|
-          allow_call(d).and_return('svc1' => %w[scotch soda], 'svc2' => %w[scotch third_server])
+        stub("balanced_frontends") do |d|
+          allow_call(d).and_return("svc1" => %w[scotch soda], "svc2" => %w[scotch third_server])
         end
       end
 

--- a/spec/classes/role/minimum_spec.rb
+++ b/spec/classes/role/minimum_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::minimum' do
+describe "nebula::role::minimum" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -13,11 +13,11 @@ describe 'nebula::role::minimum' do
       it { is_expected.to compile }
 
       case os
-      when 'debian-8-x86_64'
-        it { is_expected.not_to contain_class('nebula::profile::networking::firewall') }
+      when "debian-8-x86_64"
+        it { is_expected.not_to contain_class("nebula::profile::networking::firewall") }
         it { is_expected.to have_firewall_resource_count(0) }
-      when 'debian-9-x86_64'
-        it { is_expected.to contain_class('nebula::profile::networking::firewall') }
+      when "debian-9-x86_64"
+        it { is_expected.to contain_class("nebula::profile::networking::firewall") }
       end
     end
   end

--- a/spec/classes/role/umich_spec.rb
+++ b/spec/classes/role/umich_spec.rb
@@ -3,18 +3,18 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::umich' do
+describe "nebula::role::umich" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
 
-      it { is_expected.not_to contain_profile('nebula::profile::krb5') }
-      it { is_expected.not_to contain_profile('nebula::profile::afs') }
-      it { is_expected.not_to contain_profile('nebula::profile::users') }
+      it { is_expected.not_to contain_profile("nebula::profile::krb5") }
+      it { is_expected.not_to contain_profile("nebula::profile::afs") }
+      it { is_expected.not_to contain_profile("nebula::profile::users") }
     end
   end
 end

--- a/spec/classes/role/vmhost_spec.rb
+++ b/spec/classes/role/vmhost_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::role::vmhost' do
+describe "nebula::role::vmhost" do
   def contain_sysctl
-    contain_class('nebula::profile::networking::sysctl')
+    contain_class("nebula::profile::networking::sysctl")
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      unless os == 'debian-8-x86_64'
+      unless os == "debian-8-x86_64"
         it { is_expected.to contain_sysctl.with_bridge(true) }
       end
 
-      it { is_expected.not_to contain_class('nebula::profile::krb5') }
-      it { is_expected.not_to contain_class('nebula::profile::afs') }
-      it { is_expected.not_to contain_class('nebula::profile::users') }
+      it { is_expected.not_to contain_class("nebula::profile::krb5") }
+      it { is_expected.not_to contain_class("nebula::profile::afs") }
+      it { is_expected.not_to contain_class("nebula::profile::users") }
     end
   end
 end

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -3,219 +3,219 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-require_relative '../../support/contexts/with_mocked_nodes'
+require_relative "../../support/contexts/with_mocked_nodes"
 
-describe 'nebula::role::webhost::www_lib_vm' do
+describe "nebula::role::webhost::www_lib_vm" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(hostname: 'thisnode', datacenter: 'somedc') }
-      let(:rolenode) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'rolenode' } }
-      let(:hiera_config) { 'spec/fixtures/hiera/www_lib_config.yaml' }
+      let(:facts) { os_facts.merge(hostname: "thisnode", datacenter: "somedc") }
+      let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }
+      let(:hiera_config) { "spec/fixtures/hiera/www_lib_config.yaml" }
 
-      include_context 'with mocked puppetdb functions', 'somedc', %w[rolenode], 'nebula::profile::haproxy' => %w[]
+      include_context "with mocked puppetdb functions", "somedc", %w[rolenode], "nebula::profile::haproxy" => %w[]
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_class('Nebula::Profile::Www_lib::Register_for_load_balancing') }
-      it { is_expected.to contain_class('php') }
+      it { is_expected.to contain_class("Nebula::Profile::Www_lib::Register_for_load_balancing") }
+      it { is_expected.to contain_class("php") }
 
-      it { is_expected.to contain_mount('/www') }
+      it { is_expected.to contain_mount("/www") }
 
-      it { is_expected.to contain_apache__vhost('000-default').with(port: 80, ssl: false) }
+      it { is_expected.to contain_apache__vhost("000-default").with(port: 80, ssl: false) }
 
-      it { is_expected.to contain_apache__vhost('000-default-ssl').with(ssl: true, ssl_cert: '/etc/ssl/certs/www.lib.umich.edu.crt') }
+      it { is_expected.to contain_apache__vhost("000-default-ssl").with(ssl: true, ssl_cert: "/etc/ssl/certs/www.lib.umich.edu.crt") }
 
-      it 'configures shibboleth' do
-        expect(subject).to contain_class('nebula::profile::shibboleth')
+      it "configures shibboleth" do
+        expect(subject).to contain_class("nebula::profile::shibboleth")
           .with(startup_timeout: 900)
-          .with(watchdog_minutes: '*/30')
+          .with(watchdog_minutes: "*/30")
       end
 
       it do
-        expect(subject).to contain_file('/etc/apache2/mods-available/shib2.conf')
+        expect(subject).to contain_file("/etc/apache2/mods-available/shib2.conf")
           .with_content(%r{SetHandler shib-handler})
       end
 
       it do
-        expect(subject).to contain_file('/etc/apache2/mods-enabled/shib2.conf')
-          .with_ensure('link')
-          .with_target('/etc/apache2/mods-available/shib2.conf')
+        expect(subject).to contain_file("/etc/apache2/mods-enabled/shib2.conf")
+          .with_ensure("link")
+          .with_target("/etc/apache2/mods-available/shib2.conf")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('www.lib-ssl')
-          .with(servername: 'www.lib.umich.edu',
-                port: 443,
-                ssl: true,
-                ssl_cert: '/etc/ssl/certs/www.lib.umich.edu.crt')
-          .with_error_log_file('error.log')
+        expect(subject).to contain_apache__vhost("www.lib-ssl")
+          .with(servername: "www.lib.umich.edu",
+            port: 443,
+            ssl: true,
+            ssl_cert: "/etc/ssl/certs/www.lib.umich.edu.crt")
+          .with_error_log_file("error.log")
           .with_custom_fragment(%r{CookieName skynet})
       end
 
-      it 'www.lib vhost has clickstream and access log' do
-        expect(catalogue.resource('apache::vhost', 'www.lib-ssl')[:access_logs])
+      it "www.lib vhost has clickstream and access log" do
+        expect(catalogue.resource("apache::vhost", "www.lib-ssl")[:access_logs])
           .to contain_exactly(
-            { 'file' => 'access.log', 'format' => 'combined' },
-            'file' => 'clickstream.log', 'format' => 'usertrack',
+            {"file" => "access.log", "format" => "combined"},
+            "file" => "clickstream.log", "format" => "usertrack"
           )
       end
 
       it do
-        expect(subject).to contain_concat_fragment('www.lib-ssl-ssl')
+        expect(subject).to contain_concat_fragment("www.lib-ssl-ssl")
           .with_content(%r{^\s*SSLCertificateFile\s*"/etc/ssl/certs/www.lib.umich.edu.crt"$})
       end
 
       it do
-        expect(subject).to contain_concat_file('/usr/local/lib/cgi-bin/monitor/monitor_config.yaml')
+        expect(subject).to contain_concat_file("/usr/local/lib/cgi-bin/monitor/monitor_config.yaml")
       end
 
       # from hiera
-      it { is_expected.to contain_host('mysql-web').with_ip('10.0.0.123') }
+      it { is_expected.to contain_host("mysql-web").with_ip("10.0.0.123") }
 
       it do
-        expect(subject).to contain_apache__vhost('000-default-ssl')
-          .with_aliases([{ 'scriptalias' => '/monitor',
-                           'path' => '/usr/local/lib/cgi-bin/monitor' }])
+        expect(subject).to contain_apache__vhost("000-default-ssl")
+          .with_aliases([{"scriptalias" => "/monitor",
+                          "path" => "/usr/local/lib/cgi-bin/monitor"}])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('datamart-https')
-          .with_servername('datamart.lib.umich.edu')
-          .with_error_log_file('datamart.lib/error.log')
+        expect(subject).to contain_apache__vhost("datamart-https")
+          .with_servername("datamart.lib.umich.edu")
+          .with_error_log_file("datamart.lib/error.log")
       end
 
-      it 'datamart vhost has access log datamart.lib/access.log only' do
-        expect(catalogue.resource('apache::vhost', 'datamart-https')[:access_logs])
-          .to contain_exactly('file' => 'datamart.lib/access.log', 'format' => 'combined')
+      it "datamart vhost has access log datamart.lib/access.log only" do
+        expect(catalogue.resource("apache::vhost", "datamart-https")[:access_logs])
+          .to contain_exactly("file" => "datamart.lib/access.log", "format" => "combined")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('mediaindustriesjournal.org-redirect-http')
-          .with_redirect_dest('http://www.mediaindustriesjournal.org/')
+        expect(subject).to contain_apache__vhost("mediaindustriesjournal.org-redirect-http")
+          .with_redirect_dest("http://www.mediaindustriesjournal.org/")
           .with_serveraliases([])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('michiganelt.org-redirect-https')
-          .with_redirect_dest('https://www.press.umich.edu/elt')
-          .with_serveraliases(['www.michiganelt.org'])
+        expect(subject).to contain_apache__vhost("michiganelt.org-redirect-https")
+          .with_redirect_dest("https://www.press.umich.edu/elt")
+          .with_serveraliases(["www.michiganelt.org"])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('lib.umich.edu-redirect-https')
-          .with_redirect_dest('https://www.lib.umich.edu/')
+        expect(subject).to contain_apache__vhost("lib.umich.edu-redirect-https")
+          .with_redirect_dest("https://www.lib.umich.edu/")
           .with_serveraliases(%w[lib
-                                 library.umich.edu
-                                 www.library.umich.edu])
+            library.umich.edu
+            www.library.umich.edu])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('theater-historiography.org-redirect-https')
-          .with_ssl_cert('/etc/ssl/certs/theater-historiography.org.crt')
-          .with_redirect_dest('https://www.theater-historiography.org/')
+        expect(subject).to contain_apache__vhost("theater-historiography.org-redirect-https")
+          .with_ssl_cert("/etc/ssl/certs/theater-historiography.org.crt")
+          .with_redirect_dest("https://www.theater-historiography.org/")
           .with_serveraliases(%w[www.theater-historiography.com
-                                 theater-historiography.com
-                                 www.theatre-historiography.com
-                                 theatre-historiography.com
-                                 www.theatre-historiography.org
-                                 theatre-historiography.org])
+            theater-historiography.com
+            www.theatre-historiography.com
+            theatre-historiography.com
+            www.theatre-historiography.org
+            theatre-historiography.org])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('deepblue-https')
-          .with_ssl_cert('/etc/ssl/certs/deepblue.lib.umich.edu.crt')
-          .with_servername('deepblue.lib.umich.edu')
+        expect(subject).to contain_apache__vhost("deepblue-https")
+          .with_ssl_cert("/etc/ssl/certs/deepblue.lib.umich.edu.crt")
+          .with_servername("deepblue.lib.umich.edu")
           .with_ssl_proxyengine(true)
       end
 
       it do
-        expect(subject).to contain_apache__vhost('openmich-https')
-          .with_ssl_cert('/etc/ssl/certs/open.umich.edu.crt')
-          .with_servername('open.umich.edu')
+        expect(subject).to contain_apache__vhost("openmich-https")
+          .with_ssl_cert("/etc/ssl/certs/open.umich.edu.crt")
+          .with_servername("open.umich.edu")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('apps.staff.lib http redirect')
-          .with_servername('apps.staff.lib.umich.edu')
+        expect(subject).to contain_apache__vhost("apps.staff.lib http redirect")
+          .with_servername("apps.staff.lib.umich.edu")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('apps.staff.lib ssl')
-          .with_servername('apps.staff.lib.umich.edu')
-          .with_ssl_cert('/etc/ssl/certs/apps.staff.lib.umich.edu.crt')
+        expect(subject).to contain_apache__vhost("apps.staff.lib ssl")
+          .with_servername("apps.staff.lib.umich.edu")
+          .with_ssl_cert("/etc/ssl/certs/apps.staff.lib.umich.edu.crt")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('www.publishing-http')
+        expect(subject).to contain_apache__vhost("www.publishing-http")
       end
 
       it do
         # SSL offloading
-        expect(subject).to contain_apache__vhost('www.publishing-https')
-          .with_servername('https://www.publishing.umich.edu')
+        expect(subject).to contain_apache__vhost("www.publishing-https")
+          .with_servername("https://www.publishing.umich.edu")
           .with_ssl(false)
           .with_port(443)
       end
 
       it do
         # Name-based multi-site Wordpress
-        expect(subject).to contain_apache__vhost('publishing-partners-http')
-          .with_servername('blog.press.umich.edu')
+        expect(subject).to contain_apache__vhost("publishing-partners-http")
+          .with_servername("blog.press.umich.edu")
           .with_serveraliases([
-                                'www.theater-historiography.org',
-                                'www.digitalculture.org',
-                                'www.digitalrhetoriccollaborative.org',
-                              ])
+            "www.theater-historiography.org",
+            "www.digitalculture.org",
+            "www.digitalrhetoriccollaborative.org"
+          ])
       end
 
       it do
         # SSL offloading
         # Name-based multi-site Wordpress
-        expect(subject).to contain_apache__vhost('publishing-partners-https')
-          .with_servername('https://blog.press.umich.edu')
+        expect(subject).to contain_apache__vhost("publishing-partners-https")
+          .with_servername("https://blog.press.umich.edu")
           .with_ssl(false)
           .with_port(443)
           .with_serveraliases([
-                                'www.theater-historiography.org',
-                                'www.digitalculture.org',
-                                'www.digitalrhetoriccollaborative.org',
-                              ])
+            "www.theater-historiography.org",
+            "www.digitalculture.org",
+            "www.digitalrhetoriccollaborative.org"
+          ])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('press-http')
-          .with_servername('www.press.umich.edu')
+        expect(subject).to contain_apache__vhost("press-http")
+          .with_servername("www.press.umich.edu")
       end
 
       it do
-        expect(subject).to contain_apache__vhost('press-https')
-          .with_servername('www.press.umich.edu')
-          .with_ssl_cert('/etc/ssl/certs/www.press.umich.edu.crt')
-          .with_setenv(['HTTPS on', 'PERL_USE_UNSAFE_INC 1'])
+        expect(subject).to contain_apache__vhost("press-https")
+          .with_servername("www.press.umich.edu")
+          .with_ssl_cert("/etc/ssl/certs/www.press.umich.edu.crt")
+          .with_setenv(["HTTPS on", "PERL_USE_UNSAFE_INC 1"])
       end
 
       it do
-        expect(subject).to contain_apache__vhost('apps.lib-https')
-          .with(servername: 'apps.lib.umich.edu',
-                port: 443,
-                ssl: true,
-                ssl_cert: '/etc/ssl/certs/apps.lib.umich.edu.crt')
-          .with_error_log_file('error.log')
+        expect(subject).to contain_apache__vhost("apps.lib-https")
+          .with(servername: "apps.lib.umich.edu",
+            port: 443,
+            ssl: true,
+            ssl_cert: "/etc/ssl/certs/apps.lib.umich.edu.crt")
+          .with_error_log_file("error.log")
           .with_custom_fragment(%r{CookieName skynet})
       end
 
       # Files
-      it { is_expected.to contain_file('sqlnet.ora') }
+      it { is_expected.to contain_file("sqlnet.ora") }
 
-      it 'adds custom params to file authz_umichlib.conf' do
-        expect(subject).to contain_file('authz_umichlib.conf')
+      it "adds custom params to file authz_umichlib.conf" do
+        expect(subject).to contain_file("authz_umichlib.conf")
           .with_content(%r{DBDParams\s*user=somebody})
       end
 
-      it 'adds custom params to file tnsnames.ora' do
-        expect(subject).to contain_file('tnsnames.ora')
+      it "adds custom params to file tnsnames.ora" do
+        expect(subject).to contain_file("tnsnames.ora")
           .with_content(%r{^ORCL.MYSERVER1_ALIAS1\s+=})
           .with_content(%r{^ORCL.MYSERVER1_ALIAS2\s+=})
           .with_content(%r{^ORCL.MYSERVER2_ALIAS1\s+=})
@@ -226,12 +226,12 @@ describe 'nebula::role::webhost::www_lib_vm' do
           .with_content(%r{PORT\s+=\s+1234})
       end
 
-      it { is_expected.to contain_cron('purge apache access logs 1/2') }
-      it { is_expected.to contain_cron('purge apache access logs 2/2') }
-      it { is_expected.to contain_cron('reload fcgi for Press site nightly') }
-      it { is_expected.to contain_cron('shibd existence check') }
-      it { is_expected.to contain_cron('staff.lib parse') }
-      it { is_expected.to contain_cron('Proactively scan the log files for suspcious activity') }
+      it { is_expected.to contain_cron("purge apache access logs 1/2") }
+      it { is_expected.to contain_cron("purge apache access logs 2/2") }
+      it { is_expected.to contain_cron("reload fcgi for Press site nightly") }
+      it { is_expected.to contain_cron("shibd existence check") }
+      it { is_expected.to contain_cron("staff.lib parse") }
+      it { is_expected.to contain_cron("Proactively scan the log files for suspcious activity") }
     end
   end
 end

--- a/spec/defines/authzd_user_spec.rb
+++ b/spec/defines/authzd_user_spec.rb
@@ -3,21 +3,21 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
-require 'faker'
+require "spec_helper"
+require "faker"
 
-describe 'nebula::authzd_user' do
+describe "nebula::authzd_user" do
   let(:title) { Faker::Internet.user_name }
-  let(:home) { '/some/where' }
+  let(:home) { "/some/where" }
   let(:params) do
     {
       gid: Faker::Internet.user_name,
       home: home,
       key: {
-        type: 'ssh-rsa',
-        data: 'CCCCCCCCCCCC',
-        comment: Faker::Internet.email,
-      },
+        type: "ssh-rsa",
+        data: "CCCCCCCCCCCC",
+        comment: Faker::Internet.email
+      }
     }
   end
 
@@ -25,20 +25,20 @@ describe 'nebula::authzd_user' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      describe 'users' do
+      describe "users" do
         it {
           expect(subject).to contain_user(title).with(name: title,
-                                                      gid: params[:gid],
-                                                      home: home,
-                                                      shell: '/bin/bash',
-                                                      managehome: true)
+            gid: params[:gid],
+            home: home,
+            shell: "/bin/bash",
+            managehome: true)
         }
 
-        it { is_expected.to contain_file("#{home}/.ssh").with(ensure: 'directory', mode: '0700') }
+        it { is_expected.to contain_file("#{home}/.ssh").with(ensure: "directory", mode: "0700") }
         it { is_expected.to contain_file("#{home}/.ssh").with(owner: title, group: params[:gid]) }
         it { is_expected.to contain_file("#{home}/.ssh/authorized_keys").with(owner: title, group: params[:gid]) }
 
-        it 'creates authorized_keys with the given key' do
+        it "creates authorized_keys with the given key" do
           expect(subject).to contain_file("#{home}/.ssh/authorized_keys")
             .with_content(%r{^#{params[:key][:type]} #{params[:key][:data]} #{params[:key][:comment]}$})
         end

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -3,63 +3,63 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::cert' do
+describe "nebula::cert" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'with title set to example.invalid' do
-        let(:title) { 'example.invalid' }
+      context "with title set to example.invalid" do
+        let(:title) { "example.invalid" }
 
-        it { is_expected.to contain_class('letsencrypt').with_email('contact@default.invalid') }
+        it { is_expected.to contain_class("letsencrypt").with_email("contact@default.invalid") }
 
         it do
-          expect(subject).to contain_letsencrypt__certonly('example.invalid')
-            .with_domains(['example.invalid'])
-            .with_plugin('standalone')
+          expect(subject).to contain_letsencrypt__certonly("example.invalid")
+            .with_domains(["example.invalid"])
+            .with_plugin("standalone")
             .with_manage_cron(true)
-            .with_cron_output('log')
+            .with_cron_output("log")
         end
 
         it do
-          expect(subject).to contain_firewall('200 HTTP')
-            .with_proto('tcp')
+          expect(subject).to contain_firewall("200 HTTP")
+            .with_proto("tcp")
             .with_dport(80)
-            .with_state('NEW')
-            .with_jump('accept')
+            .with_state("NEW")
+            .with_jump("accept")
         end
 
-        context 'with additional_domains set to sub.example.invalid' do
-          let(:params) { { additional_domains: ['sub.example.invalid'] } }
+        context "with additional_domains set to sub.example.invalid" do
+          let(:params) { {additional_domains: ["sub.example.invalid"]} }
 
           it do
-            expect(subject).to contain_letsencrypt__certonly('example.invalid')
+            expect(subject).to contain_letsencrypt__certonly("example.invalid")
               .with_domains(%w[example.invalid sub.example.invalid])
-              .with_plugin('standalone')
+              .with_plugin("standalone")
           end
         end
 
-        context 'with webroot set to /var/www' do
-          let(:params) { { webroot: '/var/www' } }
+        context "with webroot set to /var/www" do
+          let(:params) { {webroot: "/var/www"} }
 
           it do
-            expect(subject).to contain_letsencrypt__certonly('example.invalid')
-              .with_plugin('webroot')
-              .with_webroot_paths(['/var/www'])
+            expect(subject).to contain_letsencrypt__certonly("example.invalid")
+              .with_plugin("webroot")
+              .with_webroot_paths(["/var/www"])
               .with_manage_cron(true)
-              .with_cron_output('log')
+              .with_cron_output("log")
           end
         end
 
-        context 'with webroot set to [/var/www]' do
-          let(:params) { { webroot: ['/var/www'] } }
+        context "with webroot set to [/var/www]" do
+          let(:params) { {webroot: ["/var/www"]} }
 
           it do
-            expect(subject).to contain_letsencrypt__certonly('example.invalid')
-              .with_plugin('webroot')
-              .with_webroot_paths(['/var/www'])
+            expect(subject).to contain_letsencrypt__certonly("example.invalid")
+              .with_plugin("webroot")
+              .with_webroot_paths(["/var/www"])
           end
         end
       end

--- a/spec/defines/cifs_mount_spec.rb
+++ b/spec/defines/cifs_mount_spec.rb
@@ -3,57 +3,57 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::cifs_mount' do
+describe "nebula::cifs_mount" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/cifs_config.yaml' }
-      let(:title) { '/mnt/default_invalid' }
+      let(:hiera_config) { "spec/fixtures/hiera/cifs_config.yaml" }
+      let(:title) { "/mnt/default_invalid" }
       let(:params) do
         {
-          remote_target: '//default.invalid/path',
-          uid: 'root',
-          gid: 'root',
-          user: 'default_cifs_user',
+          remote_target: "//default.invalid/path",
+          uid: "root",
+          gid: "root",
+          user: "default_cifs_user"
         }
       end
 
       it { is_expected.to compile }
 
-      it { is_expected.to contain_package('cifs-utils').with_ensure(%r{(present|installed)}) }
-      it { is_expected.to contain_file(title).with_ensure('directory') }
-      it { is_expected.not_to contain_file('/etc/default/an_unused_user-credentials') }
+      it { is_expected.to contain_package("cifs-utils").with_ensure(%r{(present|installed)}) }
+      it { is_expected.to contain_file(title).with_ensure("directory") }
+      it { is_expected.not_to contain_file("/etc/default/an_unused_user-credentials") }
 
       it do
-        expect(subject).to contain_file('/etc/default/default_cifs_user-credentials')
-          .with_source('puppet:///cifs-credentials/default_cifs_user-credentials')
-          .with_mode('0400')
-          .with_owner('root')
-          .with_group('root')
+        expect(subject).to contain_file("/etc/default/default_cifs_user-credentials")
+          .with_source("puppet:///cifs-credentials/default_cifs_user-credentials")
+          .with_mode("0400")
+          .with_owner("root")
+          .with_group("root")
       end
 
       it do
         expect(subject).to contain_mount(title)
-          .with_ensure('mounted')
-          .with_device('//default.invalid/path')
-          .with_fstype('cifs')
-          .with_options('credentials=/etc/default/default_cifs_user-credentials,uid=root,gid=root,file_mode=0644,dir_mode=0755,vers=2.1')
-          .that_requires('Package[cifs-utils]')
+          .with_ensure("mounted")
+          .with_device("//default.invalid/path")
+          .with_fstype("cifs")
+          .with_options("credentials=/etc/default/default_cifs_user-credentials,uid=root,gid=root,file_mode=0644,dir_mode=0755,vers=2.1")
+          .that_requires("Package[cifs-utils]")
       end
 
       context 'when remote_target is set to "//cool_store.com/wow"' do
         let(:params) do
-          super().merge(remote_target: '//cool_store.com/wow')
+          super().merge(remote_target: "//cool_store.com/wow")
         end
 
-        it { is_expected.to contain_mount(title).with_device('//cool_store.com/wow') }
+        it { is_expected.to contain_mount(title).with_device("//cool_store.com/wow") }
       end
 
       context 'when uid is set to "my_app"' do
         let(:params) do
-          super().merge(uid: 'my_app')
+          super().merge(uid: "my_app")
         end
 
         it { is_expected.to contain_mount(title).with_options(%r{,uid=my_app,}) }
@@ -61,7 +61,7 @@ describe 'nebula::cifs_mount' do
 
       context 'when gid is set to "users"' do
         let(:params) do
-          super().merge(gid: 'users')
+          super().merge(gid: "users")
         end
 
         it { is_expected.to contain_mount(title).with_options(%r{,gid=users,}) }
@@ -69,22 +69,22 @@ describe 'nebula::cifs_mount' do
 
       context 'when user is set to "example_cifs_user"' do
         let(:params) do
-          super().merge(user: 'example_cifs_user')
+          super().merge(user: "example_cifs_user")
         end
 
-        it { is_expected.to contain_file('/etc/default/example_cifs_user-credentials') }
+        it { is_expected.to contain_file("/etc/default/example_cifs_user-credentials") }
         it { is_expected.to contain_mount(title).with_options(%r{^credentials=/etc/default/example_cifs_user-credentials,}) }
       end
 
-      context 'when user is set to a user not in nebula::cifs::credentials::users' do
+      context "when user is set to a user not in nebula::cifs::credentials::users" do
         let(:params) do
-          super().merge(user: 'undefined_cifs_user')
+          super().merge(user: "undefined_cifs_user")
         end
 
         it { is_expected.not_to compile }
       end
 
-      context 'when another cifs_mount is defined with the same user' do
+      context "when another cifs_mount is defined with the same user" do
         let(:pre_condition) do
           <<~RESOURCES
             nebula::cifs_mount { '/mnt/another_mount':

--- a/spec/defines/exposed_port_spec.rb
+++ b/spec/defines/exposed_port_spec.rb
@@ -3,107 +3,107 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::exposed_port' do
+describe "nebula::exposed_port" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/exposed_port_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/exposed_port_config.yaml" }
 
       context 'with title "100 SSH", port 22, and block "developers"' do
-        let(:title) { '100 SSH' }
-        let(:params) { { port: 22, block: 'developers' } }
+        let(:title) { "100 SSH" }
+        let(:params) { {port: 22, block: "developers"} }
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_firewall('100 SSH: Developers').with(
-            proto: 'tcp',
+          expect(subject).to contain_firewall("100 SSH: Developers").with(
+            proto: "tcp",
             dport: 22,
-            source: '10.0.0.0/16',
-            state: 'NEW',
-            jump: 'accept',
+            source: "10.0.0.0/16",
+            state: "NEW",
+            jump: "accept"
           )
         end
 
         context 'with protocol "udp"' do
           let(:params) do
-            super().merge(protocol: 'udp')
+            super().merge(protocol: "udp")
           end
 
-          it { is_expected.to contain_firewall('100 SSH: Developers').with_proto('udp') }
+          it { is_expected.to contain_firewall("100 SSH: Developers").with_proto("udp") }
         end
       end
 
       context 'with title "200 HTTP", port 80, and block "users"' do
-        let(:title) { '200 HTTP' }
-        let(:params) { { port: 80, block: 'users' } }
+        let(:title) { "200 HTTP" }
+        let(:params) { {port: 80, block: "users"} }
 
         it { is_expected.to compile }
 
         it do
-          expect(subject).to contain_firewall('200 HTTP: VPN users').with(
+          expect(subject).to contain_firewall("200 HTTP: VPN users").with(
             dport: 80,
-            source: '10.10.10.0/24',
+            source: "10.10.10.0/24"
           )
         end
 
         it do
-          expect(subject).to contain_firewall('200 HTTP: On-site users')
-            .with_source('10.10.11.0/24')
+          expect(subject).to contain_firewall("200 HTTP: On-site users")
+            .with_source("10.10.11.0/24")
         end
       end
 
-      context 'with duplicate blocks' do
-        let(:title) { '200 solr' }
-        let(:params) { { port: 8081, block: 'networks::one_and_two' } }
+      context "with duplicate blocks" do
+        let(:title) { "200 solr" }
+        let(:params) { {port: 8081, block: "networks::one_and_two"} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_firewall('200 solr: Net One').with(source: '10.0.1.0/24') }
-        it { is_expected.to contain_firewall('200 solr: Net Two').with(source: '10.0.2.0/24') }
-        it { is_expected.to contain_firewall('200 solr: Net Three').with(source: '10.0.3.0/24') }
+        it { is_expected.to contain_firewall("200 solr: Net One").with(source: "10.0.1.0/24") }
+        it { is_expected.to contain_firewall("200 solr: Net Two").with(source: "10.0.2.0/24") }
+        it { is_expected.to contain_firewall("200 solr: Net Three").with(source: "10.0.3.0/24") }
       end
 
-      context 'with contradictory blocks' do
-        let(:title) { '200 solr' }
-        let(:params) { { port: 8081, block: 'networks::one_and_three' } }
+      context "with contradictory blocks" do
+        let(:title) { "200 solr" }
+        let(:params) { {port: 8081, block: "networks::one_and_three"} }
 
         it { is_expected.not_to compile }
       end
 
       context 'with block "devs_and_users"' do
-        let(:title) { '250 HTTPS' }
-        let(:params) { { port: 443, block: 'devs_and_users' } }
+        let(:title) { "250 HTTPS" }
+        let(:params) { {port: 443, block: "devs_and_users"} }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_firewall('250 HTTPS: Developers') }
-        it { is_expected.to contain_firewall('250 HTTPS: VPN users') }
-        it { is_expected.to contain_firewall('250 HTTPS: On-site users') }
+        it { is_expected.to contain_firewall("250 HTTPS: Developers") }
+        it { is_expected.to contain_firewall("250 HTTPS: VPN users") }
+        it { is_expected.to contain_firewall("250 HTTPS: On-site users") }
       end
 
       context 'with title "400 Who knows" and block "developers"' do
-        let(:title) { '400 Who knows' }
-        let(:params) { { block: 'developers' } }
+        let(:title) { "400 Who knows" }
+        let(:params) { {block: "developers"} }
 
         context 'with port "30000:32967"' do
           let(:params) do
-            super().merge(port: '30000:32967')
+            super().merge(port: "30000:32967")
           end
 
           it do
-            expect(subject).to contain_firewall('400 Who knows: Developers')
-              .with_dport('30000:32967')
+            expect(subject).to contain_firewall("400 Who knows: Developers")
+              .with_dport("30000:32967")
           end
         end
 
-        context 'with port [80, 443]' do
+        context "with port [80, 443]" do
           let(:params) do
             super().merge(port: [80, 443])
           end
 
           it do
-            expect(subject).to contain_firewall('400 Who knows: Developers')
+            expect(subject).to contain_firewall("400 Who knows: Developers")
               .with_dport([80, 443])
           end
         end

--- a/spec/defines/file/ssh_keys_spec.rb
+++ b/spec/defines/file/ssh_keys_spec.rb
@@ -3,10 +3,10 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::file::ssh_keys' do
-  let(:title) { '/opt/keys' }
+describe "nebula::file::ssh_keys" do
+  let(:title) { "/opt/keys" }
   let(:params) do
     {}
   end
@@ -15,93 +15,93 @@ describe 'nebula::file::ssh_keys' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      context 'when called /opt/keys' do
+      context "when called /opt/keys" do
         it do
-          expect(subject).to contain_file('/opt/keys')
+          expect(subject).to contain_file("/opt/keys")
             .without_content(%r{^[^#]})
         end
 
-        it { is_expected.not_to contain_file('/opt') }
+        it { is_expected.not_to contain_file("/opt") }
       end
 
-      context 'when called /etc/keys' do
-        let(:title) { '/etc/keys' }
+      context "when called /etc/keys" do
+        let(:title) { "/etc/keys" }
 
-        it { is_expected.to contain_file('/etc/keys') }
+        it { is_expected.to contain_file("/etc/keys") }
       end
 
-      context 'when given a key' do
+      context "when given a key" do
         let(:params) do
           {
             keys: [
               {
-                type: 'ssh-rsa',
-                data: 'AAAAAAAAAAAA',
-                comment: 'name',
-              },
-            ],
+                type: "ssh-rsa",
+                data: "AAAAAAAAAAAA",
+                comment: "name"
+              }
+            ]
           }
         end
 
         it do
-          expect(subject).to contain_file('/opt/keys')
+          expect(subject).to contain_file("/opt/keys")
             .with_content(%r{^ssh-rsa AAAAAAAAAAAA name$})
         end
       end
 
-      context 'when given a key with a command' do
+      context "when given a key with a command" do
         let(:params) do
           {
             keys: [
               {
-                type: 'ssh-rsa',
-                data: 'AAAAAAAAAAAA',
-                comment: 'name',
-                command: '/usr/bin/whatever',
-              },
-            ],
+                type: "ssh-rsa",
+                data: "AAAAAAAAAAAA",
+                comment: "name",
+                command: "/usr/bin/whatever"
+              }
+            ]
           }
         end
 
         it do
-          expect(subject).to contain_file('/opt/keys')
+          expect(subject).to contain_file("/opt/keys")
             .with_content(%r{^command="/usr/bin/whatever" ssh-rsa AAAAAAAAAAAA name$})
         end
       end
 
-      context 'when called /etc/secret/keys and secret is true' do
-        let(:title) { '/etc/secret/keys' }
-        let(:params) { { secret: true } }
+      context "when called /etc/secret/keys and secret is true" do
+        let(:title) { "/etc/secret/keys" }
+        let(:params) { {secret: true} }
 
         it do
-          expect(subject).to contain_file('/etc/secret').with(
-            ensure: 'directory',
-            mode: '0700',
+          expect(subject).to contain_file("/etc/secret").with(
+            ensure: "directory",
+            mode: "0700"
           )
         end
 
         it do
-          expect(subject).to contain_file('/etc/secret/keys')
-            .that_requires('File[/etc/secret]')
+          expect(subject).to contain_file("/etc/secret/keys")
+            .that_requires("File[/etc/secret]")
         end
       end
 
-      context 'when given an owner and group' do
+      context "when given an owner and group" do
         let(:params) do
           {
-            owner: 'someuser',
-            group: 'somegroup',
+            owner: "someuser",
+            group: "somegroup",
             keys: [
               {
-                type: 'ssh-rsa',
-                data: 'AAAAAAAAAAAA',
-                comment: 'name',
-              },
-            ],
+                type: "ssh-rsa",
+                data: "AAAAAAAAAAAA",
+                comment: "name"
+              }
+            ]
           }
         end
 
-        it { is_expected.to contain_file('/opt/keys').with(owner: 'someuser', group: 'somegroup') }
+        it { is_expected.to contain_file("/opt/keys").with(owner: "someuser", group: "somegroup") }
       end
     end
   end

--- a/spec/defines/firewall_allow_spec.rb
+++ b/spec/defines/firewall_allow_spec.rb
@@ -3,37 +3,37 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::firewall_allow' do
-  let(:title) { 'my_firewall_allow' }
+describe "nebula::firewall_allow" do
+  let(:title) { "my_firewall_allow" }
   let(:params) { {} }
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:hiera_config) { 'spec/fixtures/hiera/firewall_allow_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/firewall_allow_config.yaml" }
 
       context 'when given "lowest" and 1234' do
-        let(:params) { { source: 'lowest', port: 1234 } }
+        let(:params) { {source: "lowest", port: 1234} }
 
         it do
           expect(subject).to contain_firewall("300 #{title} 0").with(
-            proto: 'tcp',
+            proto: "tcp",
             dport: 1234,
-            source: '10.0.0.0/32',
-            state: 'NEW',
-            jump: 'accept',
+            source: "10.0.0.0/32",
+            state: "NEW",
+            jump: "accept"
           )
         end
 
         context 'when title is set to "Cool Firewall"' do
-          let(:title) { 'Cool Firewall' }
+          let(:title) { "Cool Firewall" }
 
-          it { is_expected.to contain_firewall('300 Cool Firewall 0') }
+          it { is_expected.to contain_firewall("300 Cool Firewall 0") }
         end
 
-        context 'when order is set to 500' do
+        context "when order is set to 500" do
           let(:params) do
             super().merge(order: 500)
           end
@@ -43,50 +43,50 @@ describe 'nebula::firewall_allow' do
 
         context 'when proto is set to "udp"' do
           let(:params) do
-            super().merge(proto: 'udp')
+            super().merge(proto: "udp")
           end
 
-          it { is_expected.to contain_firewall("300 #{title} 0").with_proto('udp') }
+          it { is_expected.to contain_firewall("300 #{title} 0").with_proto("udp") }
         end
       end
 
       context 'when given "highest" and [123, 456, 789]' do
-        let(:params) { { source: 'highest', port: [123, 456, 789] } }
+        let(:params) { {source: "highest", port: [123, 456, 789]} }
 
         it do
           expect(subject).to contain_firewall("300 #{title} 0").with(
-            proto: 'tcp',
+            proto: "tcp",
             dport: [123, 456, 789],
-            source: '10.255.255.255/32',
-            state: 'NEW',
-            jump: 'accept',
+            source: "10.255.255.255/32",
+            state: "NEW",
+            jump: "accept"
           )
         end
       end
 
       context 'when given "low_three"' do
-        let(:params) { { source: 'low_three', port: 246 } }
+        let(:params) { {source: "low_three", port: 246} }
 
-        it { is_expected.to contain_firewall("300 #{title} 0").with_source('10.0.1.0/24') }
-        it { is_expected.to contain_firewall("300 #{title} 1").with_source('10.0.2.0/24') }
-        it { is_expected.to contain_firewall("300 #{title} 2").with_source('10.0.3.0/24') }
+        it { is_expected.to contain_firewall("300 #{title} 0").with_source("10.0.1.0/24") }
+        it { is_expected.to contain_firewall("300 #{title} 1").with_source("10.0.2.0/24") }
+        it { is_expected.to contain_firewall("300 #{title} 2").with_source("10.0.3.0/24") }
       end
 
       context 'when given "all"' do
-        let(:params) { { source: 'all', port: 369 } }
+        let(:params) { {source: "all", port: 369} }
 
-        it { is_expected.to contain_firewall("300 #{title} 0").with_source('10.0.0.0/32') }
-        it { is_expected.to contain_firewall("300 #{title} 1").with_source('10.255.255.255/32') }
-        it { is_expected.to contain_firewall("300 #{title} 2").with_source('10.0.1.0/24') }
-        it { is_expected.to contain_firewall("300 #{title} 3").with_source('10.0.2.0/24') }
-        it { is_expected.to contain_firewall("300 #{title} 4").with_source('10.0.3.0/24') }
+        it { is_expected.to contain_firewall("300 #{title} 0").with_source("10.0.0.0/32") }
+        it { is_expected.to contain_firewall("300 #{title} 1").with_source("10.255.255.255/32") }
+        it { is_expected.to contain_firewall("300 #{title} 2").with_source("10.0.1.0/24") }
+        it { is_expected.to contain_firewall("300 #{title} 3").with_source("10.0.2.0/24") }
+        it { is_expected.to contain_firewall("300 #{title} 4").with_source("10.0.3.0/24") }
       end
 
       context 'when given ["lowest", "highest"]' do
-        let(:params) { { source: %w[lowest highest], port: 321 } }
+        let(:params) { {source: %w[lowest highest], port: 321} }
 
-        it { is_expected.to contain_firewall("300 #{title} 0").with_source('10.0.0.0/32') }
-        it { is_expected.to contain_firewall("300 #{title} 1").with_source('10.255.255.255/32') }
+        it { is_expected.to contain_firewall("300 #{title} 0").with_source("10.0.0.0/32") }
+        it { is_expected.to contain_firewall("300 #{title} 1").with_source("10.255.255.255/32") }
       end
     end
   end

--- a/spec/defines/haproxy_binding_spec.rb
+++ b/spec/defines/haproxy_binding_spec.rb
@@ -3,16 +3,16 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::haproxy::binding' do
-  let(:title) { 'whatever' }
+describe "nebula::haproxy::binding" do
+  let(:title) { "whatever" }
   let(:params) do
     {
-      service: 'myservice',
-      datacenter: 'dc',
-      hostname: 'thishost',
-      ipaddress: '10.1.2.123',
+      service: "myservice",
+      datacenter: "dc",
+      hostname: "thishost",
+      ipaddress: "10.1.2.123"
     }
   end
 
@@ -31,53 +31,53 @@ describe 'nebula::haproxy::binding' do
       end
 
       it do
-        expect(subject).to contain_concat_fragment('myservice-dc-http thishost binding').with(
-          target: '/etc/haproxy/services.d/myservice-http.cfg',
-          order: '04',
+        expect(subject).to contain_concat_fragment("myservice-dc-http thishost binding").with(
+          target: "/etc/haproxy/services.d/myservice-http.cfg",
+          order: "04",
           content: "server thishost 10.1.2.123:80 track myservice-dc-https-back/thishost cookie s123\n",
-          tag: 'myservice-dc-http_binding',
+          tag: "myservice-dc-http_binding"
         )
       end
 
       it do
-        expect(subject).to contain_concat_fragment('myservice-dc-https thishost binding').with(
-          target: '/etc/haproxy/services.d/myservice-https.cfg',
-          order: '04',
+        expect(subject).to contain_concat_fragment("myservice-dc-https thishost binding").with(
+          target: "/etc/haproxy/services.d/myservice-https.cfg",
+          order: "04",
           content: "server thishost 10.1.2.123:443 check cookie s123\n",
-          tag: 'myservice-dc-https_binding',
+          tag: "myservice-dc-https_binding"
         )
       end
 
       it do
-        expect(subject).to contain_concat_fragment('myservice-dc-http thishost exempt binding').with(
-          target: '/etc/haproxy/services.d/myservice-http.cfg',
-          order: '06',
+        expect(subject).to contain_concat_fragment("myservice-dc-http thishost exempt binding").with(
+          target: "/etc/haproxy/services.d/myservice-http.cfg",
+          order: "06",
           content: "server thishost 10.1.2.123:80 track myservice-dc-https-back/thishost cookie s123\n",
-          tag: 'myservice-dc-http_exempt_binding',
+          tag: "myservice-dc-http_exempt_binding"
         )
       end
 
       it do
-        expect(subject).to contain_concat_fragment('myservice-dc-https thishost exempt binding').with(
-          target: '/etc/haproxy/services.d/myservice-https.cfg',
-          order: '06',
+        expect(subject).to contain_concat_fragment("myservice-dc-https thishost exempt binding").with(
+          target: "/etc/haproxy/services.d/myservice-https.cfg",
+          order: "06",
           content: "server thishost 10.1.2.123:443 track myservice-dc-https-back/thishost cookie s123\n",
-          tag: 'myservice-dc-https_exempt_binding',
+          tag: "myservice-dc-https_exempt_binding"
         )
       end
 
-      it { is_expected.to contain_nebula__haproxy__service('myservice') }
+      it { is_expected.to contain_nebula__haproxy__service("myservice") }
 
-      context 'without https offload' do
+      context "without https offload" do
         let(:params) { super().merge(https_offload: false) }
 
         it do
-          expect(subject).to contain_concat_fragment('myservice-dc-https thishost binding')
+          expect(subject).to contain_concat_fragment("myservice-dc-https thishost binding")
             .with_content("server thishost 10.1.2.123:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check cookie s123\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('myservice-dc-https thishost exempt binding')
+          expect(subject).to contain_concat_fragment("myservice-dc-https thishost exempt binding")
             .with_content("server thishost 10.1.2.123:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt track myservice-dc-https-back/thishost cookie s123\n")
         end
       end

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -3,24 +3,24 @@
 # Copyright (c) 2018, 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::haproxy::service' do
-  let(:title) { 'svc1' }
+describe "nebula::haproxy::service" do
+  let(:title) { "svc1" }
   let(:params) { {} }
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:params) do
-        super().merge(floating_ip: '1.2.3.4')
+        super().merge(floating_ip: "1.2.3.4")
       end
 
       let(:facts) do
         os_facts.merge(
-          datacenter: 'dc1',
+          datacenter: "dc1",
           networking: {
-            ip: '40.41.42.43',
-          },
+            ip: "40.41.42.43"
+          }
         )
       end
 
@@ -42,31 +42,31 @@ describe 'nebula::haproxy::service' do
         RESOURCES
       end
 
-      describe 'https service config' do
+      describe "https service config" do
         let(:service) { title }
-        let(:service_config) { '/etc/haproxy/services.d/svc1-https.cfg' }
+        let(:service_config) { "/etc/haproxy/services.d/svc1-https.cfg" }
 
         it do
           expect(subject).to contain_concat(service_config).with(
-            ensure: 'present',
-            notify: 'Service[haproxy]',
-            mode: '0644',
+            ensure: "present",
+            notify: "Service[haproxy]",
+            mode: "0644"
           )
         end
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-https backend').with(
+          expect(subject).to contain_concat_fragment("svc1-dc1-https backend").with(
             target: service_config,
-            content: "backend svc1-dc1-https-back\n",
+            content: "backend svc1-dc1-https-back\n"
           )
         end
 
-        it { is_expected.to contain_concat_fragment('svc1-dc1-https check').with_target(service_config) }
+        it { is_expected.to contain_concat_fragment("svc1-dc1-https check").with_target(service_config) }
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-https frontend').with(
+          expect(subject).to contain_concat_fragment("svc1-dc1-https frontend").with(
             target: service_config,
-            content: <<~HAPROXY,
+            content: <<~HAPROXY
               frontend svc1-dc1-https-front
               bind 1.2.3.4:443 ssl crt /etc/ssl/private/svc1
               stats uri /haproxy?stats
@@ -87,55 +87,55 @@ describe 'nebula::haproxy::service' do
           )
         end
 
-        describe 'with frontend maxconn' do
+        describe "with frontend maxconn" do
           let(:params) do
             super().merge(max_frontend_sessions: 999)
           end
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-https frontend').with(
+            expect(subject).to contain_concat_fragment("svc1-dc1-https frontend").with(
               target: service_config,
-              content: %r{^maxconn 999$},
+              content: %r{^maxconn 999$}
             )
           end
         end
 
         it do
-          expect(subject).not_to contain_file('/etc/haproxy/errors/svc1503.http')
+          expect(subject).not_to contain_file("/etc/haproxy/errors/svc1503.http")
         end
 
-        describe 'with custom 503' do
+        describe "with custom 503" do
           let(:params) do
             super().merge(custom_503: true)
           end
 
           it do
-            expect(subject).to contain_file('/etc/haproxy/errors/svc1503.http')
-              .with_source('https://default.http_files.invalid/errorfiles/svc1503.http')
+            expect(subject).to contain_file("/etc/haproxy/errors/svc1503.http")
+              .with_source("https://default.http_files.invalid/errorfiles/svc1503.http")
           end
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-https custom 503').with(
+            expect(subject).to contain_concat_fragment("svc1-dc1-https custom 503").with(
               target: service_config,
-              content: <<~HAPROXY,
+              content: <<~HAPROXY
                 errorfile 503 /etc/haproxy/errors/svc1503.http
               HAPROXY
             )
           end
         end
 
-        describe 'with throttling parameters' do
+        describe "with throttling parameters" do
           let(:params) do
             super().merge(max_requests_per_sec: 2,
-                          max_requests_burst: 400,
-                          floating_ip: '1.2.3.4',
-                          cert_source: '')
+              max_requests_burst: 400,
+              floating_ip: "1.2.3.4",
+              cert_source: "")
           end
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-https throttling').with(
+            expect(subject).to contain_concat_fragment("svc1-dc1-https throttling").with(
               target: service_config,
-              content: <<~HAPROXY,
+              content: <<~HAPROXY
                 stick-table type ip size 200k expire 200s store http_req_rate(200s),bytes_out_rate(200s)
                 tcp-request content track-sc2 src
                 http-request set-var(req.http_rate) src_http_req_rate(svc1-dc1-http-back)
@@ -148,33 +148,33 @@ describe 'nebula::haproxy::service' do
           end
 
           it do
-            expect(subject).to contain_file('/etc/haproxy/errors/svc1429.http')
-              .with_source('https://default.http_files.invalid/errorfiles/svc1429.http')
+            expect(subject).to contain_file("/etc/haproxy/errors/svc1429.http")
+              .with_source("https://default.http_files.invalid/errorfiles/svc1429.http")
           end
 
-          context 'with no whitelists' do
-            it { is_expected.not_to contain_file('/etc/haproxy/svc1_whitelist_src.txt') }
-            it { is_expected.not_to contain_file('/etc/haproxy/svc1_whitelist_path_beg.txt') }
-            it { is_expected.not_to contain_file('/etc/haproxy/svc1_whitelist_path_end.txt') }
+          context "with no whitelists" do
+            it { is_expected.not_to contain_file("/etc/haproxy/svc1_whitelist_src.txt") }
+            it { is_expected.not_to contain_file("/etc/haproxy/svc1_whitelist_path_beg.txt") }
+            it { is_expected.not_to contain_file("/etc/haproxy/svc1_whitelist_path_end.txt") }
 
-            it 'does not reference any whitelists' do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https frontend').with_content(%r{(?!whitelist)})
+            it "does not reference any whitelists" do
+              expect(subject).to contain_concat_fragment("svc1-dc1-https frontend").with_content(%r{(?!whitelist)})
             end
 
-            it 'does not reference the exemption backend' do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https frontend').with_content(%r{(?!svc1-dc1-https?-back-exempt)})
+            it "does not reference the exemption backend" do
+              expect(subject).to contain_concat_fragment("svc1-dc1-https frontend").with_content(%r{(?!svc1-dc1-https?-back-exempt)})
             end
           end
 
-          context 'with IP exemptions' do
+          context "with IP exemptions" do
             let(:params) do
-              super().merge(whitelists: { 'src' => ['10.0.0.1', '10.2.32.0/24'] })
+              super().merge(whitelists: {"src" => ["10.0.0.1", "10.2.32.0/24"]})
             end
 
-            it { is_expected.to contain_file('/etc/haproxy/svc1_whitelist_src.txt').with_content("10.0.0.1\n10.2.32.0/24\n") }
+            it { is_expected.to contain_file("/etc/haproxy/svc1_whitelist_src.txt").with_content("10.0.0.1\n10.2.32.0/24\n") }
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https frontend').with_content(%r{#{<<~HAPROXY}}m)
+              expect(subject).to contain_concat_fragment("svc1-dc1-https frontend").with_content(%r{#{<<~HAPROXY}}m)
                 acl whitelist_src src -n -f /etc/haproxy/svc1_whitelist_src.txt
                 use_backend svc1-dc1-https-back-exempt if whitelist_src
                 default_backend svc1-dc1-https-back
@@ -182,117 +182,117 @@ describe 'nebula::haproxy::service' do
             end
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https back-exempt')
+              expect(subject).to contain_concat_fragment("svc1-dc1-https back-exempt")
                 .with_content("backend svc1-dc1-https-back-exempt\n")
             end
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https scotch binding')
+              expect(subject).to contain_concat_fragment("svc1-dc1-https scotch binding")
                 .with_content("server scotch 111.111.111.123:443 check cookie s123\n")
             end
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https soda binding')
+              expect(subject).to contain_concat_fragment("svc1-dc1-https soda binding")
                 .with_content("server soda 222.222.222.234:443 check cookie s234\n")
             end
           end
 
-          context 'with path & suffix exemptions' do
+          context "with path & suffix exemptions" do
             let(:params) do
-              super().merge(whitelists: { 'path_beg' => ['/some/where', '/another/path'],
-                                          'path_end' => ['.abc', '.def'] })
+              super().merge(whitelists: {"path_beg" => ["/some/where", "/another/path"],
+                                         "path_end" => [".abc", ".def"]})
             end
 
-            ['acl whitelist_path_beg path_beg -n -f /etc/haproxy/svc1_whitelist_path_beg.txt',
-             'acl whitelist_path_end path_end -n -f /etc/haproxy/svc1_whitelist_path_end.txt',
-             'use_backend svc1-dc1-https-back-exempt if whitelist_path_beg OR whitelist_path_end']
+            ["acl whitelist_path_beg path_beg -n -f /etc/haproxy/svc1_whitelist_path_beg.txt",
+              "acl whitelist_path_end path_end -n -f /etc/haproxy/svc1_whitelist_path_end.txt",
+              "use_backend svc1-dc1-https-back-exempt if whitelist_path_beg OR whitelist_path_end"]
               .each do |fragment|
               it do
-                expect(subject).to contain_concat_fragment('svc1-dc1-https frontend')
+                expect(subject).to contain_concat_fragment("svc1-dc1-https frontend")
                   .with_content(%r{#{fragment}})
               end
             end
 
             it do
-              expect(subject).to contain_file('/etc/haproxy/svc1_whitelist_path_beg.txt').with_content(<<~PATHS)
+              expect(subject).to contain_file("/etc/haproxy/svc1_whitelist_path_beg.txt").with_content(<<~PATHS)
                 /some/where
                 /another/path
               PATHS
             end
 
             it do
-              expect(subject).to contain_file('/etc/haproxy/svc1_whitelist_path_end.txt').with_content(<<~PATHS)
+              expect(subject).to contain_file("/etc/haproxy/svc1_whitelist_path_end.txt").with_content(<<~PATHS)
                 .abc
                 .def
               PATHS
             end
           end
 
-          context 'with throttling condition' do
+          context "with throttling condition" do
             let(:params) do
-              super().merge(throttle_condition: 'path_beg /whatever')
+              super().merge(throttle_condition: "path_beg /whatever")
             end
 
-            ['acl throttle_condition path_beg /whatever',
-             'use_backend svc1-dc1-https-back-exempt if !throttle_condition'].each do |fragment|
+            ["acl throttle_condition path_beg /whatever",
+              "use_backend svc1-dc1-https-back-exempt if !throttle_condition"].each do |fragment|
               it do
-                expect(subject).to contain_concat_fragment('svc1-dc1-https frontend')
+                expect(subject).to contain_concat_fragment("svc1-dc1-https frontend")
                   .with_content(%r{#{fragment}})
               end
             end
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https scotch exempt binding')
+              expect(subject).to contain_concat_fragment("svc1-dc1-https scotch exempt binding")
                 .with_content("server scotch 111.111.111.123:443 track svc1-dc1-https-back/scotch cookie s123\n")
             end
 
             it do
-              expect(subject).to contain_concat_fragment('svc1-dc1-https soda exempt binding')
+              expect(subject).to contain_concat_fragment("svc1-dc1-https soda exempt binding")
                 .with_content("server soda 222.222.222.234:443 track svc1-dc1-https-back/soda cookie s234\n")
             end
           end
         end
 
-        context 'with dynamic weighting' do
+        context "with dynamic weighting" do
           let(:params) do
             super().merge(dynamic_weighting: true)
           end
 
           it do
-            expect(subject).to contain_cron('dynamic weighting for svc1')
-              .with_command('/usr/bin/ruby /usr/local/bin/set_weights.rb dc1 svc1 > /dev/null 2>&1')
-              .with_user('haproxyctl')
-              .with_environment(['HAPROXY_SMOOTHING_FACTOR=2'])
+            expect(subject).to contain_cron("dynamic weighting for svc1")
+              .with_command("/usr/bin/ruby /usr/local/bin/set_weights.rb dc1 svc1 > /dev/null 2>&1")
+              .with_user("haproxyctl")
+              .with_environment(["HAPROXY_SMOOTHING_FACTOR=2"])
           end
         end
 
-        it { is_expected.not_to contain_concat_fragment('svc1-dc1-https check_timeout') }
+        it { is_expected.not_to contain_concat_fragment("svc1-dc1-https check_timeout") }
 
-        context 'with check_timeout_milliseconds set to 15000' do
+        context "with check_timeout_milliseconds set to 15000" do
           let(:params) do
             super().merge(check_timeout_milliseconds: 15000)
           end
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-https check_timeout')
+            expect(subject).to contain_concat_fragment("svc1-dc1-https check_timeout")
               .with_target(service_config)
               .with_content("timeout connect 15000\n")
           end
         end
       end
 
-      describe 'http service config' do
+      describe "http service config" do
         let(:service) { title }
-        let(:service_config) { '/etc/haproxy/services.d/svc1-http.cfg' }
+        let(:service_config) { "/etc/haproxy/services.d/svc1-http.cfg" }
 
-        it { is_expected.to contain_concat(service_config).with(ensure: 'present') }
-        it { is_expected.to contain_concat(service_config).with(notify: 'Service[haproxy]') }
-        it { is_expected.to contain_concat(service_config).with(mode: '0644') }
+        it { is_expected.to contain_concat(service_config).with(ensure: "present") }
+        it { is_expected.to contain_concat(service_config).with(notify: "Service[haproxy]") }
+        it { is_expected.to contain_concat(service_config).with(mode: "0644") }
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+          expect(subject).to contain_concat_fragment("svc1-dc1-http frontend").with(
             target: service_config,
-            content: <<~HAPROXY,
+            content: <<~HAPROXY
               frontend svc1-dc1-http-front
               bind 1.2.3.4:80
               stats uri /haproxy?stats
@@ -312,98 +312,98 @@ describe 'nebula::haproxy::service' do
         end
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-http backend').with(
+          expect(subject).to contain_concat_fragment("svc1-dc1-http backend").with(
             target: service_config,
-            content: "backend svc1-dc1-http-back\n",
+            content: "backend svc1-dc1-http-back\n"
           )
         end
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-http scotch binding')
+          expect(subject).to contain_concat_fragment("svc1-dc1-http scotch binding")
             .with_content("server scotch 111.111.111.123:80 track svc1-dc1-https-back/scotch cookie s123\n")
         end
 
         it do
-          expect(subject).to contain_concat_fragment('svc1-dc1-http soda binding')
+          expect(subject).to contain_concat_fragment("svc1-dc1-http soda binding")
             .with_content("server soda 222.222.222.234:80 track svc1-dc1-https-back/soda cookie s234\n")
         end
       end
 
-      describe 'Cloudflare proxy ACL' do
-        let(:service_config) { '/etc/haproxy/services.d/svc1-http.cfg' }
+      describe "Cloudflare proxy ACL" do
+        let(:service_config) { "/etc/haproxy/services.d/svc1-http.cfg" }
 
-        context 'with the cloudflare_protected setting' do
+        context "with the cloudflare_protected setting" do
           let(:params) { super().merge(cloudflare_protected: true) }
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+            expect(subject).to contain_concat_fragment("svc1-dc1-http frontend").with(
               target: service_config,
-              content: %r{acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt},
+              content: %r{acl cloudflare_proxied src -n -f /etc/haproxy/cloudflare-ipv4.txt}
             )
           end
 
           it do
-            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+            expect(subject).to contain_concat_fragment("svc1-dc1-http frontend").with(
               target: service_config,
-              content: %r{http-request deny unless cloudflare_proxied},
+              content: %r{http-request deny unless cloudflare_proxied}
             )
           end
 
-          it 'forwards the CF-Connecting-IP as X-Client-IP' do
-            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+          it "forwards the CF-Connecting-IP as X-Client-IP" do
+            expect(subject).to contain_concat_fragment("svc1-dc1-http frontend").with(
               target: service_config,
-              content: %r{http-request set-header X-Client-IP %\[req.hdr\(CF-Connecting-IP\)\]},
+              content: %r{http-request set-header X-Client-IP %\[req.hdr\(CF-Connecting-IP\)\]}
             )
           end
         end
 
-        context 'without the cloudflare_protected setting' do
+        context "without the cloudflare_protected setting" do
           let(:params) { super().merge(cloudflare_protected: false) }
 
           it do
-            expect(subject).not_to contain_concat_fragment('svc1-dc1-http frontend').with(
+            expect(subject).not_to contain_concat_fragment("svc1-dc1-http frontend").with(
               target: service_config,
-              content: %r{http-request deny unless cloudflare_proxied},
+              content: %r{http-request deny unless cloudflare_proxied}
             )
           end
 
-          it 'sets the originating client IP as X-Client-IP' do
-            expect(subject).to contain_concat_fragment('svc1-dc1-http frontend').with(
+          it "sets the originating client IP as X-Client-IP" do
+            expect(subject).to contain_concat_fragment("svc1-dc1-http frontend").with(
               target: service_config,
-              content: %r{http-request set-header X-Client-IP %ci},
+              content: %r{http-request set-header X-Client-IP %ci}
             )
           end
         end
       end
 
-      describe 'ssl certs' do
-        let(:dest) { '/etc/ssl/private/svc1' }
+      describe "ssl certs" do
+        let(:dest) { "/etc/ssl/private/svc1" }
 
-        context 'with an empty source' do
+        context "with an empty source" do
           it { is_expected.not_to contain_file(dest) }
         end
 
-        context 'with a source' do
+        context "with a source" do
           let(:params) do
             {
-              floating_ip: '1.2.3.4',
-              cert_source: '/some/where',
+              floating_ip: "1.2.3.4",
+              cert_source: "/some/where"
             }
           end
 
           it do
             expect(subject).to contain_file(dest).with(
-              ensure: 'directory',
-              notify: 'Service[haproxy]',
-              require: 'Package[haproxy]',
-              mode: '0700',
-              owner: 'haproxy',
-              group: 'haproxy',
+              ensure: "directory",
+              notify: "Service[haproxy]",
+              require: "Package[haproxy]",
+              mode: "0700",
+              owner: "haproxy",
+              group: "haproxy",
               recurse: true,
               source: "puppet://#{params[:cert_source]}/svc1",
               path: dest,
-              links: 'follow',
-              purge: true,
+              links: "follow",
+              purge: true
             )
           end
         end

--- a/spec/defines/log_spec.rb
+++ b/spec/defines/log_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::log' do
-  let(:title) { 'solr' }
+describe "nebula::log" do
+  let(:title) { "solr" }
   let(:params) do
     {
-      files: ['/var/log/solr.log'],
+      files: ["/var/log/solr.log"]
     }
   end
 
@@ -16,34 +16,34 @@ describe 'nebula::log' do
 
       it { is_expected.to compile }
 
-      it 'writes solr log config to solr.alloy' do
-        expect(subject).to contain_file('/etc/alloy/solr.alloy')
+      it "writes solr log config to solr.alloy" do
+        expect(subject).to contain_file("/etc/alloy/solr.alloy")
           .with_content(%r|loki.source.file "solr_0" {\s+targets\s+= \[{"__path__" = "/var/log/solr.log"}\]\s+forward_to = \[loki.process.service__solr.receiver\]\n}|)
           .with_content(%r|loki.process "service__solr" {\s+stage.static_labels {values = {"service" = "solr"}}\s+forward_to = \[loki.process.hostname.receiver\]\n}|)
       end
 
-      context 'when creating apache log' do
-        let(:title) { 'apache' }
+      context "when creating apache log" do
+        let(:title) { "apache" }
         let(:params) do
           {
-            files: ['/var/log/apache.log', '/var/log/apache.err'],
+            files: ["/var/log/apache.log", "/var/log/apache.err"]
           }
         end
 
         it { is_expected.to compile }
 
         it "writes config for 'apache.log' source file to apache.alloy" do
-          expect(subject).to contain_file('/etc/alloy/apache.alloy')
+          expect(subject).to contain_file("/etc/alloy/apache.alloy")
             .with_content(%r|loki.source.file "apache_0" {\s+targets\s+= \[{"__path__" = "/var/log/apache.log"}\]\s+forward_to = \[loki.process.service__apache.receiver\]\n}|)
         end
 
         it "writes config for 'apache.err' source file to apache.alloy" do
-          expect(subject).to contain_file('/etc/alloy/apache.alloy')
+          expect(subject).to contain_file("/etc/alloy/apache.alloy")
             .with_content(%r|loki.source.file "apache_1" {\s+targets\s+= \[{"__path__" = "/var/log/apache.err"}\]\s+forward_to = \[loki.process.service__apache.receiver\]\n}|)
         end
 
-        it 'writes config for apache label to apache.alloy' do
-          expect(subject).to contain_file('/etc/alloy/apache.alloy')
+        it "writes config for apache label to apache.alloy" do
+          expect(subject).to contain_file("/etc/alloy/apache.alloy")
             .with_content(%r|loki.process "service__apache" {\s+stage.static_labels {values = {"service" = "apache"}}\s+forward_to = \[loki.process.hostname.receiver\]\n}|)
         end
       end

--- a/spec/defines/taghosts/tag_spec.rb
+++ b/spec/defines/taghosts/tag_spec.rb
@@ -3,34 +3,34 @@
 # Copyright (c) 2024 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::taghosts::tag' do
+describe "nebula::taghosts::tag" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      describe 'with title apache' do
-        let(:title) { 'apache' }
+      describe "with title apache" do
+        let(:title) { "apache" }
 
         it { is_expected.to compile }
 
         it do
           expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 100 apache")
-            .with_tag('taghosts')
-            .with_target('/var/lib/ae/active-servers')
-            .with_content(' apache')
+            .with_tag("taghosts")
+            .with_target("/var/lib/ae/active-servers")
+            .with_content(" apache")
         end
       end
 
-      describe 'with title python' do
-        let(:title) { 'python' }
+      describe "with title python" do
+        let(:title) { "python" }
 
         it { is_expected.to compile }
         it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 100 python") }
 
-        context 'with order set to 500' do
-          let(:params) { { order: '500' } }
+        context "with order set to 500" do
+          let(:params) { {order: "500"} }
 
           it { is_expected.to compile }
           it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 500 python") }

--- a/spec/defines/unison_client_spec.rb
+++ b/spec/defines/unison_client_spec.rb
@@ -3,38 +3,38 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::unison::client' do
+describe "nebula::unison::client" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:title) { 'myinstance' }
+      let(:title) { "myinstance" }
       let(:params) do
         {
-          server: 'somehost.default.invalid',
+          server: "somehost.default.invalid",
           port: 12_345,
-          root: '/myroot',
+          root: "/myroot",
           paths: %w[path1 path2],
-          filesystems: ['fs1'],
+          filesystems: ["fs1"]
         }
       end
 
       [
         'Description=myinstance somehost.default.invalid sync \(unison\)',
-        'Requires=fs1.mount',
-        'WatchdogSec=7200',
-        'Environment=HOME=/root',
-        'ExecStart=/usr/local/bin/unisonsync myinstance',
+        "Requires=fs1.mount",
+        "WatchdogSec=7200",
+        "Environment=HOME=/root",
+        "ExecStart=/usr/local/bin/unisonsync myinstance"
       ].each do |line|
         it do
-          expect(subject).to contain_file('/etc/systemd/system/unison-client-myinstance.service')
+          expect(subject).to contain_file("/etc/systemd/system/unison-client-myinstance.service")
             .with_content(%r{^#{line}$}m)
         end
       end
 
-      it 'generates a prf file for unison clients' do
-        expect(subject).to contain_file('/root/.unison/myinstance.prf')
+      it "generates a prf file for unison clients" do
+        expect(subject).to contain_file("/root/.unison/myinstance.prf")
           .with_content(%r{root\s+=\s+/myroot})
           .with_content(%r{root\s+=\s+socket://somehost.default.invalid:12345/myroot})
           .with_content(%r{path\s+=\s+path1})
@@ -51,34 +51,34 @@ describe 'nebula::unison::client' do
       end
 
       it do
-        expect(subject).to contain_service('unison-client-myinstance')
-          .with(enable: true, ensure: 'running')
-          .that_requires('Package[unison]')
+        expect(subject).to contain_service("unison-client-myinstance")
+          .with(enable: true, ensure: "running")
+          .that_requires("Package[unison]")
       end
 
-      it 'exports firewall resource' do
+      it "exports firewall resource" do
         expect(exported_resources).to contain_firewall("200 Unison: myinstance #{facts[:hostname]}").with(
-          proto: 'tcp',
+          proto: "tcp",
           dport: [12_345],
           source: facts[:ipaddress],
-          tag: 'unison-client-myinstance',
+          tag: "unison-client-myinstance"
         )
       end
 
-      context 'with optional params' do
+      context "with optional params" do
         let(:params) do
           {
-            server: 'somehost.default.invalid',
+            server: "somehost.default.invalid",
             port: 12_345,
-            root: '/myroot',
+            root: "/myroot",
             paths: %w[path1 path2],
-            filesystems: ['fs1'],
-            ignores: %w[ignore_path1 ignore_path2],
+            filesystems: ["fs1"],
+            ignores: %w[ignore_path1 ignore_path2]
           }
         end
 
-        it 'generates a prf file for unison clients' do
-          expect(subject).to contain_file('/root/.unison/myinstance.prf')
+        it "generates a prf file for unison clients" do
+          expect(subject).to contain_file("/root/.unison/myinstance.prf")
             .with_content(%r{root\s+=\s+/myroot})
             .with_content(%r{root\s+=\s+socket://somehost.default.invalid:12345/myroot})
             .with_content(%r{path\s+=\s+path1})

--- a/spec/defines/unison_server_spec.rb
+++ b/spec/defines/unison_server_spec.rb
@@ -3,50 +3,50 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::unison::server' do
+describe "nebula::unison::server" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:title) { 'myinstance' }
+      let(:title) { "myinstance" }
       let(:params) do
         {
-          root: '/myroot',
+          root: "/myroot",
           paths: %w[path1 path2],
-          filesystems: ['fs1'],
-          port: 12_345,
+          filesystems: ["fs1"],
+          port: 12_345
         }
       end
 
-      it { is_expected.to contain_package('unison') }
+      it { is_expected.to contain_package("unison") }
 
       [
-        'Description=myinstance Unison',
-        'Requires=fs1.mount',
-        'Environment=HOME=/root',
-        'ExecStart=/usr/bin/unison -socket 12345',
+        "Description=myinstance Unison",
+        "Requires=fs1.mount",
+        "Environment=HOME=/root",
+        "ExecStart=/usr/bin/unison -socket 12345"
       ].each do |line|
         it do
-          expect(subject).to contain_file('/etc/systemd/system/unison-myinstance.service')
+          expect(subject).to contain_file("/etc/systemd/system/unison-myinstance.service")
             .with_content(%r{^#{line}$}m)
         end
       end
 
       it do
-        expect(subject).to contain_service('unison-myinstance')
-          .with(enable: true, ensure: 'running')
-          .that_requires('Package[unison]')
+        expect(subject).to contain_service("unison-myinstance")
+          .with(enable: true, ensure: "running")
+          .that_requires("Package[unison]")
       end
 
-      it 'exports client' do
-        expect(exported_resources).to contain_nebula__unison__client('myinstance').with(
+      it "exports client" do
+        expect(exported_resources).to contain_nebula__unison__client("myinstance").with(
           server: facts[:fqdn],
           # from hiera
           port: 12_345,
-          root: '/myroot',
+          root: "/myroot",
           paths: %w[path1 path2],
-          filesystems: ['fs1'],
+          filesystems: ["fs1"]
         )
       end
     end

--- a/spec/defines/usergroup_spec.rb
+++ b/spec/defines/usergroup_spec.rb
@@ -3,48 +3,48 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::usergroup' do
-  let(:title) { 'examplegroup1' }
+describe "nebula::usergroup" do
+  let(:title) { "examplegroup1" }
   let(:params) do
     {}
   end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:hiera_config) { 'spec/fixtures/hiera/usergroups_config.yaml' }
+      let(:hiera_config) { "spec/fixtures/hiera/usergroups_config.yaml" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      it { is_expected.to contain_group('examplegroup1') }
+      it { is_expected.to contain_group("examplegroup1") }
 
-      it { is_expected.to contain_user('exampleuser1') }
-      it { is_expected.to contain_user('exampleuser2') }
-      it { is_expected.not_to contain_user('exampleuser3') }
+      it { is_expected.to contain_user("exampleuser1") }
+      it { is_expected.to contain_user("exampleuser2") }
+      it { is_expected.not_to contain_user("exampleuser3") }
 
       # Rubocop made me put this underscore here.
-      it { is_expected.to contain_user('exampleuser1').with_uid(12_345) }
-      it { is_expected.to contain_user('exampleuser1').with_comment('The first example user') }
-      it { is_expected.to contain_user('exampleuser1').with_home('/home/exampleuser1') }
-      it { is_expected.to contain_user('exampleuser1').with_gid('staff') }
-      it { is_expected.to contain_user('exampleuser1').with_groups(%w[examplegroup1]) }
+      it { is_expected.to contain_user("exampleuser1").with_uid(12_345) }
+      it { is_expected.to contain_user("exampleuser1").with_comment("The first example user") }
+      it { is_expected.to contain_user("exampleuser1").with_home("/home/exampleuser1") }
+      it { is_expected.to contain_user("exampleuser1").with_gid("staff") }
+      it { is_expected.to contain_user("exampleuser1").with_groups(%w[examplegroup1]) }
 
-      it { is_expected.to contain_user('exampleuser2').with_uid(12_346) }
-      it { is_expected.to contain_user('exampleuser2').with_comment('The second example user') }
-      it { is_expected.to contain_user('exampleuser2').with_home('/home/exampleuser2') }
-      it { is_expected.to contain_user('exampleuser2').with_gid('staff') }
-      it { is_expected.to contain_user('exampleuser2').with_groups(%w[examplegroup1 examplegroup2]) }
+      it { is_expected.to contain_user("exampleuser2").with_uid(12_346) }
+      it { is_expected.to contain_user("exampleuser2").with_comment("The second example user") }
+      it { is_expected.to contain_user("exampleuser2").with_home("/home/exampleuser2") }
+      it { is_expected.to contain_user("exampleuser2").with_gid("staff") }
+      it { is_expected.to contain_user("exampleuser2").with_groups(%w[examplegroup1 examplegroup2]) }
 
-      context 'when creating examplegroup2' do
-        let(:title) { 'examplegroup2' }
+      context "when creating examplegroup2" do
+        let(:title) { "examplegroup2" }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_group('examplegroup2') }
+        it { is_expected.to contain_group("examplegroup2") }
 
-        it { is_expected.not_to contain_user('exampleuser1') }
-        it { is_expected.to contain_user('exampleuser2') }
-        it { is_expected.to contain_user('exampleuser3') }
+        it { is_expected.not_to contain_user("exampleuser1") }
+        it { is_expected.to contain_user("exampleuser2") }
+        it { is_expected.to contain_user("exampleuser3") }
       end
     end
   end

--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -3,10 +3,10 @@
 # Copyright (c) 2022 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nebula::virtual_machine' do
-  let(:title) { 'vmname' }
+describe "nebula::virtual_machine" do
+  let(:title) { "vmname" }
   let(:params) { {} }
 
   def contain_install
@@ -27,14 +27,14 @@ describe 'nebula::virtual_machine' do
 
       context 'with nothing but the title "vmname"' do
         it do
-          expect(subject).to contain_file('/tmp/.virtual.vmname').with(
-            ensure: 'directory',
+          expect(subject).to contain_file("/tmp/.virtual.vmname").with(
+            ensure: "directory"
           )
         end
 
         it do
           expect(subject).to contain_preseed.that_requires(
-            'File[/tmp/.virtual.vmname]',
+            "File[/tmp/.virtual.vmname]"
           )
         end
 
@@ -48,36 +48,36 @@ describe 'nebula::virtual_machine' do
           %r{^d-i netcfg/get_domain string default\.invalid$},
           %r{^d-i netcfg/hostname string vmname\.default\.invalid$},
           %r{^d-i apt-setup/local0/repository string http://apt\.puppetlabs\.com bullseye puppet7$.*^d-i apt-setup/local0/key string https://files\.default\.invalid/puppetlabs-pc1-keyring\.gpg$}m,
-          %r{\swget -O /target/etc/puppetlabs/puppet/puppet\.conf\s.*https://files\.default\.invalid/puppet\.conf}m,
+          %r{\swget -O /target/etc/puppetlabs/puppet/puppet\.conf\s.*https://files\.default\.invalid/puppet\.conf}m
         ].each do |line|
           it { is_expected.to contain_preseed.with_content(line) }
         end
 
         it do
-          expect(subject).to contain_package('virtinst').with(
-            ensure: 'installed',
+          expect(subject).to contain_package("virtinst").with(
+            ensure: "installed"
           )
         end
 
         it do
-          expect(subject).to contain_package('libvirt-clients').with(
-            ensure: 'installed',
+          expect(subject).to contain_package("libvirt-clients").with(
+            ensure: "installed"
           )
         end
 
         it do
           expect(subject).to contain_install.that_requires(
-            ['Package[virtinst]',
-             'Package[libvirt-clients]'],
+            ["Package[virtinst]",
+              "Package[libvirt-clients]"]
           ).with(
-            creates: '/var/lib/libvirt/images/vmname.img',
+            creates: "/var/lib/libvirt/images/vmname.img",
             timeout: 600,
             path: [
-              '/usr/bin',
-              '/usr/sbin',
-              '/bin',
-              '/sbin',
-            ],
+              "/usr/bin",
+              "/usr/sbin",
+              "/bin",
+              "/sbin"
+            ]
           )
         end
 
@@ -94,301 +94,301 @@ describe 'nebula::virtual_machine' do
           %r{ --virt-type kvm},
           %r{ --graphics vnc},
           %r{ --extra-args 'auto netcfg/disable_dhcp=true'},
-          %r{ --initrd-inject '/tmp/\.virtual\.vmname/preseed\.cfg'},
+          %r{ --initrd-inject '/tmp/\.virtual\.vmname/preseed\.cfg'}
         ].each do |command|
           it { is_expected.to contain_install.with_command(command) }
         end
 
         it do
           expect(subject).to contain_autostart.that_requires(
-            'Exec[nebula::virtual_machine::vmname::virt-install]',
+            "Exec[nebula::virtual_machine::vmname::virt-install]"
           ).with(
-            creates: '/etc/libvirt/qemu/autostart/vmname.xml',
-            command: '/usr/bin/virsh autostart vmname',
+            creates: "/etc/libvirt/qemu/autostart/vmname.xml",
+            command: "/usr/bin/virsh autostart vmname"
           )
         end
       end
 
-      context 'with bridge interface overrides' do
+      context "with bridge interface overrides" do
         let(:params) do
           {
-            internet_bridge: 'internet_bridge',
-            lan_bridge: 'lan_bridge',
+            internet_bridge: "internet_bridge",
+            lan_bridge: "lan_bridge"
           }
         end
 
         [
-          %r{ --network bridge=internet_bridge,model=virtio .* --network bridge=lan_bridge,model=virtio}m,
+          %r{ --network bridge=internet_bridge,model=virtio .* --network bridge=lan_bridge,model=virtio}m
         ].each do |command|
           it { is_expected.to contain_install.with_command(command) }
         end
       end
 
       context 'with nothing but the title "secondvm"' do
-        let(:title) { 'secondvm' }
+        let(:title) { "secondvm" }
 
         it do
-          expect(subject).to contain_file('/tmp/.virtual.secondvm').with(
-            ensure: 'directory',
+          expect(subject).to contain_file("/tmp/.virtual.secondvm").with(
+            ensure: "directory"
           )
         end
 
         it do
           expect(subject).to contain_preseed.that_requires(
-            'File[/tmp/.virtual.secondvm]',
+            "File[/tmp/.virtual.secondvm]"
           )
         end
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_hostname string secondvm\.default\.invalid$},
+            %r{^d-i netcfg/get_hostname string secondvm\.default\.invalid$}
           )
         end
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/hostname string secondvm\.default\.invalid$},
+            %r{^d-i netcfg/hostname string secondvm\.default\.invalid$}
           )
         end
 
-        it { is_expected.to contain_package('virtinst') }
-        it { is_expected.to contain_package('libvirt-clients') }
+        it { is_expected.to contain_package("virtinst") }
+        it { is_expected.to contain_package("libvirt-clients") }
 
         it do
           expect(subject).to contain_install.with_creates(
-            '/var/lib/libvirt/images/secondvm.img',
+            "/var/lib/libvirt/images/secondvm.img"
           )
         end
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ -n 'secondvm'},
+            %r{ -n 'secondvm'}
           )
         end
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --disk '/var/lib/libvirt/images/secondvm\.img,size=[0-9]+'},
+            %r{ --disk '/var/lib/libvirt/images/secondvm\.img,size=[0-9]+'}
           )
         end
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --initrd-inject '/tmp/\.virtual\.secondvm/preseed\.cfg'},
+            %r{ --initrd-inject '/tmp/\.virtual\.secondvm/preseed\.cfg'}
           )
         end
 
         it do
           expect(subject).to contain_autostart.with_creates(
-            '/etc/libvirt/qemu/autostart/secondvm.xml',
+            "/etc/libvirt/qemu/autostart/secondvm.xml"
           )
         end
 
         it do
           expect(subject).to contain_autostart.with_command(
-            '/usr/bin/virsh autostart secondvm',
+            "/usr/bin/virsh autostart secondvm"
           )
         end
       end
 
-      context 'with cpus set to 8' do
-        let(:params) { { cpus: 8 } }
+      context "with cpus set to 8" do
+        let(:params) { {cpus: 8} }
 
         it do
           expect(subject).to contain_install.with_command(%r{ --vcpus 8})
         end
       end
 
-      context 'with ram set to 4' do
-        let(:params) { { ram: 4 } }
+      context "with ram set to 4" do
+        let(:params) { {ram: 4} }
 
         it { is_expected.to contain_install.with_command(%r{ -r 4096}) }
       end
 
-      context 'with image_dir set to /libvirt-images' do
-        let(:params) { { image_dir: '/libvirt-images' } }
+      context "with image_dir set to /libvirt-images" do
+        let(:params) { {image_dir: "/libvirt-images"} }
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --disk '/libvirt-images/vmname.img,size=[0-9]+'},
+            %r{ --disk '/libvirt-images/vmname.img,size=[0-9]+'}
           )
         end
 
         it do
           expect(subject).to contain_install.with_creates(
-            '/libvirt-images/vmname.img',
+            "/libvirt-images/vmname.img"
           )
         end
       end
 
-      context 'with image_path set to /mnt/custom.img' do
-        let(:params) { { image_path: '/mnt/custom.img' } }
+      context "with image_path set to /mnt/custom.img" do
+        let(:params) { {image_path: "/mnt/custom.img"} }
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --disk '/mnt/custom.img,size=[0-9]+'},
+            %r{ --disk '/mnt/custom.img,size=[0-9]+'}
           )
         end
 
         it do
           expect(subject).to contain_install.with_creates(
-            '/mnt/custom.img',
+            "/mnt/custom.img"
           )
         end
       end
 
-      context 'with image_path and image_dir both set' do
+      context "with image_path and image_dir both set" do
         let(:params) do
-          { image_path: 'image_path',
-            image_dir: 'image_dir' }
+          {image_path: "image_path",
+           image_dir: "image_dir"}
         end
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --disk 'image_path,size=[0-9]+'},
+            %r{ --disk 'image_path,size=[0-9]+'}
           )
         end
 
-        it { is_expected.to contain_install.with_creates('image_path') }
+        it { is_expected.to contain_install.with_creates("image_path") }
       end
 
-      context 'with disk set to 64' do
-        let(:params) { { disk: 64 } }
+      context "with disk set to 64" do
+        let(:params) { {disk: 64} }
 
         it do
           expect(subject).to contain_install.with_command(
-            %r{ --disk '[^,']+,size=64'},
+            %r{ --disk '[^,']+,size=64'}
           )
         end
       end
 
-      context 'with timeout set to 0' do
-        let(:params) { { timeout: 0 } }
+      context "with timeout set to 0" do
+        let(:params) { {timeout: 0} }
 
         it { is_expected.to contain_install.with_timeout(0) }
       end
 
-      context 'with autostart_path set to /etc/autostart' do
-        let(:params) { { autostart_path: '/etc/autostart' } }
+      context "with autostart_path set to /etc/autostart" do
+        let(:params) { {autostart_path: "/etc/autostart"} }
 
         it do
           expect(subject).to contain_autostart.with_creates(
-            '/etc/autostart/vmname.xml',
+            "/etc/autostart/vmname.xml"
           )
         end
       end
 
-      context 'with invalid build name' do
-        let(:params) { { build: 'foobar' } }
+      context "with invalid build name" do
+        let(:params) { {build: "foobar"} }
 
         it { is_expected.not_to compile }
       end
 
-      context 'with bullseye build name' do
-        let(:params) { { build: 'bullseye' } }
+      context "with bullseye build name" do
+        let(:params) { {build: "bullseye"} }
 
         [
           %r{^d-i preseed/late_command string\b},
-          %r{\sin-target systemctl enable puppet\b},
+          %r{\sin-target systemctl enable puppet\b}
         ].each do |line|
           it { is_expected.to contain_preseed.with_content(line) }
         end
       end
 
-      context 'with pre-bullseye build name' do
-        let(:params) { { build: 'buster' } }
+      context "with pre-bullseye build name" do
+        let(:params) { {build: "buster"} }
 
         [
-          %r{\sin-target systemctl enable puppet\b},
+          %r{\sin-target systemctl enable puppet\b}
         ].each do |line|
           it { is_expected.not_to contain_preseed.with_content(line) }
         end
       end
 
-      context 'with domain set to awesome.com' do
-        let(:params) { { domain: 'awesome.com' } }
+      context "with domain set to awesome.com" do
+        let(:params) { {domain: "awesome.com"} }
 
         [
           %r{^d-i netcfg/get_hostname string vmname\.awesome\.com$},
           %r{^d-i netcfg/get_domain string awesome\.com$},
-          %r{^d-i netcfg/hostname string vmname\.awesome\.com$},
+          %r{^d-i netcfg/hostname string vmname\.awesome\.com$}
         ].each do |line|
           it { is_expected.to contain_preseed.with_content(line) }
         end
       end
 
-      context 'with filehost set to gr8storage.biz' do
-        let(:params) { { filehost: 'gr8storage.biz' } }
+      context "with filehost set to gr8storage.biz" do
+        let(:params) { {filehost: "gr8storage.biz"} }
 
         [
           %r{^d-i apt-setup/local0/repository string http://apt\.puppetlabs\.com bullseye puppet7$.*^d-i apt-setup/local0/key string https://gr8storage\.biz/puppetlabs-pc1-keyring\.gpg$}m,
-          %r{\swget -O /target/etc/puppetlabs/puppet/puppet\.conf\s.*https://gr8storage\.biz/puppet\.conf}m,
+          %r{\swget -O /target/etc/puppetlabs/puppet/puppet\.conf\s.*https://gr8storage\.biz/puppet\.conf}m
         ].each do |line|
           it { is_expected.to contain_preseed.with_content(line) }
         end
       end
 
-      context 'with netmask set to 0.0.0.0' do
-        let(:params) { { netmask: '0.0.0.0' } }
+      context "with netmask set to 0.0.0.0" do
+        let(:params) { {netmask: "0.0.0.0"} }
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_netmask string 0\.0\.0\.0$},
+            %r{^d-i netcfg/get_netmask string 0\.0\.0\.0$}
           )
         end
       end
 
-      context 'with gateway set to 10.0.0.1' do
-        let(:params) { { gateway: '10.0.0.1' } }
+      context "with gateway set to 10.0.0.1" do
+        let(:params) { {gateway: "10.0.0.1"} }
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_gateway string 10\.0\.0\.1$},
+            %r{^d-i netcfg/get_gateway string 10\.0\.0\.1$}
           )
         end
       end
 
-      context 'with nameservers set to [1.2.3.4, 4.3.2.1]' do
-        let(:params) { { nameservers: ['1.2.3.4', '4.3.2.1'] } }
+      context "with nameservers set to [1.2.3.4, 4.3.2.1]" do
+        let(:params) { {nameservers: ["1.2.3.4", "4.3.2.1"]} }
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_nameservers string 1\.2\.3\.4 4\.3\.2\.1$},
+            %r{^d-i netcfg/get_nameservers string 1\.2\.3\.4 4\.3\.2\.1$}
           )
         end
       end
 
-      context 'with an addr' do
-        let(:params) { { addr: '1.2.3.4' } }
+      context "with an addr" do
+        let(:params) { {addr: "1.2.3.4"} }
 
         it { is_expected.to compile }
       end
 
-      context 'with an existing vm' do
-        let(:title) { 'invalid_existing_guest' }
+      context "with an existing vm" do
+        let(:title) { "invalid_existing_guest" }
 
         it { is_expected.to compile }
         it { is_expected.not_to contain_install }
       end
 
       context 'with title set to "myhost.mysub"' do
-        let(:title) { 'myhost.mysub' }
+        let(:title) { "myhost.mysub" }
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_hostname string myhost\.mysub$},
+            %r{^d-i netcfg/get_hostname string myhost\.mysub$}
           )
         end
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/get_domain string mysub$},
+            %r{^d-i netcfg/get_domain string mysub$}
           )
         end
 
         it do
           expect(subject).to contain_preseed.with_content(
-            %r{^d-i netcfg/hostname string myhost\.mysub$},
+            %r{^d-i netcfg/hostname string myhost\.mysub$}
           )
         end
       end

--- a/spec/functions/fact_for_spec.rb
+++ b/spec/functions/fact_for_spec.rb
@@ -3,40 +3,40 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'fact_for' do
-  let(:node_id) { '' }
-  let(:fact_name) { '' }
-  let(:fact_value) { '' }
+describe "fact_for" do
+  let(:node_id) { "" }
+  let(:fact_name) { "" }
+  let(:fact_value) { "" }
 
   before(:each) do
-    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue) { |_| raise 'OVERRIDE ME!' }
+    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue) { |_| raise "OVERRIDE ME!" }
 
     allow(scope).to receive(:function_puppetdb_query)
-      .with([['from', 'facts', ['extract', ['value'], ['and', ['=', 'certname', node_id], ['=', 'name', fact_name]]]]])
-      .and_return([{ 'value' => fact_value }])
+      .with([["from", "facts", ["extract", ["value"], ["and", ["=", "certname", node_id], ["=", "name", fact_name]]]]])
+      .and_return([{"value" => fact_value}])
   end
 
-  context 'when my_node has datacenter my_datacenter' do
-    let(:node_id) { 'my_node' }
-    let(:fact_name) { 'datacenter' }
-    let(:fact_value) { 'my_datacenter' }
+  context "when my_node has datacenter my_datacenter" do
+    let(:node_id) { "my_node" }
+    let(:fact_name) { "datacenter" }
+    let(:fact_value) { "my_datacenter" }
 
     it do
-      expect(subject).to run.with_params('my_node', 'datacenter')
-                            .and_return('my_datacenter')
+      expect(subject).to run.with_params("my_node", "datacenter")
+        .and_return("my_datacenter")
     end
   end
 
-  context 'when node_a has networking.ip 10.1.2.3' do
-    let(:node_id) { 'node_a' }
-    let(:fact_name) { 'networking' }
-    let(:fact_value) { { 'ip' => '10.1.2.3' } }
+  context "when node_a has networking.ip 10.1.2.3" do
+    let(:node_id) { "node_a" }
+    let(:fact_name) { "networking" }
+    let(:fact_value) { {"ip" => "10.1.2.3"} }
 
     it do
-      expect(subject).to run.with_params('node_a', 'networking.ip')
-                            .and_return('10.1.2.3')
+      expect(subject).to run.with_params("node_a", "networking.ip")
+        .and_return("10.1.2.3")
     end
   end
 end

--- a/spec/functions/find_all_files_under_spec.rb
+++ b/spec/functions/find_all_files_under_spec.rb
@@ -3,9 +3,9 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'find_all_files_under' do
+describe "find_all_files_under" do
   before :each do
     `mkdir spec/test_files`
 
@@ -33,13 +33,13 @@ describe 'find_all_files_under' do
     `rm -r spec/test_files`
   end
 
-  it { is_expected.to run.with_params('spec/test_files/does_not_exist').and_return([]) }
+  it { is_expected.to run.with_params("spec/test_files/does_not_exist").and_return([]) }
 
-  it { is_expected.to run.with_params('spec/test_files/empty').and_return([]) }
+  it { is_expected.to run.with_params("spec/test_files/empty").and_return([]) }
 
-  it { is_expected.to run.with_params('spec/test_files/one_file').and_return(%w[just_me.txt]) }
+  it { is_expected.to run.with_params("spec/test_files/one_file").and_return(%w[just_me.txt]) }
 
-  it { is_expected.to run.with_params('spec/test_files/some_empty_subdirs').and_return([]) }
+  it { is_expected.to run.with_params("spec/test_files/some_empty_subdirs").and_return([]) }
 
-  it { is_expected.to run.with_params('spec/test_files/nested_files').and_return(%w[a_file.txt a/another_file.txt b/c/yet_another_file.txt].sort) }
+  it { is_expected.to run.with_params("spec/test_files/nested_files").and_return(%w[a_file.txt a/another_file.txt b/c/yet_another_file.txt].sort) }
 end

--- a/spec/functions/inverted_hashlist_spec.rb
+++ b/spec/functions/inverted_hashlist_spec.rb
@@ -3,39 +3,39 @@
 # Copyright (c) 2018 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'inverted_hashlist' do
-  let(:hiera_config) { 'spec/fixtures/hiera/inverted_hashlist_config.yaml' }
+describe "inverted_hashlist" do
+  let(:hiera_config) { "spec/fixtures/hiera/inverted_hashlist_config.yaml" }
 
   [
     [{}, {}],
-    [{ 'a' => [] }, {}],
-    [{ 'a' => %w[1] }, { '1' => %w[a] }],
-    [{ 'a' => %w[1 2] }, { '1' => %w[a], '2' => %w[a] }],
-    [{ 'a' => %w[1], 'b' => %w[2] }, { '1' => %w[a], '2' => %w[b] }],
+    [{"a" => []}, {}],
+    [{"a" => %w[1]}, {"1" => %w[a]}],
+    [{"a" => %w[1 2]}, {"1" => %w[a], "2" => %w[a]}],
+    [{"a" => %w[1], "b" => %w[2]}, {"1" => %w[a], "2" => %w[b]}]
   ].each do |input, output|
     it { is_expected.to run.with_params(input).and_return(output) }
   end
 
   it do
-    result = subject.execute('a' => %w[1], 'b' => %w[1])
-    expect(result.keys).to contain_exactly('1')
-    expect(result['1']).to contain_exactly('a', 'b')
+    result = subject.execute("a" => %w[1], "b" => %w[1])
+    expect(result.keys).to contain_exactly("1")
+    expect(result["1"]).to contain_exactly("a", "b")
   end
 
   it do
-    result = subject.execute('a' => %w[1 2], 'b' => %w[2])
-    expect(result.keys).to contain_exactly('1', '2')
-    expect(result['1']).to contain_exactly('a')
-    expect(result['2']).to contain_exactly('a', 'b')
+    result = subject.execute("a" => %w[1 2], "b" => %w[2])
+    expect(result.keys).to contain_exactly("1", "2")
+    expect(result["1"]).to contain_exactly("a")
+    expect(result["2"]).to contain_exactly("a", "b")
   end
 
   it do
-    result = subject.execute('example_hash')
-    expect(result.keys).to contain_exactly('value_1', 'value_2', 'value_3')
-    expect(result['value_1']).to contain_exactly('key_1')
-    expect(result['value_2']).to contain_exactly('key_1', 'key_2')
-    expect(result['value_3']).to contain_exactly('key_2')
+    result = subject.execute("example_hash")
+    expect(result.keys).to contain_exactly("value_1", "value_2", "value_3")
+    expect(result["value_1"]).to contain_exactly("key_1")
+    expect(result["value_2"]).to contain_exactly("key_1", "key_2")
+    expect(result["value_3"]).to contain_exactly("key_2")
   end
 end

--- a/spec/functions/ip_from_cidr_spec.rb
+++ b/spec/functions/ip_from_cidr_spec.rb
@@ -3,19 +3,19 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'ip_from_cidr' do
+describe "ip_from_cidr" do
   [
-    ['10.0.0.0/8', 0, '10.0.0.0'],
-    ['10.0.0.0/8', 1, '10.0.0.1'],
-    ['10.0.0.0/8', 123, '10.0.0.123'],
-    ['10.0.0.0/8', 256, '10.0.1.0'],
-    ['192.168.14.0/24', 55, '192.168.14.55'],
-    ['fc00::/7', 0x123456789abcdef, 'fc00::123:4567:89ab:cdef'],
+    ["10.0.0.0/8", 0, "10.0.0.0"],
+    ["10.0.0.0/8", 1, "10.0.0.1"],
+    ["10.0.0.0/8", 123, "10.0.0.123"],
+    ["10.0.0.0/8", 256, "10.0.1.0"],
+    ["192.168.14.0/24", 55, "192.168.14.55"],
+    ["fc00::/7", 0x123456789abcdef, "fc00::123:4567:89ab:cdef"]
   ].each do |cidr, i, ipaddress|
     it { is_expected.to run.with_params(cidr, i).and_return(ipaddress) }
   end
 
-  it { is_expected.to run.with_params('10.0.0.0/24', 256).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params("10.0.0.0/24", 256).and_raise_error(ArgumentError) }
 end

--- a/spec/functions/is_publicly_accessible_spec.rb
+++ b/spec/functions/is_publicly_accessible_spec.rb
@@ -3,74 +3,74 @@
 # Copyright (c) 2020 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'is_publicly_accessible' do
-  let(:facts) { { 'networking' => { 'interfaces' => interfaces } } }
-  let(:interfaces) { { 'lo' => { 'ip' => '127.0.0.1' } } }
+describe "is_publicly_accessible" do
+  let(:facts) { {"networking" => {"interfaces" => interfaces}} }
+  let(:interfaces) { {"lo" => {"ip" => "127.0.0.1"}} }
 
-  context 'with no internet connection' do
+  context "with no internet connection" do
     it { is_expected.to run.and_return(false) }
   end
 
-  context 'with the ip address 10.1.2.3' do
+  context "with the ip address 10.1.2.3" do
     let :interfaces do
-      super().merge('eth0' => { 'ip' => '10.1.2.3' })
+      super().merge("eth0" => {"ip" => "10.1.2.3"})
     end
 
     it { is_expected.to run.and_return(false) }
 
-    context 'with a nil ip address' do
+    context "with a nil ip address" do
       let :interfaces do
-        super().merge('hfdlksajh' => { 'ip' => nil })
+        super().merge("hfdlksajh" => {"ip" => nil})
       end
 
       it { is_expected.to run.and_return(false) }
     end
 
-    context 'with the ip address 12.34.56.78' do
+    context "with the ip address 12.34.56.78" do
       let :interfaces do
-        super().merge('eth1' => { 'ip' => '12.34.56.78' })
+        super().merge("eth1" => {"ip" => "12.34.56.78"})
       end
 
       it { is_expected.to run.and_return(true) }
 
-      context 'with a nil ip address' do
+      context "with a nil ip address" do
         let :interfaces do
-          super().merge('hfdlksajh' => { 'ip' => nil })
+          super().merge("hfdlksajh" => {"ip" => nil})
         end
 
         it { is_expected.to run.and_return(true) }
       end
     end
 
-    context 'with the ip address 21.43.65.87' do
+    context "with the ip address 21.43.65.87" do
       let :interfaces do
-        super().merge('eth1' => { 'ip' => '21.43.65.87' })
+        super().merge("eth1" => {"ip" => "21.43.65.87"})
       end
 
       it { is_expected.to run.and_return(true) }
     end
   end
 
-  context 'with the ip address 172.20.12.34' do
+  context "with the ip address 172.20.12.34" do
     let :interfaces do
-      super().merge('eth0' => { 'ip' => '172.20.12.34' })
+      super().merge("eth0" => {"ip" => "172.20.12.34"})
     end
 
     it { is_expected.to run.and_return(false) }
   end
 
-  context 'with the ip address 192.168.1.123' do
+  context "with the ip address 192.168.1.123" do
     let :interfaces do
-      super().merge('eth0' => { 'ip' => '192.168.1.123' })
+      super().merge("eth0" => {"ip" => "192.168.1.123"})
     end
 
     it { is_expected.to run.and_return(false) }
   end
 
-  context 'with no interfaces set' do
-    let(:facts) { { 'networking' => {} } }
+  context "with no interfaces set" do
+    let(:facts) { {"networking" => {}} }
 
     it { is_expected.to run.and_return(false) }
   end

--- a/spec/functions/lookup_role_spec.rb
+++ b/spec/functions/lookup_role_spec.rb
@@ -3,18 +3,18 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'lookup_role' do
-  context 'when the role is my_role' do
-    let(:hiera_config) { 'spec/fixtures/hiera/role_is_my_role_config.yaml' }
+describe "lookup_role" do
+  context "when the role is my_role" do
+    let(:hiera_config) { "spec/fixtures/hiera/role_is_my_role_config.yaml" }
 
-    it { is_expected.to run.and_return('my_role') }
+    it { is_expected.to run.and_return("my_role") }
   end
 
-  context 'when the role is nebula::role::aws::auto' do
-    let(:hiera_config) { 'spec/fixtures/hiera/role_is_aws_auto_config.yaml' }
+  context "when the role is nebula::role::aws::auto" do
+    let(:hiera_config) { "spec/fixtures/hiera/role_is_aws_auto_config.yaml" }
 
-    it { is_expected.to run.and_return('nebula::role::aws') }
+    it { is_expected.to run.and_return("nebula::role::aws") }
   end
 end

--- a/spec/functions/nodes_for_class_spec.rb
+++ b/spec/functions/nodes_for_class_spec.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-describe 'nodes_for_class' do
-  let(:class_title) { '' }
+describe "nodes_for_class" do
+  let(:class_title) { "" }
   let(:nodes) { [] }
 
   before(:each) do
-    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue) { |_| raise 'OVERRIDE ME!' }
+    Puppet::Parser::Functions.newfunction(:puppetdb_query, type: :rvalue) { |_| raise "OVERRIDE ME!" }
 
     allow(scope).to receive(:function_puppetdb_query)
-      .with([['from', 'resources', ['extract', ['certname'], ['=', 'title', class_title]]]])
-      .and_return(nodes.map { |n| { 'certname' => n } })
+      .with([["from", "resources", ["extract", ["certname"], ["=", "title", class_title]]]])
+      .and_return(nodes.map { |n| {"certname" => n} })
   end
 
-  context 'when nodes node_a and node_b have the role my_role' do
-    let(:class_title) { 'My_role' }
+  context "when nodes node_a and node_b have the role my_role" do
+    let(:class_title) { "My_role" }
     let(:nodes) { %w[node_a node_b] }
 
     it do
-      expect(subject).to run.with_params('my_role')
-                            .and_return(%w[node_a node_b])
+      expect(subject).to run.with_params("my_role")
+        .and_return(%w[node_a node_b])
     end
   end
 
-  context 'when nodes node_1, node_2, and node_3 have the role nebula::default' do
-    let(:class_title) { 'Nebula::Default' }
+  context "when nodes node_1, node_2, and node_3 have the role nebula::default" do
+    let(:class_title) { "Nebula::Default" }
     let(:nodes) { %w[node_1 node_2 node_3] }
 
     it do
-      expect(subject).to run.with_params('nebula::default')
-                            .and_return(%w[node_1 node_2 node_3])
+      expect(subject).to run.with_params("nebula::default")
+        .and_return(%w[node_1 node_2 node_3])
     end
   end
 
-  context 'when nodes node_b, node_a, and node_z have the role My_role' do
-    let(:class_title) { 'My_role' }
+  context "when nodes node_b, node_a, and node_z have the role My_role" do
+    let(:class_title) { "My_role" }
     let(:nodes) { %w[node_b node_a node_z] }
 
-    it 'returns the nodes sorted by name' do
-      expect(subject).to run.with_params('my_role')
-                            .and_return(%w[node_a node_b node_z])
+    it "returns the nodes sorted by name" do
+      expect(subject).to run.with_params("my_role")
+        .and_return(%w[node_a node_b node_z])
     end
   end
 end

--- a/spec/functions/public_ip_spec.rb
+++ b/spec/functions/public_ip_spec.rb
@@ -3,14 +3,14 @@
 # Copyright (c) 2019 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
-require 'spec_helper'
+require "spec_helper"
 
-describe 'public_ip' do
+describe "public_ip" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to run.and_return(facts[:networking]['ip']) }
+      it { is_expected.to run.and_return(facts[:networking]["ip"]) }
     end
   end
 end

--- a/spec/spec_helper/deep_merge.rb
+++ b/spec/spec_helper/deep_merge.rb
@@ -9,7 +9,7 @@ class Hash
     merge!(other) do |key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)
         this_val.deep_merge(other_val, &block)
-      elsif block_given?
+      elsif block
         block.call(key, this_val, other_val)
       else
         other_val

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'faker'
-require 'spec_helper/deep_merge'
-require 'spec_helper/stub_loader'
+require "faker"
+require "spec_helper/deep_merge"
+require "spec_helper/stub_loader"

--- a/spec/support/contexts/with_htvm_setup.rb
+++ b/spec/support/contexts/with_htvm_setup.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require_relative './with_mocked_nodes'
-require 'faker'
+require_relative "./with_mocked_nodes"
+require "faker"
 
-RSpec.shared_context 'with setup for htvm node' do |os_facts|
+RSpec.shared_context "with setup for htvm node" do |os_facts|
   let(:facts) do
     os_facts.deep_merge(
-      datacenter: 'somedc',
-      networking: { 'ip' => Faker::Internet.ip_v4_address, 'interfaces' => {}, 'hostname' => 'thisnode' },
+      datacenter: "somedc",
+      networking: {"ip" => Faker::Internet.ip_v4_address, "interfaces" => {}, "hostname" => "thisnode"}
     )
   end
-  let(:hiera_config) { 'spec/fixtures/hiera/hathitrust_config.yaml' }
-  let(:rolenode) { { 'ip' => Faker::Internet.ip_v4_address, 'hostname' => 'rolenode' } }
+  let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
+  let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }
 
-  include_context 'with mocked puppetdb functions', 'somedc', %w[rolenode], 'nebula::profile::haproxy' => %w[]
+  include_context "with mocked puppetdb functions", "somedc", %w[rolenode], "nebula::profile::haproxy" => %w[]
 end

--- a/spec/support/contexts/with_mocked_nodes.rb
+++ b/spec/support/contexts/with_mocked_nodes.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'with mocked puppetdb functions' do |_datacenter, nodes, class_nodes|
+RSpec.shared_context "with mocked puppetdb functions" do |_datacenter, nodes, class_nodes|
   before(:each) do
     stub_loader!
   end
 
   before(:each) do
-    stub('nodes_for_class') do |d|
+    stub("nodes_for_class") do |d|
       class_nodes.each do |node_class, nodes_in_class|
         allow_call(d).with(node_class).and_return(%w[rolenode] + nodes_in_class)
       end
     end
 
-    stub('fact_for') do |d|
+    stub("fact_for") do |d|
       nodes.each do |node|
-        allow_call(d).with(node, 'networking').and_return(send(node.to_sym))
+        allow_call(d).with(node, "networking").and_return(send(node.to_sym))
       end
     end
   end


### PR DESCRIPTION
- add standardrb to gem, rake task
- standardrb config skips files that aren't part of this repo or are controlled by `pdk`
- replace rubocop w/ standardrb in CI
- puppet-lint configuration skips tests that don't actually work (more detail on this in commit)
- ran automated fixes with standardrb and puppet-lint
- manually fixed specs to match changes made by puppet-lint