### PR TITLE
Mark two alerts as less severe

### DIFF
--- a/templates/profile/prometheus/rules.yml.erb
+++ b/templates/profile/prometheus/rules.yml.erb
@@ -65,7 +65,7 @@ groups:
     expr: 'up{job!="node",job!="ipmi"} == 0'
     for: 30m
     labels:
-      severity: page
+      severity: "ticket"
   - alert: LightsOutDeviceDown
     annotations:
       summary: '{{$labels.instance}} isn''t responding to Prometheus (via {{$labels.via}})'
@@ -125,7 +125,7 @@ groups:
       ) > 0.95
     for: 30m
     labels:
-      severity: ticket
+      severity: "info"
   - alert: DiskFull
     annotations:
       summary: 'Filesystem {{$labels.hostname}}:{{$labels.mountpoint}} is full.'


### PR DESCRIPTION
GenericMetricsExporterDown alerts are for prometheus metrics exporters other than node and ipmi, and they are usually very confusing and also nonemergencies, so a page is not warranted.

DiskPressure (disk > 95.0% full) alerts are much less useful than the "filling up fast" alert, so we're demoting it from ticket to info.