### PR TITLE
switch from ntpd to chrony

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -37,7 +37,6 @@ fixtures:
     lvm:                 {"repo": "puppetlabs/lvm",             "ref": "3.0.0" }
     mount_core:          {"repo": "puppetlabs/mount_core",      "ref": "1.3.0" }
     mysql:               {"repo": "puppetlabs/mysql",           "ref": "16.2.0"}
-    ntp:                 {"repo": "puppetlabs/ntp",             "ref": "11.0.0"}
     reboot:              {"repo": "puppetlabs/reboot",          "ref": "5.1.0" }
     sshkeys_core:        {"repo": "puppetlabs/sshkeys_core",    "ref": "2.5.0" }
     stdlib:              {"repo": "puppetlabs/stdlib",          "ref": "9.7.0" }

--- a/files/chrony/chrony.conf
+++ b/files/chrony/chrony.conf
@@ -1,0 +1,33 @@
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3

--- a/files/chrony/leapsectz.conf
+++ b/files/chrony/leapsectz.conf
@@ -1,0 +1,4 @@
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+leapsectz right/UTC

--- a/manifests/profile/ntp.pp
+++ b/manifests/profile/ntp.pp
@@ -1,32 +1,76 @@
-# Copyright (c) 2018 The Regents of the University of Michigan.
-# All Rights Reserved. Licensed according to the terms of the Revised
-# BSD License. See LICENSE.txt for details.
-
 # nebula::profile::ntp
 #
 # Manage ntp settings.
 #
