### PR TITLE
don't require two-factor for sudo

### DIFF
--- a/files/default/bookworm/etc/pam.d/sudo
+++ b/files/default/bookworm/etc/pam.d/sudo
@@ -1,0 +1,8 @@
+#%PAM-1.0
+
+# Set up user limits from /etc/security/limits.conf.
+session    required   pam_limits.so
+
+@include common-auth
+@include common-account
+@include common-session-noninteractive

--- a/files/default/bullseye/etc/pam.d/sudo
+++ b/files/default/bullseye/etc/pam.d/sudo
@@ -1,0 +1,5 @@
+#%PAM-1.0
+
+@include common-auth
+@include common-account
+@include common-session-noninteractive

--- a/files/default/jammy/etc/pam.d/sudo
+++ b/files/default/jammy/etc/pam.d/sudo
@@ -1,0 +1,11 @@
+#%PAM-1.0
+
+# Set up user limits from /etc/security/limits.conf.
+session    required   pam_limits.so
+
+session    required   pam_env.so readenv=1 user_readenv=0
+session    required   pam_env.so readenv=1 envfile=/etc/default/locale user_readenv=0
+
+@include common-auth
+@include common-account
+@include common-session-noninteractive

--- a/manifests/profile/duo.pp
+++ b/manifests/profile/duo.pp
@@ -26,23 +26,11 @@ class nebula::profile::duo (
     'libpam-duo'
   ])
 
-  package { 'duo-unix':
-    ensure => absent
-  }
-
-  ['sudo'].each |$pamfile| {
-    file_line { "/etc/pam.d/${pamfile}: pam_duo":
-      path    => "/etc/pam.d/${pamfile}",
-      line    => 'auth required pam_duo.so',
-      after   => '^@include common-auth',
-      require => Package['sudo', 'libpam-duo'],
-    }
-
-    file_line { "/etc/pam.d/${pamfile}: remove /lib64/security/pam_duo":
-      ensure => absent,
-      path   => "/etc/pam.d/${pamfile}",
-      line   => 'auth required /lib64/security/pam_duo.so'
-    }
+  # Replace default /etc/pam.d/sudo
+  # This is only here to eliminate previous customizations
+  # Remove after January 2025
+  file { '/etc/pam.d/sudo':
+    source  => "puppet:///modules/nebula/default/${facts['os']['distro']['codename']}/etc/pam.d/sudo",
   }
 
   concat_fragment { '/etc/pam.d/sshd: pam_duo':

--- a/spec/classes/profile/duo_spec.rb
+++ b/spec/classes/profile/duo_spec.rb
@@ -24,11 +24,8 @@ describe "nebula::profile::duo" do
       end
 
       it do
-        expect(subject).to contain_file_line("/etc/pam.d/sudo: pam_duo")
-          .with_path("/etc/pam.d/sudo")
-          .with_line("auth required pam_duo.so")
-          .with_after("^@include common-auth")
-          .that_requires(["Package[sudo]", "Package[libpam-duo]"])
+        expect(subject).to contain_file("/etc/pam.d/sudo")
+          .with_source("puppet:///modules/nebula/default/#{facts[:os]["distro"]["codename"]}/etc/pam.d/sudo")
       end
 
       it do


### PR DESCRIPTION
- remove check for historical duo-unix package
- don't modify /etc/pam.d/sudo
- revert /etc/pam.d/sudo to default state on each supported distro
  - this should be removed after all hosts are reverted

Because:
- we confirmed this isn't needed
- reverting to the os package supplied config files makes upgrades safer and easier