### PR TITLE
break up ci spec jobs into multiple tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         - "profiles_2"
         - "roles"
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Run tests
       run: |
         docker compose --file docker-compose.test.yml build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,15 @@ jobs:
       matrix:
         target:
         - "lint"
-        - "specs"
+        - "all_roles_1"
+        - "all_roles_2"
+        - "classes"
+        - "defines_and_functions"
+        - "ht_profiles"
+        - "ht_roles"
+        - "profiles_1"
+        - "profiles_2"
+        - "roles"
     steps:
     - uses: actions/checkout@v5
     - name: Run tests

--- a/.github/workflows/librarian.yml
+++ b/.github/workflows/librarian.yml
@@ -11,7 +11,7 @@ jobs:
   librarian:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Resolve Dependencies
       run: |
         docker compose --file docker-compose.test.yml build

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,62 @@
-version: '3'
 services:
   specs:
     build: .
     command: 'bundle exec rake parallel_spec'
+
+  all_roles_1:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/all_roles_[1-4]_spec\.rb$"'
+  all_roles_2:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/all_roles.*_spec\.rb$" --exclude-pattern "^spec\/classes\/all_roles_[1-4].*$"'
+  classes:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/.*_spec\.rb$" --exclude-pattern "^spec\/classes\/(profile\/|role\/|all_roles_).*$"'
+  defines_and_functions:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/(defines|functions)\/.*_spec\.rb$"'
+  ht_profiles:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/profile\/(hathi|ht).*_spec\.rb$"'
+  ht_roles:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/role\/(hathi|ht).*_spec\.rb$"'
+  profiles_1:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/profile\/[a-k].*_spec\.rb$" --exclude-pattern "^spec\/classes\/profile\/(hathi|ht).*$"'
+  profiles_2:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/profile\/.*_spec\.rb$" --exclude-pattern "^spec\/classes\/profile\/[a-k].*$"'
+  roles:
+    build: .
+    command:
+    - /bin/bash
+    - '-c'
+    - 'bundle exec rake spec_prep && bundle exec parallel_rspec --pattern "^spec\/classes\/role\/.*_spec\.rb$" --exclude-pattern "^spec\/classes\/role\/(hathi|ht).*$"'
 
   lint:
     build: .

--- a/spec/classes/all_roles.rb
+++ b/spec/classes/all_roles.rb
@@ -22,11 +22,11 @@ module RSpec::Puppet
       end
 
       def failure_message
-        "You probably need to add a hiera_config to spec/classes/all_roles_spec.rb:\n #{super()}"
+        "You probably need to add a hiera_config to spec/classes/all_roles.rb:\n #{super()}"
       end
 
       def failure_message_when_negated
-        "You probably need to add a hiera_config to spec/classes/all_roles_spec.rb:\n #{super()}"
+        "You probably need to add a hiera_config to spec/classes/all_roles.rb:\n #{super()}"
       end
     end
 

--- a/spec/classes/all_roles.rb
+++ b/spec/classes/all_roles.rb
@@ -81,10 +81,6 @@ def test_roles(slice_number = 1, slice_count = 1)
 
           it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
           it { is_expected.to contain_class("nebula::role::minimum") }
-
-          if role_name.match?(%r{^nebula::role::hathitrust})
-            it { is_expected.to contain_nebula__taghosts__tag("ht") }
-          end
         end
       end
     end

--- a/spec/classes/all_roles_1_spec.rb
+++ b/spec/classes/all_roles_1_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(1, 5)
+test_roles(1, 8)

--- a/spec/classes/all_roles_2_spec.rb
+++ b/spec/classes/all_roles_2_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(2, 5)
+test_roles(2, 8)

--- a/spec/classes/all_roles_4_spec.rb
+++ b/spec/classes/all_roles_4_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(4, 5)
+test_roles(4, 8)

--- a/spec/classes/all_roles_5_spec.rb
+++ b/spec/classes/all_roles_5_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(5, 5)
+test_roles(5, 8)