+# @param pools List of ntp pools to use
 # @param servers List of ntp servers to use
 #
 # @example
 #   include nebula::profile::ntp
 class nebula::profile::ntp (
-  Array[String] $servers,
+  Optional[Array[String[1]]] $pools = undef,
+  Optional[Array[String[1]]] $servers = undef,
 ) {
-  class { 'ntp':
-    servers       => $servers,
-    # debian default
-    restrict      => [
-      '-4 default kod notrap nomodify nopeer noquery limited',
-      '-6 default kod notrap nomodify nopeer noquery limited',
-      '127.0.0.1',
-      '::1',
-      'source notrap nomodify noquery'
+  ensure_packages(
+    [
+      'ntp',
+      'ntpsec',
+      'sntp',
+      'ntpstat',
+      'systemd-timesyncd',
     ],
-    # enabled by default on debian, but we do not use it
-    iburst_enable => false
+    { ensure => purged }
+  )
+
+  package { 'chrony': }
+
+  service { 'chrony':
+    ensure  => 'running',
+    enable  => true,
+    require => Package['chrony'],
   }
 
-  # not installed by ntp class
-  package { 'ntpstat': }
+  file { '/etc/chrony/chrony.conf':
+    source  => 'puppet:///modules/nebula/chrony/chrony.conf',
+    notify  => Service['chrony'],
+    require => Package['chrony'],
+  }
+
+  # aws ntp servers smear leap seconds for us, so we need
+  # to disable chrony's leap second handling
+  unless fact('cloud.provider') == 'aws' {
+    file { '/etc/chrony/conf.d/leapsectz.conf':
+      source  => 'puppet:///modules/nebula/chrony/leapsectz.conf',
+      notify  => Service['chrony'],
+      require => Package['chrony'],
+    }
+  }
+
+  if $pools and size($pools) > 0 {
+    file { '/etc/chrony/sources.d/local-pools.sources':
+      content => $pools.map |$x| { "pool ${x} iburst\n" }.join,
+      notify  => Service['chrony'],
+      require => Package['chrony'],
+    }
+  }
+
+  if $servers and size($servers) > 0 {
+    file { '/etc/chrony/sources.d/local-servers.sources':
+      content => $servers.map |$x| { "server ${x} iburst\n" }.join,
+      notify  => Service['chrony'],
+      require => Package['chrony'],
+    }
+  }
+
+  file { default:
+    ensure  => directory,
+    recurse => true,
+    purge   => true,
+    ignore  => 'README',
+    notify  => Service['chrony'],
+    require => Package['chrony'],
+    ;
+    '/etc/chrony/conf.d/': ;
+    '/etc/chrony/sources.d/': ;
+  }
 }

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -25,6 +25,7 @@ class nebula::role::minimum (
     include nebula::profile::apt
     include nebula::profile::vim
     include nebula::profile::elastic::filebeat::configs::ulib
+    include nebula::profile::ntp
   }
 
   include nebula::profile::taghosts::tags

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,6 @@
     {"name": "puppetlabs/lvm",             "version_requirement": ">= 3.0.0  < 4.0.0" },
     {"name": "puppetlabs/mount_core",      "version_requirement": ">= 1.3.0  < 2.0.0" },
     {"name": "puppetlabs/mysql",           "version_requirement": ">= 16.2.0 < 17.0.0"},
-    {"name": "puppetlabs/ntp",             "version_requirement": ">= 11.0.0 < 12.0.0"},
     {"name": "puppetlabs/reboot",          "version_requirement": ">= 5.1.0  < 6.0.0" },
     {"name": "puppetlabs/sshkeys_core",    "version_requirement": ">= 2.5.0  < 3.0.0" },
     {"name": "puppetlabs/stdlib",          "version_requirement": ">= 9.7.0  < 10.0.0"},

--- a/spec/classes/profile/ntp_spec.rb
+++ b/spec/classes/profile/ntp_spec.rb
@@ -1,46 +1,118 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018 The Regents of the University of Michigan.
-# All Rights Reserved. Licensed according to the terms of the Revised
-# BSD License. See LICENSE.txt for details.
 require "spec_helper"
 
 describe "nebula::profile::ntp" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:pools) { "/etc/chrony/sources.d/local-pools.sources" }
+      let(:servers) { "/etc/chrony/sources.d/local-servers.sources" }
+      let(:ntp_opts) { " iburst" }
 
-      it do
-        expect(subject).to contain_service("ntp").with(
-          enable: true,
-          ensure: "running"
-        )
+      it "does not configure ntpd" do
+        is_expected.not_to contain_class("ntp")
+        is_expected.not_to contain_service("ntp")
+        is_expected.not_to contain_file("/etc/ntp.conf")
+        is_expected.not_to contain_file("/etc/ntpsec/ntp.conf")
       end
 
-      it { is_expected.to contain_package("ntp") }
-      it { is_expected.to contain_package("ntpstat") }
+      it "purges deprecated and conflicting ntp packages" do
+        %i[ntp ntpsec sntp ntpstat systemd-timesyncd].each do |package|
+          is_expected.to contain_package(package).with_ensure("purged")
+        end
+      end
 
-      it { is_expected.to contain_file("/etc/ntp.conf").with_content(%r{^server ntp.example.invalid$}m) }
+      it "installs chrony" do
+        is_expected.to contain_package("chrony")
+        is_expected.to contain_service("chrony")
+          .that_requires("Package[chrony]")
+        is_expected.to contain_file("/etc/chrony/chrony.conf")
+          .with_source("puppet:///modules/nebula/chrony/chrony.conf")
+          .that_requires("Package[chrony]")
+          .that_notifies("Service[chrony]")
+      end
 
-      it { is_expected.to contain_file("/etc/ntp.conf").that_notifies("Service[ntp]") }
+      it "deletes unmanaged drop in configs" do
+        %i[conf.d sources.d].each do |dir|
+          is_expected.to contain_file("/etc/chrony/#{dir}/")
+            .with_ensure("directory")
+            .that_requires("Package[chrony]")
+            .that_notifies("Service[chrony]")
+        end
+      end
 
-      context "with ntp[123].realdomain.com" do
+      context "with default hiera data" do
+        it "writes pool to source config" do
+          is_expected.to contain_file(pools)
+            .with_content(/^pool ntp.example.invalid#{ntp_opts}$/)
+        end
+      end
+
+      context "with pools, blank servers" do
         let(:params) do
           {
-            servers: [
-              "ntp1.realdomain.com",
-              "ntp2.realdomain.com",
-              "ntp3.realdomain.com"
-            ]
+            pools: ["time.com", "time.net"],
+            servers: []
           }
         end
 
-        [
-          "ntp1.realdomain.com",
-          "ntp2.realdomain.com",
-          "ntp3.realdomain.com"
-        ].each do |server|
-          it { is_expected.to contain_file("/etc/ntp.conf").with_content(%r{^server #{server}$}m) }
+        it "writes pools source config" do
+          is_expected.to contain_file(pools)
+            .with_content(/^pool time.com#{ntp_opts}$/)
+            .with_content(/^pool time.net#{ntp_opts}$/)
+        end
+      end
+
+      context "with servers only" do
+        let(:params) do
+          {servers: ["foo.com", "bar.com"]}
+        end
+
+        it "writes pools from heira data to source config" do
+          is_expected.to contain_file(pools)
+            .with_content(/^pool ntp.example.invalid#{ntp_opts}$/)
+        end
+        it "writes servers source config" do
+          is_expected.to contain_file(servers)
+            .with_content(/^server foo.com#{ntp_opts}$/)
+            .with_content(/^server bar.com#{ntp_opts}$/)
+        end
+      end
+
+      context "with servers and pools" do
+        let(:params) do
+          {
+            pools: ["time.com", "time.net"],
+            servers: ["10.1.1.1", "10.2.2.2"]
+          }
+        end
+
+        it "writes pools source config" do
+          is_expected.to contain_file(pools)
+            .with_content(/^pool time.com#{ntp_opts}$/)
+            .with_content(/^pool time.net#{ntp_opts}$/)
+        end
+        it "writes servers source config" do
+          is_expected.to contain_file(servers)
+            .with_content(/^server 10.1.1.1#{ntp_opts}$/)
+            .with_content(/^server 10.2.2.2#{ntp_opts}$/)
+        end
+      end
+
+      context "default facts" do
+        it "enables leap second handling" do
+          is_expected.to contain_file("/etc/chrony/conf.d/leapsectz.conf")
+            .with_source("puppet:///modules/nebula/chrony/leapsectz.conf")
+        end
+      end
+
+      context "in aws" do
+        # let(:facts) { os_facts.merge(datacenter: "mydatacenter") }
+        let(:facts) { os_facts.merge("cloud" => {"provider" => "aws"}) }
+
+        it "disables leap second handling" do
+          is_expected.not_to contain_file("/etc/chrony/conf.d/leapsectz.conf")
         end
       end
     end

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -65,7 +65,7 @@ nebula::profile::base::environment::vars: {}
 nebula::profile::exim4::root_email: root@default.invalid
 nebula::profile::exim4::relay_domain: exim.default.invalid
 
-nebula::profile::ntp::servers:
+nebula::profile::ntp::pools:
 - ntp.example.invalid
 
 nebula::profile::duo::ikey: ikey.default.invalid


### PR DESCRIPTION
- purge ntp, supporting packages
- install and configure chrony
- add nebula::profile::ntp::pools key to differentiate pools and servers
  - this will require a corresponding update to heira data
- remove ntp module
- intentionally not using chrony module:
  - our usage is too simple to justify a new dependency
  - ~because module set iburst by default, this update would actually be more complex with the module, not less~
- add ntp profile to mimimum role