### PR TITLE
grub: remove ixgbe flags

### DIFF
--- a/manifests/profile/grub.pp
+++ b/manifests/profile/grub.pp
@@ -20,7 +20,7 @@ class nebula::profile::grub (
     $grub_serial_command = 'serial --unit=0 --speed=9600'
   } else {
     $getty = 'serial-getty@ttyS1'
-    $default_grub_cmdline = 'console=tty0 console=ttyS1,115200n8 ixgbe.allow_unsupported_sfp=1'
+    $default_grub_cmdline = 'console=tty0 console=ttyS1,115200n8'
     $grub_terminal = 'console'
     $grub_serial_command = 'serial'
   }

--- a/spec/classes/profile/grub_spec.rb
+++ b/spec/classes/profile/grub_spec.rb
@@ -38,7 +38,7 @@ describe "nebula::profile::grub" do
 
           it {
             is_expected.to contain_file("/etc/default/grub.d/grub.cfg")
-              .with_content(/^GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8 ixgbe.allow_unsupported_sfp=1"$/)
+              .with_content(/^GRUB_CMDLINE_LINUX="console=tty0 console=ttyS1,115200n8"$/)
               .with_content(/^GRUB_CMDLINE_LINUX_DEFAULT=""$/)
               .with_content(/^GRUB_SERIAL_COMMAND="serial"$/)
               .with_content(/^GRUB_TERMINAL="console"$/)


### PR DESCRIPTION
We're setting this in hiera for each of the (few) hosts that still use the ixgbe kernel module.