### PR TITLE
Prometheus certificate keys should be 600 not 644

### DIFF
--- a/manifests/profile/prometheus.pp
+++ b/manifests/profile/prometheus.pp
@@ -123,14 +123,26 @@ class nebula::profile::prometheus (
 
   file { '/etc/prometheus/tls/ca.crt':
     source => 'puppet:///ssl-certs/prometheus-pki/ca.crt',
+    mode   => '0644',
+    owner  => 'nobody',
+    group  => 'nogroup',
+    notify => Docker::Run['prometheus'],
   }
 
   file { '/etc/prometheus/tls/client.crt':
     source => "puppet:///ssl-certs/prometheus-pki/${::networking['fqdn']}.crt",
+    mode   => '0644',
+    owner  => 'nobody',
+    group  => 'nogroup',
+    notify => Docker::Run['prometheus'],
   }
 
   file { '/etc/prometheus/tls/client.key':
     source => "puppet:///ssl-certs/prometheus-pki/${::networking['fqdn']}.key",
+    mode   => '0600',
+    owner  => 'nobody',
+    group  => 'nogroup',
+    notify => Docker::Run['prometheus'],
   }
 
   file { '/opt/prometheus':

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -125,18 +125,30 @@ describe "nebula::profile::prometheus" do
       it do
         expect(subject).to contain_file("/etc/prometheus/tls/ca.crt")
           .with_source("puppet:///ssl-certs/prometheus-pki/ca.crt")
+          .with_mode("0644")
+          .with_owner("nobody")
+          .with_group("nogroup")
+          .that_notifies("Docker::Run[prometheus]")
           .that_requires("File[/etc/prometheus/tls]")
       end
 
       it do
         expect(subject).to contain_file("/etc/prometheus/tls/client.crt")
           .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.crt")
+          .with_mode("0644")
+          .with_owner("nobody")
+          .with_group("nogroup")
+          .that_notifies("Docker::Run[prometheus]")
           .that_requires("File[/etc/prometheus/tls]")
       end
 
       it do
         expect(subject).to contain_file("/etc/prometheus/tls/client.key")
           .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.key")
+          .with_mode("0600")
+          .with_owner("nobody")
+          .with_group("nogroup")
+          .that_notifies("Docker::Run[prometheus]")
           .that_requires("File[/etc/prometheus/tls]")
       end
 


### PR DESCRIPTION
Noticed this while renewing. These aren't servers anyone should be able to connect to directly, but security is about layers, so let's tighten this layer.