### PR TITLE
Add cf.* serveralias for hathitrust web

### DIFF
--- a/manifests/profile/hathitrust/apache/babel.pp
+++ b/manifests/profile/hathitrust/apache/babel.pp
@@ -76,6 +76,7 @@ class nebula::profile::hathitrust::apache::babel (
 
   apache::vhost { "${servername} ssl":
     servername                  => $servername,
+    serveraliases               => ["cf.${servername}"],
     use_canonical_name          => 'On',
     port                        => '443',
     docroot                     => $sdrroot,

--- a/manifests/profile/hathitrust/apache/catalog.pp
+++ b/manifests/profile/hathitrust/apache/catalog.pp
@@ -35,6 +35,7 @@ class nebula::profile::hathitrust::apache::catalog (
 
   apache::vhost { "${servername} ssl":
     servername         => $servername,
+    serveraliases      => ["cf.${servername}"],
     use_canonical_name => 'On',
     port               => 443,
     manage_docroot     => false,

--- a/manifests/profile/hathitrust/apache/www.pp
+++ b/manifests/profile/hathitrust/apache/www.pp
@@ -35,6 +35,7 @@ class nebula::profile::hathitrust::apache::www (
 
   apache::vhost { "${servername} ssl":
     servername         => $servername,
+    serveraliases      => ["cf.${servername}"],
     use_canonical_name => 'On',
     port               => '443',
     manage_docroot     => false,

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -82,6 +82,16 @@ describe "nebula::profile::hathitrust::apache" do
         end
       end
 
+      describe "cloudflare aliases" do
+        %w[babel catalog www].each do |vhost|
+          it {
+            expect(subject).to contain_apache__vhost("#{vhost}.hathitrust.org ssl").with(
+              serveraliases: ["cf.#{vhost}.hathitrust.org"]
+            )
+          }
+        end
+      end
+
       context "with a domain and prefix specified" do
         let(:params) do
           {


### PR DESCRIPTION
cf.catalog.hathitrust.org
cf.babel.hathitrust.org
cf.www.hathitrust.org

for cloudflare testing