### PR TITLE
resolv_conf: disable systemd-resolved

### DIFF
--- a/manifests/resolv_conf.pp
+++ b/manifests/resolv_conf.pp
@@ -14,4 +14,19 @@ class nebula::resolv_conf (
     mode    => $mode,
     content => template('nebula/resolv_conf/resolv.conf.erb'),
   }
+
+  # we never want systemd-resolved
+  # on older Debian releases it's part of systemd, so we can't purge it
+  if $facts['os']['distro']['codename'] in ['jammy','bullseye'] {
+    service { 'systemd-resolved':
+      ensure => stopped,
+      enable => false,
+      before => File['/etc/resolv.conf'],
+    }
+  } else {
+    package { 'systemd-resolved':
+      ensure => absent,
+      before => File['/etc/resolv.conf'],
+    }
+  }
 }

--- a/spec/classes/resolv_conf_spec.rb
+++ b/spec/classes/resolv_conf_spec.rb
@@ -54,6 +54,20 @@ describe "nebula::resolv_conf" do
             .with_mode("0664")
         end
       end
+
+      case os
+      when "debian-11-x86_64", "ubuntu-22.04-x86_64"
+        it "disables systemd-resolved service" do
+          is_expected.to contain_service("systemd-resolved")
+            .with_enable("false")
+            .with_ensure("stopped")
+        end
+      when "debian-12-x86_64", "ubuntu-24.04-x86_64"
+        it "removes systemd-resolved package" do
+          is_expected.to contain_package("systemd-resolved")
+            .with_ensure("absent")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
On Ubuntu 22.04 jammy, the `systemd-resolved` service is running, and it shouldn't be.

This is part of the resolv_conf class because `systemd-resolved` presumes to overwrite /etc/resolv.conf.

I have confirmed:
* `systemd-resolved` service exists but is stopped+disabled on all bullseye (Debian 11) hosts
* `systemd-resolved` package is purged on all bookworm (Debian 12) hosts

…so on Debian this will be a no-op, just confirming the status quo.