### PR TITLE
allow group creation w/ $gid == undef

### DIFF
--- a/manifests/profile/groups.pp
+++ b/manifests/profile/groups.pp
@@ -11,7 +11,7 @@
 # @example
 #   include nebula::profile::groups
 class nebula::profile::groups (
-  Hash[String, Integer] $all_groups,
+  Hash[String, Optional[Integer]] $all_groups,
 ) {
   $all_groups.each |$group, $gid| {
     group { $group:

--- a/spec/classes/profile/groups_spec.rb
+++ b/spec/classes/profile/groups_spec.rb
@@ -15,6 +15,7 @@ describe "nebula::profile::groups" do
 
       it { is_expected.to contain_group("examplegroup1").with_gid(1234) }
       it { is_expected.to contain_group("examplegroup2").with_gid(2468) }
+      it { is_expected.to contain_group("gidlessgroup") }
 
       context "when given different_group with a gid of 2358" do
         let(:params) { {all_groups: {"different_group" => 2358}} }

--- a/spec/fixtures/hiera/usergroups.yaml
+++ b/spec/fixtures/hiera/usergroups.yaml
@@ -12,6 +12,7 @@ nebula::usergroup::membership:
 nebula::profile::groups::all_groups:
   examplegroup1: 1234
   examplegroup2: 2468
+  gidlessgroup: null
 
 nebula::virtual::users::default_group: staff
 nebula::virtual::users::all_users:


### PR DESCRIPTION
undef in `.pp` corresponds to null in hiera yaml. Setting gid in yaml to null lets the os choose the gid. Puppet already supported this, we're just relaxing our parameter checking to allow it.