--- a/spec/classes/all_roles_6_spec.rb
+++ b/spec/classes/all_roles_6_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(6, 8)

--- a/spec/classes/all_roles_7_spec.rb
+++ b/spec/classes/all_roles_7_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(7, 8)

--- a/spec/classes/all_roles_8_spec.rb
+++ b/spec/classes/all_roles_8_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(8, 8)

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -120,18 +120,22 @@ describe "nebula::profile::haproxy" do
       end
 
       describe "service" do
-        it { is_expected.to contain_service(service).that_requires("Package[keepalived]") }
-        it { is_expected.to contain_service(service).with(enable: true) }
-        it { is_expected.to contain_service(service).with(ensure: "running") }
+        it {
+          is_expected.to contain_service(service).that_requires("Package[keepalived]")
+            .with(enable: true)
+            .with(ensure: "running")
+        }
       end
 
       describe "haproxy default file" do
         let(:file) { default_file }
 
-        it { is_expected.to contain_file(file).with(ensure: "file") }
-        it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
-        it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
-        it { is_expected.to contain_file(file).with(mode: "0644") }
+        it {
+          is_expected.to contain_file(file).with(ensure: "file")
+            .with(require: "Package[haproxy]")
+            .with(notify: "Service[haproxy]")
+            .with(mode: "0644")
+        }
 
         it "says it is managed by puppet" do
           expect(subject).to contain_file(file).with_content(
@@ -166,10 +170,12 @@ describe "nebula::profile::haproxy" do
       describe "base haproxy config file" do
         let(:file) { haproxy_conf }
 
-        it { is_expected.to contain_file(file).with(ensure: "file") }
-        it { is_expected.to contain_file(file).with(require: "Package[haproxy]") }
-        it { is_expected.to contain_file(file).with(notify: "Service[haproxy]") }
-        it { is_expected.to contain_file(file).with(mode: "0644") }
+        it {
+          is_expected.to contain_file(file).with(ensure: "file")
+            .with(require: "Package[haproxy]")
+            .with(notify: "Service[haproxy]")
+            .with(mode: "0644")
+        }
         it { is_expected.to contain_file("/etc/haproxy/services.d").with(ensure: "directory") }
 
         it "says it is managed by puppet" do
@@ -264,16 +270,19 @@ describe "nebula::profile::haproxy" do
           )
         end
 
-        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{interface #{facts[:networking][:primary]}}) }
-
-        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{notification_email {\n\s.*root@default.invalid\n\s.*}}m) }
-        it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{notification_email_from root@default.invalid}) }
+        it {
+          is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{interface #{facts[:networking][:primary]}})
+            .with_content(%r{notification_email {\n\s.*root@default.invalid\n\s.*}}m)
+            .with_content(%r{notification_email_from root@default.invalid})
+        }
 
         context "when on a master node" do
           let(:params) { base_params.merge(master: true) }
 
-          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 101}) }
-          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{state MASTER}) }
+          it {
+            is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 101})
+              .with_content(%r{state MASTER})
+          }
 
           it do
             expect(subject).to contain_class("Nebula::Profile::Prometheus::Exporter::Haproxy")
@@ -284,8 +293,10 @@ describe "nebula::profile::haproxy" do
         context "when on a backup node" do
           let(:params) { base_params.merge(master: false) }
 
-          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 100}) }
-          it { is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{state BACKUP}) }
+          it {
+            is_expected.to contain_concat_fragment("keepalived preamble").with_content(%r{priority 100})
+              .with_content(%r{state BACKUP})
+          }
 
           it do
             expect(subject).to contain_class("Nebula::Profile::Prometheus::Exporter::Haproxy")
@@ -297,8 +308,10 @@ describe "nebula::profile::haproxy" do
       describe "sysctl conf" do
         let(:file) { "/etc/sysctl.d/keepalived.conf" }
 
