### PR TITLE
use TLSv1.3 for apache

### DIFF
--- a/manifests/apache/www_lib_vhost.pp
+++ b/manifests/apache/www_lib_vhost.pp
@@ -113,8 +113,6 @@ define nebula::apache::www_lib_vhost (
     priority                    => $priority,
     ssl                         => $ssl,
     # unused if ssl is false
-    ssl_protocol                => '+TLSv1.2',
-    ssl_cipher                  => 'ECDHE-RSA-AES256-GCM-SHA384',
     ssl_cert                    => $ssl_cert,
     ssl_key                     => $ssl_key,
     rewrites                    => $rewrites,

--- a/manifests/profile/apache.pp
+++ b/manifests/profile/apache.pp
@@ -49,6 +49,12 @@ class nebula::profile::apache (
     conf_enabled           => '/etc/apache2/conf-enabled',
   }
 
+  class { 'apache::mod::ssl':
+    ssl_protocol         => '-all +TLSv1.3',
+    ssl_openssl_conf_cmd => 'Curves X25519:prime256v1:secp384r1',
+    ssl_honorcipherorder => false
+  }
+
   class { 'apache::mod::prefork':
     startservers           => 10,
     minspareservers        => 5,

--- a/manifests/profile/apache/standalone_app_host.pp
+++ b/manifests/profile/apache/standalone_app_host.pp
@@ -40,9 +40,14 @@ class nebula::profile::apache::standalone_app_host (
   include apache::mod::proxy
   include apache::mod::proxy_http
   include apache::mod::headers
-  include apache::mod::ssl
   include apache::mod::rewrite
   include apache::mod::setenvif
+
+  class { 'apache::mod::ssl':
+    ssl_protocol         => '-all +TLSv1.3',
+    ssl_openssl_conf_cmd => 'Curves X25519:prime256v1:secp384r1',
+    ssl_honorcipherorder => false
+  }
 
   apache::listen { ['80','443']: }
 }

--- a/manifests/profile/hathitrust/apache.pp
+++ b/manifests/profile/hathitrust/apache.pp
@@ -65,6 +65,12 @@ class nebula::profile::hathitrust::apache (
     conf_enabled           => '/etc/apache2/conf-enabled',
   }
 
+  class { 'apache::mod::ssl':
+    ssl_protocol         => '-all +TLSv1.3',
+    ssl_openssl_conf_cmd => 'Curves X25519:prime256v1:secp384r1',
+    ssl_honorcipherorder => false
+  }
+
   class { 'apache::mod::prefork':
     startservers           => 10,
     minspareservers        => 10,
@@ -150,8 +156,6 @@ class nebula::profile::hathitrust::apache (
     haproxy_ips    => $haproxy_ips,
     ssl_params     => {
       ssl            => true,
-      ssl_protocol   => '+TLSv1.2',
-      ssl_cipher     => 'ECDHE-RSA-AES256-GCM-SHA384',
       ssl_cert       => '/etc/ssl/certs/www.hathitrust.org.crt',
       ssl_key        => '/etc/ssl/private/www.hathitrust.org.key',
     },

--- a/manifests/profile/http_fileserver.pp
+++ b/manifests/profile/http_fileserver.pp
@@ -53,6 +53,12 @@ class nebula::profile::http_fileserver (
     }
   }
 
+  class { 'apache::mod::ssl':
+    ssl_protocol         => '-all +TLSv1.3',
+    ssl_openssl_conf_cmd => 'Curves X25519:prime256v1:secp384r1',
+    ssl_honorcipherorder => false
+  }
+
   apache::vhost { "${::networking['fqdn']} http":
     servername => $::networking['fqdn'],
     port       => 80,

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -73,8 +73,6 @@ describe "nebula::profile::hathitrust::apache" do
             expect(subject).to contain_apache__vhost("#{vhost}.hathitrust.org ssl").with(
               servername: "#{vhost}.hathitrust.org",
               ssl: true,
-              ssl_protocol: "+TLSv1.2",
-              ssl_cipher: "ECDHE-RSA-AES256-GCM-SHA384",
               ssl_cert: "/etc/ssl/certs/www.hathitrust.org.crt",
               ssl_key: "/etc/ssl/private/www.hathitrust.org.key"
             )

--- a/templates/profile/haproxy/haproxy.cfg.erb
+++ b/templates/profile/haproxy/haproxy.cfg.erb
@@ -1,29 +1,39 @@
 # Managed by puppet (nebula/profile/haproxy/haproxy.cfg.erb)
 
 global
+  # Debian 11 defaults
   log /dev/log  local0
   log /dev/log  local1 notice
   chroot /var/lib/haproxy
-  stats socket /run/haproxy/admin.sock mode 660 level admin
+  stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
   stats timeout 30s
   user haproxy
   group haproxy
   daemon
   ca-base /etc/ssl/certs
   crt-base /etc/ssl/private
+  # 2018-08-10; tuning for our level of usage
   maxconn 16384
 
-ssl-default-bind-ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-CCM:DHE-RSA-AES256-CCM8:DHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-CCM:DHE-RSA-AES128-CCM8:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA
+  # adapted from https://ssl-config.mozilla.org/#server=haproxy
+  ssl-default-bind-curves X25519:prime256v1:secp384r1
+  ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+  ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-bind-options prefer-client-ciphers ssl-min-ver TLSv1.2 no-tls-tickets
 
-  ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11 
-  tune.ssl.default-dh-param 2048
+  ssl-default-server-curves X25519:prime256v1:secp384r1
+  ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+  ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-server-options ssl-min-ver TLSv1.2 no-tls-tickets
 
 defaults
+  # Debian 11 defaults
   log  global
   mode  http
   option  httplog
   option  dontlognull
   timeout connect 5000
+  # 2018-08-10; prevent observed 504 errors
   timeout client  180000
   timeout server  360000
   errorfile 400 /etc/haproxy/errors/400.http
@@ -33,10 +43,10 @@ defaults
   errorfile 502 /etc/haproxy/errors/502.http
   errorfile 503 /etc/haproxy/errors/503.http
   errorfile 504 /etc/haproxy/errors/504.http
+  # local/custom lit config
   balance roundrobin
   cookie STICKY insert indirect nocache
   option httpchk GET /monitor/monitor.pl
   default-server inter 20s fall 3 rise 2
   timeout check 4s
   option log-health-checks
-

--- a/templates/profile/kubernetes/haproxy/haproxy.cfg.erb
+++ b/templates/profile/kubernetes/haproxy/haproxy.cfg.erb
@@ -1,31 +1,49 @@
 # Managed by puppet (nebula/profile/kubernetes/haproxy/haproxy.cfg.erb)
 
 global
+  # Debian 11 defaults
   log /dev/log  local0
   log /dev/log  local1 notice
   chroot /var/lib/haproxy
-  stats socket /run/haproxy/admin.sock mode 660 level admin
+  stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
   stats timeout 30s
   user haproxy
   group haproxy
   daemon
   ca-base /etc/ssl/certs
   crt-base /etc/ssl/private
+  # 2018-08-10; tuning for our level of usage
   maxconn 16384
 
-ssl-default-bind-ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-CCM:DHE-RSA-AES256-CCM8:DHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-CCM:DHE-RSA-AES128-CCM8:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA
+  # adapted from https://ssl-config.mozilla.org/#server=haproxy
+  ssl-default-bind-curves X25519:prime256v1:secp384r1
+  ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+  ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-bind-options prefer-client-ciphers ssl-min-ver TLSv1.2 no-tls-tickets
 
-  ssl-default-bind-options no-sslv3
-  tune.ssl.default-dh-param 2048
+  ssl-default-server-curves X25519:prime256v1:secp384r1
+  ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+  ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+  ssl-default-server-options ssl-min-ver TLSv1.2 no-tls-tickets
 
 defaults
+  # Debian 11 defaults
   log  global
   mode  http
   option  httplog
   option  dontlognull
   timeout connect 5000
+  # 2018-08-10; prevent observed 504 errors
   timeout client  180000
   timeout server  360000
+
+
+
+
+
+
+
+  # local/custom lit config
   balance roundrobin
   cookie STICKY insert indirect nocache
   option httpchk GET /monitor/monitor.pl


### PR DESCRIPTION
Since apache only serves internal requests, we should have no need to support TLSv1.2.

- remove TLS cipher settings from all vhosts
- add global config for mod_ssl
  - only allow TLSv1.3
  - set curve preferences
  - don't set preferred cipher, as all TLSv1.3 ciphers are secure
  - accept client cipher preference
