### PR TITLE
apt: don't anger dpkg when removing 20apt-esm-hook

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -157,8 +157,17 @@ class nebula::profile::apt (
       'security' : release => "${facts['os']['distro']['codename']}-security";
     }
 
+    # remove unwanted recommendeds from `ubuntu-server` package
     package { 'landscape-common': ensure => purged }
     package { 'open-vm-tools': ensure => purged }
-    file { '/etc/apt/apt.conf.d/20apt-esm-hook.conf': ensure => absent }
+
+    # disable ubuntu subscription advertisements
+    exec { 'disable 20apt-esm-hook.conf':
+      creates => '/etc/apt/apt.conf.d/20apt-esm-hook.conf.disabled',
+      timeout => 30,
+      command => "/usr/bin/dpkg-divert --rename \
+--divert /etc/apt/apt.conf.d/20apt-esm-hook.conf.disabled \
+--add /etc/apt/apt.conf.d/20apt-esm-hook.conf"
+    }
   }
 }

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -162,6 +162,12 @@ describe "nebula::profile::apt" do
             .with_repos("main restricted universe")
             .with_release("#{facts[:lsbdistcodename]}-backports")
         end
+
+        it "disables 20apt-esm-hook.conf" do
+          is_expected.to contain_exec("disable 20apt-esm-hook.conf")
+            .with_creates("/etc/apt/apt.conf.d/20apt-esm-hook.conf.disabled")
+            .with_command("/usr/bin/dpkg-divert --rename --divert /etc/apt/apt.conf.d/20apt-esm-hook.conf.disabled --add /etc/apt/apt.conf.d/20apt-esm-hook.conf")
+        end
       end
 
       it { is_expected.not_to contain_apt__source("hpe") }


### PR DESCRIPTION
Instead of `rm`, use `dpkg-divert` to relocate this file so dpkg doesn't think it's missing.