### PR TITLE
Update icmp limit to stop corrective firewall changes

### DIFF
--- a/manifests/profile/networking/firewall.pp
+++ b/manifests/profile/networking/firewall.pp
@@ -148,7 +148,7 @@ class nebula::profile::networking::firewall (
   firewall { '500 allow ping':
     proto => 'icmp',
     icmp  => 8,
-    limit => '5/second',
+    limit => '5/sec',
     jump  => 'accept',
   }
 

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -102,7 +102,7 @@ describe "nebula::profile::networking::firewall" do
           proto: "icmp",
           jump: "accept",
           icmp: 8,
-          limit: "5/second"
+          limit: "5/sec"
         )
       end
 


### PR DESCRIPTION
5/second here produces 5/sec in real life, and then the firewall thinks the real thing (5/sec) doesn't match what it should be (5/second) so it makes a corrective change (ultimately to 5/sec, changing nothing).

This should remove the noise.