### PR TITLE
Make all_roles spec faster

### DIFF
--- a/spec/classes/all_roles.rb
+++ b/spec/classes/all_roles.rb
@@ -22,11 +22,11 @@ module RSpec::Puppet
       end
 
       def failure_message
-        "You probably need to add a hiera_config to spec/classes/all_roles_spec.rb:\n #{super()}"
+        "You probably need to add a hiera_config to spec/classes/all_roles.rb:\n #{super()}"
       end
 
       def failure_message_when_negated
-        "You probably need to add a hiera_config to spec/classes/all_roles_spec.rb:\n #{super()}"
+        "You probably need to add a hiera_config to spec/classes/all_roles.rb:\n #{super()}"
       end
     end
 

--- a/spec/classes/all_roles_1_spec.rb
+++ b/spec/classes/all_roles_1_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(1, 5)
+test_roles(1, 8)

--- a/spec/classes/all_roles_2_spec.rb
+++ b/spec/classes/all_roles_2_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(2, 5)
+test_roles(2, 8)

--- a/spec/classes/all_roles_4_spec.rb
+++ b/spec/classes/all_roles_4_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(4, 5)
+test_roles(4, 8)

--- a/spec/classes/all_roles_5_spec.rb
+++ b/spec/classes/all_roles_5_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "./all_roles_spec"
+require_relative "./all_roles"
 
-test_roles(5, 5)
+test_roles(5, 8)

--- a/spec/classes/all_roles_6_spec.rb
+++ b/spec/classes/all_roles_6_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(6, 8)

--- a/spec/classes/all_roles_7_spec.rb
+++ b/spec/classes/all_roles_7_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(7, 8)

--- a/spec/classes/all_roles_8_spec.rb
+++ b/spec/classes/all_roles_8_spec.rb
@@ -3,4 +3,4 @@
 require "spec_helper"
 require_relative "./all_roles"
 
-test_roles(3, 8)
+test_roles(8, 8)

--- a/spec/classes/all_roles_spec.rb
+++ b/spec/classes/all_roles_spec.rb
@@ -81,10 +81,6 @@ def test_roles(slice_number = 1, slice_count = 1)
 
           it { is_expected.to compile_along_with_all_roles(hiera_fixture) }
           it { is_expected.to contain_class("nebula::role::minimum") }
-
-          if role_name.match?(%r{^nebula::role::hathitrust})
-            it { is_expected.to contain_nebula__taghosts__tag("ht") }
-          end
         end
       end
     end


### PR DESCRIPTION
- Increase number of shards to 8
  - This gets the run time down of each shard to that of our other
    slowest spec files.
  - Divisible by 4, the number of cores on default GitHub runner.
- rename all_roles_spec.rb to all_roles.rb
  - This causes our Rakefile to skip trying to run this file that has no
    tests in it.
- remove one useless test (which runs many many times, and is really slow)