### PR TITLE
rm sudo group

### DIFF
--- a/manifests/profile/users.pp
+++ b/manifests/profile/users.pp
@@ -9,5 +9,5 @@
 # @example
 #   include nebula::profile::users
 class nebula::profile::users {
-  nebula::usergroup { 'sudo': }
+  # nebula::usergroup { 'sudo': }
 }


### PR DESCRIPTION
Don't install sudo group by default.

If we want to do this, this is almost certainly not the way. Just floating the idea.