### PR TITLE
fix regression: use our ssh_config

### DIFF
--- a/manifests/profile/networking/sshd.pp
+++ b/manifests/profile/networking/sshd.pp
@@ -26,6 +26,10 @@ class nebula::profile::networking::sshd (
     hasrestart => true,
   }
 
+  file { '/etc/ssh/ssh_config.d/80-lit.conf':
+    content => template('nebula/profile/networking/ssh_config.erb'),
+  }
+
   # Reset sshd_config to original distro config. May be deleted once this has been applied to existing hosts.
   file { '/etc/ssh/sshd_config':
     source => "puppet:///modules/nebula/default/${facts['os']['distro']['codename']}/etc/ssh/sshd_config",

--- a/spec/classes/profile/networking/sshd_spec.rb
+++ b/spec/classes/profile/networking/sshd_spec.rb
@@ -16,6 +16,8 @@ describe "nebula::profile::networking::sshd" do
 
       it { is_expected.to contain_sshd.that_notifies("Service[sshd]") }
 
+      it { is_expected.to contain_file("/etc/ssh/ssh_config.d/80-lit.conf") }
+
       it do
         expect(subject).to contain_service("sshd").only_with(
           ensure: "running",

--- a/templates/profile/networking/ssh_config.erb
+++ b/templates/profile/networking/ssh_config.erb
@@ -1,4 +1,4 @@
-# Managed by puppet (nebula/profile/base/ssh_config.erb)
+# Managed by puppet (nebula/profile/networking/ssh_config.erb)
 Host *
     HashKnownHosts no
     GSSAPIAuthentication yes


### PR DESCRIPTION
ssh_config.erb was recently updated, but was not actually used. This adds its content to a new drop-in in /etc/ssh/ssh_config.d/.