### PR TITLE
support mounting all ht nfs mounts on truenas

### DIFF
--- a/manifests/profile/hathitrust/mounts.pp
+++ b/manifests/profile/hathitrust/mounts.pp
@@ -36,12 +36,23 @@ class nebula::profile::hathitrust::mounts (
     options => "size=${ramdisk_size}"
   }
 
+  # TODO: rename smartconnect_mounts, remove support for smartconnect
   $smartconnect_mounts.each |$mount| {
-    nebula::nfs_mount { $mount:
-      remote_target   => "nas-${facts['datacenter']}.sc:/ifs${mount}",
-      tag             => 'smartconnect',
-      private_network => true,
-      monitored       => true
+    if($use_truenas) {
+      nebula::nfs_mount { $mount:
+        options         => 'auto,hard',
+        remote_target   => "truenas:/mnt/tank${mount}",
+        private_network => true,
+        monitored       => true
+      }
+    }
+    else {
+      nebula::nfs_mount { $mount:
+        remote_target   => "nas-${facts['datacenter']}.sc:/ifs${mount}",
+        tag             => 'smartconnect',
+        private_network => true,
+        monitored       => true
+      }
     }
   }
 

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -52,6 +52,10 @@ describe "nebula::profile::hathitrust::mounts" do
             device: "truenas:/mnt/tank/sdr",
             fstype: "nfs"
           )
+          is_expected.to contain_mount("/htapps").with(
+            device: "truenas:/mnt/tank/htapps",
+            fstype: "nfs"
+          )
         end
 
         it "symlinks /sdr#" do


### PR DESCRIPTION
use_truenas flag moves all "smartconnect" mounts to truenas

This is an interim solution: "smartconnect" is an isilon feature, but for now I'm using it as "other mounts that need to be mounted from whatever nfs server we're using for HT". 