### PR TITLE
Allow quoted queries sent to taghosts

### DIFF
--- a/templates/profile/taghosts/taghosts.sh.erb
+++ b/templates/profile/taghosts/taghosts.sh.erb
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+[ $# = 1 ] && set $1
 set -eo pipefail
 IFS=$'\n\t'
 PROG="$0"


### PR DESCRIPTION
Previously, taghosts required each tag be its own separate argument i.e.

    $ taghosts tag1 tag2 -v not-tag3

or even

    $ taghosts "tag1" "tag2" -v "not-tag3"

but

    $ taghosts "tag1 tag2 -v not-tag3"

would not work. This can be a pain point, as exechosts *requires* that you quote the taghosts query, so this line adds support for taghosts queries that let you

    -taghosts
    +exechosts

and get on with your day, if you already added in quotes.