-        it { is_expected.to contain_file(file).with(ensure: "file") }
-        it { is_expected.to contain_file(file).with(mode: "0644") }
+        it {
+          is_expected.to contain_file(file).with(ensure: "file")
+            .with(mode: "0644")
+        }
 
         it "says it is managed by puppet" do
           expect(subject).to contain_file(file).with_content(
@@ -339,13 +352,15 @@ describe "nebula::profile::haproxy" do
       describe "log rotation" do
         let(:rotate_logs) { contain_logrotate__rule("haproxy") }
 
-        it { is_expected.to rotate_logs.with_path("/var/log/haproxy.log") }
-        it { is_expected.to rotate_logs.with_rotate_every("day") }
-        it { is_expected.to rotate_logs.with_rotate(5) }
-        it { is_expected.to rotate_logs.with_missingok(true) }
-        it { is_expected.to rotate_logs.with_ifempty(false) }
-        it { is_expected.to rotate_logs.with_compress(true) }
-        it { is_expected.to rotate_logs.with_postrotate(["/usr/lib/rsyslog/rsyslog-rotate", "/bin/systemctl restart filebeat"]) }
+        it {
+          is_expected.to rotate_logs.with_path("/var/log/haproxy.log")
+            .with_rotate_every("day")
+            .with_rotate(5)
+            .with_missingok(true)
+            .with_ifempty(false)
+            .with_compress(true)
+            .with_postrotate(["/usr/lib/rsyslog/rsyslog-rotate", "/bin/systemctl restart filebeat"])
+        }
       end
     end
   end

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -15,8 +15,11 @@ describe "nebula::profile::hathitrust::mounts" do
       it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3,ro") }
       it { is_expected.to contain_nebula__nfs_mount("/sdr1") }
 
-      it { is_expected.to contain_mount("/htapps").that_requires("File[/etc/resolv.conf]") }
-      it { is_expected.to contain_mount("/htapps").that_requires("Service[bind9]") }
+      it {
+        is_expected.to contain_mount("/htapps")
+          .that_requires("File[/etc/resolv.conf]")
+          .that_requires("Service[bind9]")
+      }
       it { is_expected.to contain_nebula__nfs_mount("/htapps") }
 
       it { is_expected.to contain_file("/etc/resolv.conf").with_content(%r{nameserver 127.0.0.1}) }

--- a/spec/classes/profile/hathitrust/php_spec.rb
+++ b/spec/classes/profile/hathitrust/php_spec.rb
@@ -12,7 +12,6 @@ describe "nebula::profile::hathitrust::php" do
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 
-      it { is_expected.to compile }
       it { is_expected.to contain_php__extension("File_MARC").with_provider("pear") }
     end
   end

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -82,8 +82,11 @@ describe "nebula::profile::prometheus::exporter::node" do
       context "with promfile_owner set to brlglph" do
         let(:params) { {promfile_owner: "brlglph"} }
 
-        it { is_expected.to contain_file("/var/lib/prometheus/node-exporter").with_owner("brlglph") }
-        it { is_expected.to contain_file("/var/lib/prometheus/node-exporter").with_group("prometheus") }
+        it {
+          is_expected.to contain_file("/var/lib/prometheus/node-exporter")
+            .with_owner("brlglph")
+            .with_group("prometheus")
+        }
       end
 
       it do

--- a/spec/classes/role/aleph_marcedit_spec.rb
+++ b/spec/classes/role/aleph_marcedit_spec.rb
@@ -11,8 +11,6 @@ describe "nebula::role::aleph::marcedit" do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_class("nebula::profile::krb5") }
       it { is_expected.to contain_class("nebula::profile::afs") }
       it { is_expected.to contain_class("nebula::profile::users") }

