### PR TITLE
remove openjdk-8-jre

### DIFF
--- a/manifests/profile/quod/dependencies/packages.pp
+++ b/manifests/profile/quod/dependencies/packages.pp
@@ -18,7 +18,6 @@ class nebula::profile::quod::dependencies::packages () {
       'imagemagick',
       'libapache2-mod-authz-umichlib',
       'libaprutil1-dbd-oracle',
-      'openjdk-8-jre',
       'oracle-instantclient12.1-basic',
       'oracle-instantclient12.1-devel',
     ]


### PR DESCRIPTION
Debian has decided that this package is now obsolete and removed it from the Debian 11 repos.   Was caught when doing a dist-upgrade that uninstalled it.