### PR TITLE
Raise vm.max_map_count for OpenSearch

### DIFF
--- a/templates/profile/kubernetes/kubeadm_sysctl.conf.erb
+++ b/templates/profile/kubernetes/kubeadm_sysctl.conf.erb
@@ -2,3 +2,6 @@
 
 fs.inotify.max_user_instances = 8192
 fs.inotify.max_user_watches = 524288
+
+# Memory map limit, raise from default of 65530 for OpenSearch/Elasticsearch
+vm.max_map_count = 524288


### PR DESCRIPTION
OpenSearch uses a lot of memory maps for larger indexes, and newer versions check that the value is high enough. The minimum accepted is
262144. There are recommendations for double that, 524288, for machines with 32-64GB, while some distributions have raised the default to 1M.

We take the conservative value of 524288 here to exceed the minimum and stay well within the recommended maximums for our smallest VMs.

The OpenSearch Operator does support setting this dynamically, but that requires privileged pods. Rather than enable that for a general purpose and non-isolated setting, we choose to manage it at the node level.

See also:

- https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-settings
- https://opster.com/guides/elasticsearch/capacity-planning/elasticsearch-vm-max-map-count/