### PR TITLE
Restart every VM after a crash

### DIFF
--- a/manifests/virtual_machine.pp
+++ b/manifests/virtual_machine.pp
@@ -93,7 +93,16 @@ define nebula::virtual_machine (
     ensure => 'directory',
   }
 
-  unless $facts['vm_guests'].member($title) {
+  if $facts['vm_guests'].member($title) {
+    # If the VM already exists, ensure that it's marked to autostart
+    # when the host boots. (This exec is in this conditional because it
+    # isn't constructed to be safe to run before the VM exists.)
+    exec { "${prefix}::autostart":
+      creates => "${autostart_path}/${title}.xml",
+      command => "/usr/bin/virsh autostart ${title}",
+    }
+  } else {
+    # If the VM does not already exist, create it.
     if $build == 'bullseye' {
       file { "${tmpdir}/preseed.cfg":
         content => template("nebula/virtual_machine/${build}.cfg.erb"),
@@ -132,11 +141,26 @@ define nebula::virtual_machine (
           --extra-args 'auto netcfg/disable_dhcp=true'
         | VIRT_INSTALL_EOF
     }
+  }
 
-    exec { "${prefix}::autostart":
-      require => Exec["${prefix}::virt-install"],
-      creates => "${autostart_path}/${title}.xml",
-      command => "/usr/bin/virsh autostart ${title}",
-    }
+  # Ensure that the xml file that sets up future instances of this VM is
+  # set to restart after a crash.
+  exec { "/usr/bin/virsh set-lifecycle-action ${title} crash restart --config":
+    # If the VM doesn't exist yet, or if it's set to do anything other
+    # than destroy on crash, this exec won't run.
+    onlyif => "/usr/bin/virsh dumpxml --inactive ${title} | grep on_crash | grep -q destroy",
+  }
+
+  # If the VM is running, the above exec won't affect the live
+  # configuration, so this exec ensures that, if it is running, it too
+  # is set to restart after a crash.
+  exec { "/usr/bin/virsh set-lifecycle-action ${title} crash restart --live":
+    # If the VM doesn't exist yet, or if it's set to do anything other
+    # than destroy on crash, this exec won't run.
+    onlyif  => "/usr/bin/virsh dumpxml ${title} | grep on_crash | grep -q destroy",
+
+    # This is to prevent running with --live on a VM that exists but is
+    # powered off.
+    require => Exec["/usr/bin/virsh set-lifecycle-action ${title} crash restart --config"],
   }
 }

--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -99,13 +99,28 @@ describe "nebula::virtual_machine" do
           it { is_expected.to contain_install.with_command(command) }
         end
 
+        context "with vmname in the vm_guests fact" do
+          let(:facts) { os_facts.merge(vm_guests: ["vmname"]) }
+
+          it { is_expected.not_to contain_install }
+
+          it do
+            expect(subject).to contain_autostart.with(
+              creates: "/etc/libvirt/qemu/autostart/vmname.xml",
+              command: "/usr/bin/virsh autostart vmname"
+            )
+          end
+        end
+
         it do
-          expect(subject).to contain_autostart.that_requires(
-            "Exec[nebula::virtual_machine::vmname::virt-install]"
-          ).with(
-            creates: "/etc/libvirt/qemu/autostart/vmname.xml",
-            command: "/usr/bin/virsh autostart vmname"
-          )
+          is_expected.to contain_exec("/usr/bin/virsh set-lifecycle-action vmname crash restart --config")
+            .with_onlyif("/usr/bin/virsh dumpxml --inactive vmname | grep on_crash | grep -q destroy")
+        end
+
+        it do
+          is_expected.to contain_exec("/usr/bin/virsh set-lifecycle-action vmname crash restart --live")
+            .with_onlyif("/usr/bin/virsh dumpxml vmname | grep on_crash | grep -q destroy")
+            .that_requires("Exec[/usr/bin/virsh set-lifecycle-action vmname crash restart --config]")
         end
       end
 
@@ -178,16 +193,22 @@ describe "nebula::virtual_machine" do
           )
         end
 
-        it do
-          expect(subject).to contain_autostart.with_creates(
-            "/etc/libvirt/qemu/autostart/secondvm.xml"
-          )
-        end
+        context "with secondvm in the vm_guests fact" do
+          let(:facts) { os_facts.merge(vm_guests: ["secondvm"]) }
 
-        it do
-          expect(subject).to contain_autostart.with_command(
-            "/usr/bin/virsh autostart secondvm"
-          )
+          it { is_expected.not_to contain_install }
+
+          it do
+            expect(subject).to contain_autostart.with_creates(
+              "/etc/libvirt/qemu/autostart/secondvm.xml"
+            )
+          end
+
+          it do
+            expect(subject).to contain_autostart.with_command(
+              "/usr/bin/virsh autostart secondvm"
+            )
+          end
         end
       end
 
@@ -271,10 +292,16 @@ describe "nebula::virtual_machine" do
       context "with autostart_path set to /etc/autostart" do
         let(:params) { {autostart_path: "/etc/autostart"} }
 
-        it do
-          expect(subject).to contain_autostart.with_creates(
-            "/etc/autostart/vmname.xml"
-          )
+        context "with secondvm in the vm_guests fact" do
+          let(:facts) { os_facts.merge(vm_guests: ["vmname"]) }
+
+          it { is_expected.not_to contain_install }
+
+          it do
+            expect(subject).to contain_autostart.with_creates(
+              "/etc/autostart/vmname.xml"
+            )
+          end
         end
       end
 


### PR DESCRIPTION
The bit of code that configures VMs to autostart was inside the "make sure this VM isn't already installed" condition, which was either a mistake or a shortest path to get the tests to pass. I've fixed the tests, so this commit will also mark every VM it manages as autostart.

Otherwise, this will only set a VM to restart after a crash if it is currently set to destroy after a crash.

All the options for what to do after a crash are:

1.  destroy
2.  restart
3.  rename-restart
4.  preserve
5.  coredump-destroy (only available on crash, not e.g. poweroff)
6.  coredump-restart (only available on crash, not e.g. poweroff)

I haven't looked into what any of these mean, but coredump is an intriguing word. This commit simply changes anything that's option 1 to option 2.