### PR TITLE
update deepblue.lib vhost config to support DSpace 7 running in Kubernetes instead of DSpace 6 on bulleit-2

### DIFF
--- a/manifests/profile/www_lib/vhosts/deepblue.pp
+++ b/manifests/profile/www_lib/vhosts/deepblue.pp
@@ -9,8 +9,8 @@
 # @example
 #   include nebula::profile::www_lib::vhosts::deepblue
 class nebula::profile::www_lib::vhosts::deepblue (
-  String $prefix,
   String $domain,
+  String $prefix,
   String $ssl_cn = 'deepblue.lib.umich.edu',
   String $docroot = '/www/deepblue/web'
 ) {
@@ -43,6 +43,7 @@ class nebula::profile::www_lib::vhosts::deepblue (
     usertrack                   => true,
     auth_openidc                => true,
     auth_openidc_redirect_uri   => 'https://deepblue.lib.umich.edu/openid-connect/callback',
+    ssl_proxy_machine_cert      => '/etc/ssl/private/machine-cert-deepblue.lib.pem',
 
     rewrites                    => [
       {
@@ -69,13 +70,25 @@ class nebula::profile::www_lib::vhosts::deepblue (
         rewrite_rule => '^(/data.*)$ http://app-deepbluedata:30060$1 [P]',
       },
       {
-        comment      => 'Deep Blue Documents; dont proxy auth_oidc',
-        rewrite_cond => ['%{ENV:badrobot} !(^true$)', '%{REQUEST_URI} !^(/openid-connect)'],
-        rewrite_rule => '^(.*)$	http://bulleit-2.umdl.umich.edu:8080$1 [P]'
+        comment      => 'Deep Blue Preservation redirect',
+        rewrite_rule => '^/static/about/deepbluepreservation.html https://www.lib.umich.edu/about-us/policies/digital-repository-services-digital-preservation-policy/registered-formats-and [R=permanent,L]',
       },
       {
-        comment      => 'Deep Blue Preservation redirect',
-        rewrite_rule => '^/static/about/deepbluepreservation.html https://www.lib.umich.edu/about-us/policies/digital-repository-services-digital-preservation-policy/registered-formats-and [R=permanent,L]'
+        comment      => 'new path in DSpace 7 REST-API',
+        rewrite_rule => '^/RESTapi/(.*)$ https://backend.production.deepblue-documents.lib.umich.edu/rest/$1 [R=permanent,L]',
+      },
+      {
+        comment      => 'new path in DSpace 7 for OAI',
+        rewrite_rule => '^/dspace-oai/(.*)$ https://backend.production.deepblue-documents.lib.umich.edu/server/oai/$1 [R=permanent,L]',
+      },
+      {
+        comment      => 'new path in DSpace 7 for SWORDV2',
+        rewrite_rule => '^/swordv2/(.*)$ https://backend.production.deepblue-documents.lib.umich.edu/server/swordv2/$1 [R=permanent,L]',
+      },
+      {
+        comment      => 'Deep Blue Documents; dont proxy auth_oidc',
+        rewrite_cond => ['%{ENV:badrobot} !(^true$)', '%{REQUEST_URI} !^(/openid-connect)'],
+        rewrite_rule => '^(.*)$ https://production.deepblue-documents.lib.umich.edu:8443$1 [P]',
       },
     ],
 
@@ -106,15 +119,6 @@ class nebula::profile::www_lib::vhosts::deepblue (
         | EOT
       },
       {
-        provider        => 'location',
-        path            => '/webiso-login',
-        auth_type       => 'openid-connect',
-        auth_require    => 'valid-user',
-        custom_fragment => @(EOT)
-        OIDCUnAuthAction auth true
-        | EOT
-      },
-      {
         provider        => 'locationmatch',
         path            => '^/data/login',
         auth_type       => 'openid-connect',
@@ -137,6 +141,8 @@ class nebula::profile::www_lib::vhosts::deepblue (
       'set X-Remote-User "expr=%{REMOTE_USER}"',
       # Fix redirects being sent to non ssl url (https -> http)
       'set X-Forwarded-Proto "https"',
+      #Set original host name of the request.
+      'set X-Forwarded-Host "deepblue.lib.umich.edu"',
       # Remove existing X-Forwarded-For headers; mod_proxy will automatically add the correct one.
       'unset X-Forwarded-For',
     ],
@@ -156,7 +162,7 @@ class nebula::profile::www_lib::vhosts::deepblue (
 
     custom_fragment             => @(EOT)
       ProxyPassReverse /data https://app-deepbluedata.deepblue.lib.umich.edu:30060/
-      ProxyPassReverse / http://bulleit-2.umdl.umich.edu:8080/
+      ProxyPassReverse / https://production.deepblue-documents.lib.umich.edu:8443/
     | EOT
   }
 }


### PR DESCRIPTION
Apache redirect for the new dspace in kubernetes. 