### PR TITLE
fix bundler warning on ruby 3.3

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -18,6 +18,9 @@ Gemfile:
       - gem: pdk
         version: '>= 3.3.0'
       - gem: standard
+      # Silence bundler errors. It's expected that newer PDK will
+      # add syslog. When that happens, remove this line.
+      - gem: syslog
 Rakefile:
   extra_disabled_lint_checks:
     # We sometimes refer to non-nebula puppet fileserver paths.

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development do
   gem "librarian-puppet", '>= 5.0',              require: false
   gem "pdk", '>= 3.3.0',                         require: false
   gem "standard",                                require: false
+  gem "syslog",                                  require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]


### PR DESCRIPTION
Without this ruby 3.3 spits warnings, and ruby 3.4 is expected to not work at all.