### PR TITLE
puppet-lint: ignore modules/*

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
+# override puppetlabs_spec_helper's defaults
+PuppetLint.configuration.ignore_paths << 'modules/**/*.pp'
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_puppet_url_without_modules')
 PuppetLint.configuration.send('disable_strict_indent')


### PR DESCRIPTION
don't run lint on 3rd party code, it will fail, and we don't care