### PR TITLE
root bashrc: colorize `ip`, `rgrep`

### DIFF
--- a/files/root/.bashrc
+++ b/files/root/.bashrc
@@ -19,6 +19,8 @@ alias la='ls -AF'
 alias grep='grep --color=auto'
 alias fgrep='fgrep --color=auto'
 alias egrep='egrep --color=auto'
+alias rgrep='rgrep --color=auto'
+alias ip='ip -color=auto'
 
 # history
 HISTCONTROL=ignoredups:ignorespace


### PR DESCRIPTION
- `ip -color` make ip approximately 100x more readable
- `rgrep --color` added for consistancy