### PR TITLE
Add etcd db size alerts

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -353,6 +353,24 @@ groups:
     annotations:
       summary: 'MySQL Connection Count is approaching MAX on {{$labels.hostname}}'
       description: 'MySQL Connection Count is approaching MAX'
+  - alert: "EtcdDatabaseFillingUpFast"
+    expr: >
+      max by (datacenter) (delta(etcd_debugging_mvcc_db_total_size_in_bytes[5m])) > 10000
+    for: "30m"
+    labels:
+      severity: "ticket"
+    annotations:
+      summary: "{{$labels.datacenter}} etcd db filling up fast"
+      dashboard: "https://grafana.lib.umich.edu/d/aeihrf5qwmccge/all-etcd-clusters"
+  - alert: "BigEtcdDatabase"
+    expr: >
+      max by (datacenter) (etcd_debugging_mvcc_db_total_size_in_bytes) > 500 * 1024 * 1024
+    for: "30m"
+    labels:
+      severity: "ticket"
+    annotations:
+      summary: "{{$labels.datacenter}} etcd db larger than 500Mi"
+      dashboard: "https://grafana.lib.umich.edu/d/aeihrf5qwmccge/all-etcd-clusters"
 
   # These are aggregate rules for federated collection across our full
   # system. By putting them here, we essentially precompile them.


### PR DESCRIPTION
EtcdDatabaseFillingUpFast should probably be `severity: page`, but I don't want to do that without letting this live for a while.

EtcdDatabaseTooBig exists mostly so that alerts don't stop when the db finishes running out of space. It could be set closer to 100% full, but for years, "normal" etcd db size has been strictly less than 25% full, so 75% seems reasonably high to say there is a problem, even if it's no longer increasing.

This week's incident would have fired EtcdDatabaseFillingUpFast but would not have fired EtcdDatabaseTooBig, as it never got above 1.2Gi, so I'd hear an argument for decreasing the threshold to e.g. 1Gi.