### PR TITLE
k8s gateway sshd: stop blocking puppet bolt

### DIFF
--- a/manifests/profile/kubernetes/router.pp
+++ b/manifests/profile/kubernetes/router.pp
@@ -46,4 +46,18 @@ class nebula::profile::kubernetes::router {
     source   => $node_cidr,
     tosource => $public_address,
   }
+
+  service { 'sshd':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+  }
+
+  file { '/etc/ssh/sshd_config.d/70-MaxStartups.conf':
+    content => @("EOT"),
+    # allow >10 simultaneous pending connections so Puppet Bolt can reach worker nodes _en masse_
+    MaxStartups 100
+    | EOT
+    notify  => Service['sshd'],
+  }
 }

--- a/spec/classes/profile/kubernetes/router_spec.rb
+++ b/spec/classes/profile/kubernetes/router_spec.rb
@@ -50,6 +50,11 @@ describe "nebula::profile::kubernetes::router" do
           .with_tosource("10.0.0.1")
       end
 
+      it "configures sshd MaxStartups" do
+        is_expected.to contain_file("/etc/ssh/sshd_config.d/70-MaxStartups.conf")
+          .with_content(/^MaxStartups 100$/)
+      end
+
       context "with cluster set to second_cluster" do
         let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 


### PR DESCRIPTION
Override default MaxStartups setting. Default randomly blocks some ssh sessions when there are already >= 10 pending connections. We routinely start ~30 connections simultaneously when using Puppet Bolt.