### PR TITLE
Set up Prometheus remote_write to Mimir

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -133,6 +133,20 @@ class nebula::profile::prometheus (
     source => "puppet:///ssl-certs/prometheus-pki/${::networking['fqdn']}.key",
   }
 
+  file { '/etc/prometheus/tls/mimir-client.crt':
+    source => "/etc/puppetlabs/puppet/ssl/certs/${::networking['fqdn']}.pem",
+    mode   => '0644',
+    owner  => 65534,
+    group  => 65534,
+  }
+
+  file { '/etc/prometheus/tls/mimir-client.key':
+    source => "/etc/puppetlabs/puppet/ssl/private_keys/${::networking['fqdn']}.pem",
+    mode   => '0600',
+    owner  => 65534,
+    group  => 65534,
+  }
+
   file { '/opt/prometheus':
     ensure => 'directory',
     owner  => 65534,

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -140,6 +140,22 @@ describe "nebula::profile::prometheus" do
           .that_requires("File[/etc/prometheus/tls]")
       end
 
+      it do
+        expect(subject).to contain_file("/etc/prometheus/tls/mimir-client.crt")
+          .with_source("/etc/puppetlabs/puppet/ssl/certs/#{facts[:fqdn]}.pem")
+          .with_mode("0644")
+          .with_owner(65534)
+          .with_group(65534)
+      end
+
+      it do
+        expect(subject).to contain_file("/etc/prometheus/tls/mimir-client.key")
+          .with_source("/etc/puppetlabs/puppet/ssl/private_keys/#{facts[:fqdn]}.pem")
+          .with_mode("0600")
+          .with_owner(65534)
+          .with_group(65534)
+      end
+
       %w[ca.crt client.crt client.key].each do |filename|
         it do
           expect(subject).to contain_docker__run("prometheus")

--- a/templates/profile/prometheus/config.yml.erb
+++ b/templates/profile/prometheus/config.yml.erb
@@ -20,6 +20,11 @@ alerting:
       - <%= alert_manager %>
 <% end -%>
 <% end -%>
+remote_write:
+  - url: https://mimir.lib.umich.edu/push
+    tls_config:
+      cert_file: /tls/mimir-client.crt
+      key_file: /tls/mimir-client.key
 scrape_configs:
 - job_name: prometheus
   static_configs:


### PR DESCRIPTION
For now, we are using the puppet-issued machine cert for authentication to Mimir. The config will reference it under /etc/prometheus/tls, and we can decide later whether this is the right CA/cert or auth method.

This setup is partly motivated by the apparent behavior that Prometheus resolves paths relative to its config, even if starting with a slash, but it is also useful indirection from the Puppet mechanics.