### PR TITLE
Don't manage firewall on k8s hosts

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -74,37 +74,20 @@ class nebula::profile::networking::firewall (
         }
       }
 
-      'kubernetes_calico': {
-        $input_ignore = [
-          '-j cali-INPUT',
-          '-j KUBE-FIREWALL',
-          '-j KUBE-SERVICES',
-          '-j KUBE-EXTERNAL-SERVICES',
-        ]
-
-        $output_ignore = [
-          '-j cali-OUTPUT',
-          '-j KUBE-FIREWALL',
-          '-j KUBE-SERVICES',
-        ]
-
-        $forward_ignore = [
-          '-j cali-FORWARD',
-          '-j KUBE-FORWARD',
-          '-j KUBE-SERVICES',
-        ]
-      }
-
       'fwknop': {
         $input_ignore = ['-j FWKNOP_INPUT']
         $output_ignore = []
         $forward_ignore = []
       }
 
-      default: {
+      '': {
         $input_ignore = []
         $output_ignore = []
         $forward_ignore = []
+      }
+
+      default: {
+        fail('internal_routing set to an unsupported option')
       }
     }
 

--- a/manifests/role/kubernetes/controller.pp
+++ b/manifests/role/kubernetes/controller.pp
@@ -4,7 +4,7 @@
 
 class nebula::role::kubernetes::controller {
   class { 'nebula::role::minimum':
-    internal_routing => 'kubernetes_calico',
+    manage_firewall => false,
   }
 
   include nebula::profile::ntp

--- a/manifests/role/kubernetes/etcd.pp
+++ b/manifests/role/kubernetes/etcd.pp
@@ -4,7 +4,7 @@
 
 class nebula::role::kubernetes::etcd {
   class { 'nebula::role::minimum':
-    internal_routing => 'kubernetes_calico',
+    manage_firewall => false,
   }
 
   include nebula::profile::ntp

--- a/manifests/role/kubernetes/worker.pp
+++ b/manifests/role/kubernetes/worker.pp
@@ -4,7 +4,7 @@
 
 class nebula::role::kubernetes::worker {
   class { 'nebula::role::minimum':
-    internal_routing => 'kubernetes_calico',
+    manage_firewall => false,
   }
 
   include nebula::profile::ntp

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -8,6 +8,7 @@
 #   include nebula::role::minimum
 class nebula::role::minimum (
   String $internal_routing = '',
+  Boolean $manage_firewall = true,
 ) {
   if $facts['os']['family'] == 'Debian' {
     include nebula::profile::base
@@ -17,8 +18,13 @@ class nebula::role::minimum (
     include nebula::profile::falcon
     include nebula::profile::root
 
-    class { 'nebula::profile::networking::firewall':
-      internal_routing => $internal_routing,
+    if ($manage_firewall) {
+      class { 'nebula::profile::networking::firewall':
+        internal_routing => $internal_routing,
+      }
+    } else {
+      package { 'netfilter-persistent': ensure => purged }
+      package { 'iptables-persistent': ensure => purged }
     }
 
     include nebula::profile::networking::firewall::private_ssh

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -116,21 +116,7 @@ describe "nebula::profile::networking::firewall" do
       context "when internal_routing is set to kubernetes_calico" do
         let(:params) { {internal_routing: "kubernetes_calico"} }
 
-        it { is_expected.not_to contain_resources("firewall") }
-
-        %w[INPUT OUTPUT FORWARD].each do |chain|
-          it do
-            expect(subject).to contain_firewallchain("#{chain}:filter:IPv4")
-              .with_ensure("present")
-              .with_purge(false)
-          end
-
-          it do
-            expect(subject).to contain_firewallchain("#{chain}:filter:IPv6")
-              .with_ensure("present")
-              .with_purge(false)
-          end
-        end
+        it { is_expected.not_to compile }
       end
     end
   end

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -61,37 +61,14 @@ end
 
         it { is_expected.to contain_class("Nebula::Profile::Ntp") }
 
-        it { is_expected.not_to contain_resources("firewall").with_purge(false) }
-
-        it do
-          expect(subject).to contain_firewallchain("INPUT:filter:IPv4").with(
-            ensure: "present",
-            purge: false,
-            ignore: ["-j cali-INPUT",
-              "-j KUBE-FIREWALL",
-              "-j KUBE-SERVICES",
-              "-j KUBE-EXTERNAL-SERVICES"]
-          )
+        it "does not configure firewall" do
+          is_expected.not_to contain_resources("firewall")
+          is_expected.not_to contain_class("nebula::profile::networking::firewall")
         end
-
-        it do
-          expect(subject).to contain_firewallchain("OUTPUT:filter:IPv4").with(
-            ensure: "present",
-            purge: false,
-            ignore: ["-j cali-OUTPUT",
-              "-j KUBE-FIREWALL",
-              "-j KUBE-SERVICES"]
-          )
-        end
-
-        it do
-          expect(subject).to contain_firewallchain("FORWARD:filter:IPv4").with(
-            ensure: "present",
-            purge: false,
-            ignore: ["-j cali-FORWARD",
-              "-j KUBE-FORWARD",
-              "-j KUBE-SERVICES"]
-          )
+        it "does not configure firewallchains" do
+          is_expected.not_to contain_firewallchain("INPUT:filter:IPv4")
+          is_expected.not_to contain_firewallchain("OUTPUT:filter:IPv4")
+          is_expected.not_to contain_firewallchain("FORWARD:filter:IPv4")
         end
 
         case role

--- a/spec/classes/role/minimum_spec.rb
+++ b/spec/classes/role/minimum_spec.rb
@@ -10,14 +10,16 @@ describe "nebula::role::minimum" do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
+      it { is_expected.to contain_class("nebula::profile::networking::firewall") }
 
-      case os
-      when "debian-8-x86_64"
+      context "manage_firewall false" do
+        let(:params) do
+          {manage_firewall: false}
+        end
+
         it { is_expected.not_to contain_class("nebula::profile::networking::firewall") }
-        it { is_expected.to have_firewall_resource_count(0) }
-      when "debian-9-x86_64"
-        it { is_expected.to contain_class("nebula::profile::networking::firewall") }
+        it { is_expected.to contain_package("netfilter-persistent").with_ensure("purged") }
+        it { is_expected.to contain_package("iptables-persistent").with_ensure("purged") }
       end
     end
   end


### PR DESCRIPTION
- role::minimum: make firewall management optional
- controller/worker/etcd: disable firewall management

These nodes are all behind NAT. Puppet management of host firewall is redundant and conflicts with calico.

- firewall profile: rm support for internal_routing = kubernetes_calico, and reject any unrecognised options