### PR TITLE
fix puppet lint

### DIFF
--- a/manifests/profile/afs.pp
+++ b/manifests/profile/afs.pp
@@ -66,7 +66,7 @@ class nebula::profile::afs (
   }
 
   file { '/usr/local/skel/sys.profile':
-    source  => 'puppet:///modules/nebula/skel.txt',
+    source => 'puppet:///modules/nebula/skel.txt',
   }
 
   file { '/usr/local/skel':

--- a/manifests/profile/apache/auth_openidc.pp
+++ b/manifests/profile/apache/auth_openidc.pp
@@ -27,7 +27,7 @@ class nebula::profile::apache::auth_openidc (
   String $oidc_crypto,
 ) {
   apache::mod { 'auth_openidc':
-    package       => 'libapache2-mod-auth-openidc',
+    package => 'libapache2-mod-auth-openidc',
   }
   include apache::mod::authn_core
   include apache::mod::authz_user

--- a/manifests/profile/certbot_cloudflare.pp
+++ b/manifests/profile/certbot_cloudflare.pp
@@ -40,11 +40,11 @@ class nebula::profile::certbot_cloudflare (
   $certs.each |$service, $domains| {
     $domains.each |$main_domain, $alt_domains| {
       concat { "${cert_dir}/${main_domain}.crt":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${cert_dir}/${main_domain}.key":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${haproxy_cert_dir}/${service}/${main_domain}.pem":
@@ -77,7 +77,7 @@ class nebula::profile::certbot_cloudflare (
 
   $simple_certs.each |$domain, $sans| {
     concat { "${cert_dir}/${domain}.crt":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat_fragment { "${cert_dir}/${domain}.crt cert":
@@ -86,7 +86,7 @@ class nebula::profile::certbot_cloudflare (
     }
 
     concat { "${cert_dir}/${domain}.key":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat_fragment { "${cert_dir}/${domain}.key key":

--- a/manifests/profile/certbot_incommon.pp
+++ b/manifests/profile/certbot_incommon.pp
@@ -21,11 +21,11 @@ class nebula::profile::certbot_incommon (
   $certs.each |$service, $domains| {
     $domains.each |$main_domain, $alt_domains| {
       concat { "${cert_dir}/${main_domain}.crt":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${cert_dir}/${main_domain}.key":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${haproxy_cert_dir}/${service}/${main_domain}.pem":
@@ -58,11 +58,11 @@ class nebula::profile::certbot_incommon (
 
   $simple_certs.each |$domain, $sans| {
     concat { "${cert_dir}/${domain}.crt":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat { "${cert_dir}/${domain}.key":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat_fragment { "${cert_dir}/${domain}.crt cert":

--- a/manifests/profile/certbot_route53.pp
+++ b/manifests/profile/certbot_route53.pp
@@ -42,11 +42,11 @@ class nebula::profile::certbot_route53 (
   $certs.each |$service, $domains| {
     $domains.each |$main_domain, $alt_domains| {
       concat { "${cert_dir}/${main_domain}.crt":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${cert_dir}/${main_domain}.key":
-        group  => 'puppet',
+        group => 'puppet',
       }
 
       concat { "${haproxy_cert_dir}/${service}/${main_domain}.pem":
@@ -79,11 +79,11 @@ class nebula::profile::certbot_route53 (
 
   $simple_certs.each |$domain, $sans| {
     concat { "${cert_dir}/${domain}.crt":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat { "${cert_dir}/${domain}.key":
-      group  => 'puppet',
+      group => 'puppet',
     }
 
     concat_fragment { "${domain}.crt cert":

--- a/manifests/profile/fulcrum/base.pp
+++ b/manifests/profile/fulcrum/base.pp
@@ -12,7 +12,7 @@ class nebula::profile::fulcrum::base (
   ])
 
   host { 'localhost':
-    ip           => '127.0.0.1',
+    ip => '127.0.0.1',
   }
 
   host { $::networking['hostname']:

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -32,7 +32,7 @@ class nebula::profile::haproxy (
     '/etc/default/haproxy':
       content => template('nebula/profile/haproxy/default.erb');
     '/etc/haproxy/errors/hsts400.http':
-      source  => 'puppet:///modules/nebula/haproxy/errors/hsts400.http';
+      source => 'puppet:///modules/nebula/haproxy/errors/hsts400.http';
     '/etc/haproxy/global_badrobots.txt':
       content => $global_badrobots;
   }

--- a/manifests/profile/hathitrust/hosts.pp
+++ b/manifests/profile/hathitrust/hosts.pp
@@ -51,7 +51,7 @@ class nebula::profile::hathitrust::hosts (
 
   $solr_search.each |Integer $i, String $ip| {
     host { "solr-sdr-search-${$i+1}":
-      ip      => $ip
+      ip => $ip
     }
   }
 

--- a/manifests/profile/hathitrust/secure_rsync.pp
+++ b/manifests/profile/hathitrust/secure_rsync.pp
@@ -40,7 +40,7 @@ class nebula::profile::hathitrust::secure_rsync (
     '/etc/systemd/system/secure-rsync.service':
       content  => template('nebula/profile/hathitrust/secure_rsync/secure-rsync.service.erb');
     "${rsync_home}/stunnel.conf":
-      content  => template('nebula/profile/hathitrust/secure_rsync/stunnel.conf.erb');
+      content => template('nebula/profile/hathitrust/secure_rsync/stunnel.conf.erb');
     "${rsync_home}/rsyncd.conf":
       content => template('nebula/profile/hathitrust/rsync/rsyncd.conf.erb');
     "${rsync_home}/server.key":

--- a/manifests/profile/logrotate.pp
+++ b/manifests/profile/logrotate.pp
@@ -26,7 +26,7 @@ class nebula::profile::logrotate {
       create_mode => '0664',
       ;
     'btmp':
-      path        => '/var/log/btmp',
+      path => '/var/log/btmp',
       ;
   }
 }

--- a/manifests/profile/monitor_pl.pp
+++ b/manifests/profile/monitor_pl.pp
@@ -60,7 +60,7 @@ class nebula::profile::monitor_pl (
 
   concat_fragment {
     default:
-      tag  => 'monitor_config';
+      tag => 'monitor_config';
 
     'monitor nfs mounts':
       content => { 'nfs' => $nfs_mounts }.to_yaml();

--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -170,7 +170,7 @@ class nebula::profile::prometheus (
     }
   } else {
     class { 'nginx':
-      server_tokens        => 'off',
+      server_tokens => 'off',
     }
     nginx::resource::server { 'https-forwarder':
       server_name       => [$::networking['fqdn']],

--- a/manifests/profile/ruby.pp
+++ b/manifests/profile/ruby.pp
@@ -107,7 +107,7 @@ class nebula::profile::ruby (
   }
 
   file { '/usr/local/rubytests/':
-    ensure  => 'directory',
+    ensure => 'directory',
   }
 
   file { '/etc/cron.daily/ruby-health-check':

--- a/manifests/role/webhost/htvm.pp
+++ b/manifests/role/webhost/htvm.pp
@@ -24,7 +24,7 @@ class nebula::role::webhost::htvm (
   include nebula::profile::hathitrust::babel_logs
 
   class { 'nebula::profile::hathitrust::imgsrv':
-    sdrview  => 'full'
+    sdrview => 'full'
   }
 
   include nebula::profile::hathitrust::apache

--- a/manifests/virtual/users.pp
+++ b/manifests/virtual/users.pp
@@ -50,7 +50,7 @@ class nebula::virtual::users (
       ;
 
       $username:
-        *          => $data,
+        * => $data,
       ;
     }
   }


### PR DESCRIPTION
`s/ +=>/ =>/`

Not clear when this changed, but it's breaking CI. This should fix all the CI errors that are holding up #807.

Bizzarely, `bundle exec rake lint` is fine with both the before and after version on my local machine.

