### PR TITLE
profile::root: use individial files, not directory

### DIFF
--- a/manifests/profile/root.pp
+++ b/manifests/profile/root.pp
@@ -8,17 +8,14 @@ class nebula::profile::root (
   Boolean $manage = true,
 ) {
   if ($manage) {
-    file { '/root/':
-      ensure             => directory,
-      mode               => '0700',
-      source             => 'puppet:///modules/nebula/root/',
-      source_permissions => use,
-      recurse            => remote,
-      purge              => false,
-    }
-
-    file { '/root/.bash_profile':
-      ensure => absent
+    file {
+      default:
+        ensure => file,
+        mode   => '0644',
+      ;
+      '/root/.bashrc': source => 'puppet:///modules/nebula/root/.bashrc';
+      '/root/.profile': source => 'puppet:///modules/nebula/root/.profile';
+      '/root/.bash_profile': ensure => absent;
     }
   }
 }

--- a/spec/classes/profile/root_spec.rb
+++ b/spec/classes/profile/root_spec.rb
@@ -8,8 +8,8 @@ describe "nebula::profile::root" do
       let(:facts) { os_facts }
 
       it {
-        is_expected.to contain_file("/root/")
-          .with(recurse: "remote", purge: false, source_permissions: "use")
+        is_expected.to contain_file("/root/.bashrc")
+        is_expected.to contain_file("/root/.profile")
       }
       it {
         is_expected.to contain_file("/root/.bash_profile")


### PR DESCRIPTION
- fixes deprecation warning
- sets permissions correctly