--- a/spec/classes/role/app_host_dev_spec.rb
+++ b/spec/classes/role/app_host_dev_spec.rb
@@ -11,8 +11,6 @@ describe "nebula::role::app_host::dev" do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_class("nebula::profile::krb5") }
       it { is_expected.to contain_class("nebula::profile::afs") }
       it { is_expected.to contain_class("nebula::profile::users") }

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -11,8 +11,6 @@ describe "nebula::role::chipmunk" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/chipmunk_config.yaml" }
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_class("nebula::profile::networking::sshd_group_umask") }
     end
   end

--- a/spec/classes/role/fulcrum_www_and_app_spec.rb
+++ b/spec/classes/role/fulcrum_www_and_app_spec.rb
@@ -16,8 +16,6 @@ describe "nebula::role::webhost::fulcrum_www_and_app" do
 
       include_context "with mocked puppetdb functions", "somedc", %w[rolenode], "nebula::profile::haproxy" => %w[]
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_class("nebula::profile::fulcrum::app") }
 
       it { is_expected.to contain_class("Nebula::Profile::Www_lib::Register_for_load_balancing") }

--- a/spec/classes/role/hathitrust/solr/catalog_spec.rb
+++ b/spec/classes/role/hathitrust/solr/catalog_spec.rb
@@ -8,7 +8,6 @@ describe "nebula::role::hathitrust::solr::catalog" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to compile }
       it { is_expected.to contain_class("nebula::role::hathitrust") }
       it { is_expected.to contain_class("nebula::profile::loki") }
       it { is_expected.not_to contain_package("openafs-client") }

--- a/spec/classes/role/hathitrust/solr/lss_spec.rb
+++ b/spec/classes/role/hathitrust/solr/lss_spec.rb
@@ -8,7 +8,6 @@ describe "nebula::role::hathitrust::solr::lss" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to compile }
       it { is_expected.to contain_class("nebula::role::hathitrust") }
       it { is_expected.not_to contain_package("openafs-client") }
     end

--- a/spec/classes/role/hathitrust_spec.rb
+++ b/spec/classes/role/hathitrust_spec.rb
@@ -8,7 +8,6 @@ describe "nebula::role::hathitrust" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to compile }
       it { is_expected.to contain_package("openafs-client") }
 
       context "when $afs is false" do

--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -12,8 +12,6 @@ describe "nebula::role::hathitrust::datasets" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_package("nfs-common") }
       it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3,ro") }
       it { is_expected.to contain_mount("/htprep") }

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -12,8 +12,6 @@ describe "nebula::role::hathitrust::ingest_indexing" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_package("nfs-common") }
       it { is_expected.to contain_mount("/sdr1").with_options("auto,hard,nfsvers=3") }
       # causes a warning if concat fragment is included but monitor_pl isn't
@@ -24,12 +22,14 @@ describe "nebula::role::hathitrust::ingest_indexing" do
       # default from hiera
       it { is_expected.to contain_host("mysql-sdr").with_ip("10.1.2.4") }
 
-      # not specified explicitly as a usergroup, just brought in as part of 'all groups'
-      it { is_expected.to contain_group("htprod") }
-      it { is_expected.to contain_group("htingest") }
-      # not specified explicitly - realized through Nebula::Usergroup[htingest]
-      it { is_expected.to contain_user("htingest") }
-      it { is_expected.not_to contain_user("htweb") }
+      it "contains expected groups and users" do
+        # not specified explicitly as a usergroup, just brought in as part of 'all groups'
+        is_expected.to contain_group("htprod")
+        is_expected.to contain_group("htingest")
+        # not specified explicitly - realized through Nebula::Usergroup[htingest]
+        is_expected.to contain_user("htingest")
+        is_expected.not_to contain_user("htweb")
+      end
 
       it { is_expected.to contain_file("/etc/logrotate.d/babel") }
     end

--- a/spec/classes/role/htvm_global_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_global_primary_webhost_spec.rb
@@ -11,13 +11,12 @@ describe "nebula::role::webhost::htvm::global_primary" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
-      it { is_expected.to compile }
 
