### PR TITLE
release ht solr catalog at 6, not 6:30

### DIFF
--- a/manifests/profile/hathitrust/solr6/catalog.pp
+++ b/manifests/profile/hathitrust/solr6/catalog.pp
@@ -49,10 +49,10 @@ class nebula::profile::hathitrust::solr6::catalog (
   }
   if ($is_primary_site) {
     $cron_h = 6
-    $cron_m = 30
+    $cron_m = 0
   } else {
-    $cron_h = 6
-    $cron_m = 25
+    $cron_h = 5
+    $cron_m = 55
   }
   cron { 'catalog solr index release':
     hour    => $cron_h,

--- a/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
@@ -44,7 +44,7 @@ describe "nebula::profile::hathitrust::solr6::catalog" do
 
         it {
           expect(subject).to contain_cron("catalog solr index release")
-            .with(hour: 6, minute: 30)
+            .with(hour: 6, minute: 0)
         }
       end
 
@@ -60,7 +60,7 @@ describe "nebula::profile::hathitrust::solr6::catalog" do
 
         it {
           expect(subject).to contain_cron("catalog solr index release")
-            .with(hour: 6, minute: 25)
+            .with(hour: 5, minute: 55)
         }
       end
 


### PR DESCRIPTION
Solr release may cause a breif period where servers are unavailable to users. There seems to be no good reason to have this happen twice per day, so let's have catalog release at the same time as lss.