-      # includes cron jobs that run on only one node in cluster
-      it { is_expected.to contain_class("nebula::profile::hathitrust::cron::catalog") }
-      it { is_expected.to contain_class("nebula::role::webhost::htvm::site_primary") }
+      it "contains expected nebula manifests, crons" do
+        # includes cron jobs that run on only one node in cluster
+        is_expected.to contain_class("nebula::profile::hathitrust::cron::catalog")
+        is_expected.to contain_class("nebula::role::webhost::htvm::site_primary")
 
-      it do
         expect(subject).to contain_cron("wordpress cron")
           .with(user: "nobody",
             command: %r{.*wp-cron.php.*},

--- a/spec/classes/role/htvm_prod_webhost_spec.rb
+++ b/spec/classes/role/htvm_prod_webhost_spec.rb
@@ -11,7 +11,6 @@ describe "nebula::role::webhost::htvm::prod" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
-      it { is_expected.to compile }
 
       it "exports a haproxy::binding resource for hathitrust" do
         expect(exported_resources).to contain_nebula__haproxy__binding("thisnode hathitrust")

--- a/spec/classes/role/htvm_site_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_site_primary_webhost_spec.rb
@@ -11,13 +11,12 @@ describe "nebula::role::webhost::htvm::site_primary" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
-      it { is_expected.to compile }
 
-      # includes cron jobs that run at each site
-      it { is_expected.to contain_class("nebula::profile::hathitrust::cron::mdp_misc") }
-      # sets cache parameters
-      #
-      it { is_expected.to contain_package("rdist") }
+      it "includes crons, rdist package" do
+        # includes cron jobs that run at each site
+        is_expected.to contain_class("nebula::profile::hathitrust::cron::mdp_misc")
+        is_expected.to contain_package("rdist")
+      end
     end
   end
 end

--- a/spec/classes/role/htvm_test_webhost_spec.rb
+++ b/spec/classes/role/htvm_test_webhost_spec.rb
@@ -10,7 +10,6 @@ describe "nebula::role::webhost::htvm::test" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
-      it { is_expected.to compile }
       it { is_expected.to contain_package("nodejs") }
     end
   end

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -11,8 +11,6 @@ describe "nebula::role::webhost::htvm" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
-      # binding.irb
-      it { is_expected.to compile }
 
       it do
         expect(subject).to contain_class("nebula::profile::shibboleth")
@@ -20,21 +18,10 @@ describe "nebula::role::webhost::htvm" do
           .with(watchdog_minutes: "*/30")
       end
 
-      it do
-        expect(subject).to contain_class("nebula::profile::hathitrust::dependencies")
-        expect(subject).to contain_class("nebula::profile::hathitrust::hosts")
-        expect(subject).to contain_class("nebula::profile::hathitrust::mounts")
-        expect(subject).to contain_class("nebula::profile::hathitrust::perl")
-        expect(subject).to contain_class("nebula::profile::hathitrust::php")
-      end
-
-      it do
-        expect(subject).to contain_concat_fragment("monitor nfs /sdr1")
+      it "contains nfs monitor concat fragments" do
+        is_expected.to contain_concat_fragment("monitor nfs /sdr1")
           .with(tag: "monitor_config", content: {"nfs" => ["/sdr1"]}.to_yaml)
-      end
-
-      it do
-        expect(subject).to contain_concat_fragment("monitor nfs /htapps")
+        is_expected.to contain_concat_fragment("monitor nfs /htapps")
           .with(tag: "monitor_config", content: {"nfs" => ["/htapps"]}.to_yaml)
       end
 
@@ -54,25 +41,35 @@ describe "nebula::role::webhost::htvm" do
         it { is_expected.to contain_service("bind9").that_requires("Exec[ifup ens4]") }
       end
 
-      it { is_expected.to contain_class("nebula::profile::networking::firewall") }
-
-      it { is_expected.to contain_class("nebula::profile::krb5") }
-      it { is_expected.to contain_class("nebula::profile::afs") }
-      it { is_expected.to contain_class("nebula::profile::users") }
-
-      if os == "debian-11-x86_64"
-        it { is_expected.not_to contain_package("php5-common") }
-        it { is_expected.not_to contain_package("php5-dev") }
-        it { is_expected.to contain_package("libapache2-mod-shib") }
-        it { is_expected.not_to contain_package("libapache2-mod-shib2") }
+      it "contains expected nebula profiles" do
+        is_expected.to contain_class("nebula::profile::hathitrust::dependencies")
+        is_expected.to contain_class("nebula::profile::hathitrust::hosts")
+        is_expected.to contain_class("nebula::profile::hathitrust::mounts")
+        is_expected.to contain_class("nebula::profile::hathitrust::perl")
+        is_expected.to contain_class("nebula::profile::hathitrust::php")
+        is_expected.to contain_class("nebula::profile::networking::firewall")
+        is_expected.to contain_class("nebula::profile::krb5")
+        is_expected.to contain_class("nebula::profile::afs")
+        is_expected.to contain_class("nebula::profile::users")
       end
 
-      # not specified explicitly as a usergroup, just brought in as part of 'all groups'
-      it { is_expected.to contain_group("htprod") }
-      it { is_expected.to contain_group("htingest") }
-      # not specified explicitly - realized through Nebula::Usergroup[htprod]
-      it { is_expected.to contain_user("htingest") }
-      it { is_expected.to contain_user("htweb") }
+      if os == "debian-11-x86_64"
+        it "contains expected php and apache packages" do
+          is_expected.not_to contain_package("php5-common")
+          is_expected.not_to contain_package("php5-dev")
+          is_expected.to contain_package("libapache2-mod-shib")
+          is_expected.not_to contain_package("libapache2-mod-shib2")
+        end
+      end
+
+      it "contains expected groups" do
+        # not specified explicitly as a usergroup, just brought in as part of 'all groups'
+        is_expected.to contain_group("htprod")
+        is_expected.to contain_group("htingest")
+        # not specified explicitly - realized through Nebula::Usergroup[htprod]
+        is_expected.to contain_user("htingest")
+        is_expected.to contain_user("htweb")
+      end
 
       it { is_expected.to contain_nebula__cpan("Prometheus::Tiny::Shared") }
     end

--- a/spec/classes/role/umich_spec.rb
+++ b/spec/classes/role/umich_spec.rb
@@ -10,8 +10,6 @@ describe "nebula::role::umich" do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
-
       it { is_expected.not_to contain_profile("nebula::profile::krb5") }
       it { is_expected.not_to contain_profile("nebula::profile::afs") }
       it { is_expected.not_to contain_profile("nebula::profile::users") }

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -16,8 +16,6 @@ describe "nebula::role::webhost::www_lib_vm" do
 
       include_context "with mocked puppetdb functions", "somedc", %w[rolenode], "nebula::profile::haproxy" => %w[]
 
-      it { is_expected.to compile }
-
       it { is_expected.to contain_class("Nebula::Profile::Www_lib::Register_for_load_balancing") }
       it { is_expected.to contain_class("php") }
 


### PR DESCRIPTION
Edit: it was really useful to have all of these changes in the same CI run to see how much performance there is to be gained. But this is too much for one PR. I'll resubmit these changes over a few new PRs.

* Use 9 runners instead of 1 for rspec.
* Strategically sort jobs to limit starved cpu cores.
* Make a few individual spec files faster.
  * This is more important that it sounds. The less variation we have in run time per spec file, the more efficiently all the tests run because we can keep all cores busy longer.

In my testing:
* github actions CI completes in < 3 minutes vs. > 9 minutes
* locally, `bundle exec rake parallel_spec_standalone` is consistantly finishing in under 2:00, vs about 2:30 before (o/c this is very hardware dependent)

Future development: with these tasks down to 1-3 minutes, the 60 seconds it takes to run `bundle exec rake spec_prep` is really significant. Not sure what it would take to cache this data, but it could make difference.