### PR TITLE
support running CI per OS

### DIFF
--- a/rakelib/supported_os.rake
+++ b/rakelib/supported_os.rake
@@ -1,0 +1,16 @@
+desc "List supported operating systems"
+task :supported_os do |t|
+  require "json"
+  require_relative "../spec/spec_helper/supported_os"
+
+  list = []
+
+  Nebula.supported_os.each do |os|
+    name = os["operatingsystem"]
+    os["operatingsystemrelease"].each do |rel|
+      list.push("#{name} #{rel}")
+    end
+  end
+
+  puts list.to_json
+end

--- a/spec/classes/all_roles.rb
+++ b/spec/classes/all_roles.rb
@@ -47,7 +47,7 @@ def test_roles(slice_number = 1, slice_count = 1)
   slice.each do |file_path|
     role_name = puppet_role_name_from(file_path)
     describe role_name do
-      on_supported_os.each do |os, os_facts|
+      on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
         context "on #{os}" do
           let(:facts) { os_facts }
 

--- a/spec/classes/profile/afs_spec.rb
+++ b/spec/classes/profile/afs_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::afs" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:kernelrelease) { os_facts[:kernelrelease] }

--- a/spec/classes/profile/alma_integrations_spec.rb
+++ b/spec/classes/profile/alma_integrations_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::alma_integrations" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/apt/mono_spec.rb
+++ b/spec/classes/profile/apt/mono_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::apt::mono" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/apt/nodejs_spec.rb
+++ b/spec/classes/profile/apt/nodejs_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::apt::nodejs" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::apt" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/authorized_keys_spec.rb
+++ b/spec/classes/profile/authorized_keys_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::authorized_keys" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }

--- a/spec/classes/profile/aws/filesystem_spec.rb
+++ b/spec/classes/profile/aws/filesystem_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::aws::filesystem" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge("disks" => {

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::base" do
     contain_class("nebula::profile::base::#{name}")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:fqdn) { facts[:fqdn] }

--- a/spec/classes/profile/bolt_spec.rb
+++ b/spec/classes/profile/bolt_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::bolt" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/certbot_cloudflare_spec.rb
+++ b/spec/classes/profile/certbot_cloudflare_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::certbot_cloudflare" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/certbot_incommon_spec.rb
+++ b/spec/classes/profile/certbot_incommon_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::certbot_incommon" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/certbot_route53_spec.rb
+++ b/spec/classes/profile/certbot_route53_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::certbot_route53" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/client_cert_https_spec.rb
+++ b/spec/classes/profile/client_cert_https_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::client_cert_https" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/containerd_spec.rb
+++ b/spec/classes/profile/containerd_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::containerd" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/cron_runner_spec.rb
+++ b/spec/classes/profile/cron_runner_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::cron_runner" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/dns/aws_spec.rb
+++ b/spec/classes/profile/dns/aws_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::dns::aws" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/dns/smartconnect_spec.rb
+++ b/spec/classes/profile/dns/smartconnect_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::dns::smartconnect" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/dns/standard_spec.rb
+++ b/spec/classes/profile/dns/standard_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::dns::standard" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::docker" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/duo_spec.rb
+++ b/spec/classes/profile/duo_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::duo" do
     contain_file("/etc/security/pam_duo.conf")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/elastic/filebeat/configs/ulib_spec.rb
+++ b/spec/classes/profile/elastic/filebeat/configs/ulib_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::elastic::filebeat::configs::ulib" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:file) { "/etc/filebeat/configs/ulib.yml" }

--- a/spec/classes/profile/elastic/filebeat_spec.rb
+++ b/spec/classes/profile/elastic/filebeat_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::elastic::filebeat" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/elastic/metricbeat_spec.rb
+++ b/spec/classes/profile/elastic/metricbeat_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::elastic::metricbeat" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/elastic_spec.rb
+++ b/spec/classes/profile/elastic_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::elastic" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/exim4_spec.rb
+++ b/spec/classes/profile/exim4_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::exim4" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:fqdn) { facts[:fqdn] }

--- a/spec/classes/profile/falcon_spec.rb
+++ b/spec/classes/profile/falcon_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::falcon" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/fulcrum/base_spec.rb
+++ b/spec/classes/profile/fulcrum/base_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::fulcrum::base" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/fulcrum/logrotate_spec.rb
+++ b/spec/classes/profile/fulcrum/logrotate_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::fulcrum::logrotate" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/fulcrum/solr_spec.rb
+++ b/spec/classes/profile/fulcrum/solr_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::fulcrum::solr" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/fulcrum_config.yaml" }

--- a/spec/classes/profile/github_pull_account_spec.rb
+++ b/spec/classes/profile/github_pull_account_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::github_pull_account" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/groups_spec.rb
+++ b/spec/classes/profile/groups_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::groups" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/usergroups_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/grub_spec.rb
+++ b/spec/classes/profile/grub_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::grub" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::haproxy" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:my_ip) { Faker::Internet.ip_v4_address }
 

--- a/spec/classes/profile/hathitrust/apache/babel_spec.rb
+++ b/spec/classes/profile/hathitrust/apache/babel_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::apache::babel" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/hathitrust/apache_spec.rb
+++ b/spec/classes/profile/hathitrust/apache_spec.rb
@@ -11,7 +11,7 @@ describe "nebula::profile::hathitrust::apache" do
     Regexp.new(string.split("\n").map { |line| Regexp.escape(line.lstrip) }.join('\n\s*'))
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:vhost_config) { "babel.hathitrust.org ssl-directories" }

--- a/spec/classes/profile/hathitrust/babel_logs_spec.rb
+++ b/spec/classes/profile/hathitrust/babel_logs_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../../support/contexts/with_htvm_setup"
 
 describe "nebula::profile::hathitrust::babel_logs" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/hathitrust/cron/catalog_spec.rb
+++ b/spec/classes/profile/hathitrust/cron/catalog_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::cron::catalog" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
+++ b/spec/classes/profile/hathitrust/cron/mdp_misc_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::cron::mdp_misc" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/hathitrust/dependencies_spec.rb
+++ b/spec/classes/profile/hathitrust/dependencies_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../../support/contexts/with_htvm_setup"
 
 describe "nebula::profile::hathitrust::dependencies" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/profile/hathitrust/hosts_spec.rb
+++ b/spec/classes/profile/hathitrust/hosts_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::hosts" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:my_ip) { Faker::Internet.ip_v4_address }
       let(:mysql_ip) { Faker::Internet.ip_v4_address }

--- a/spec/classes/profile/hathitrust/imgsrv_spec.rb
+++ b/spec/classes/profile/hathitrust/imgsrv_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::imgsrv" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) do

--- a/spec/classes/profile/hathitrust/mounts_spec.rb
+++ b/spec/classes/profile/hathitrust/mounts_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::mounts" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(networking: {ip: Faker::Internet.ip_v4_address, interfaces: {}}) }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/hathitrust/perl_spec.rb
+++ b/spec/classes/profile/hathitrust/perl_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../../support/contexts/with_htvm_setup"
 
 describe "nebula::profile::hathitrust::perl" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/profile/hathitrust/php_spec.rb
+++ b/spec/classes/profile/hathitrust/php_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../../support/contexts/with_htvm_setup"
 
 describe "nebula::profile::hathitrust::php" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/profile/hathitrust/slip_spec.rb
+++ b/spec/classes/profile/hathitrust/slip_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::slip" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/catalog_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::solr6::catalog" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/hathitrust/solr6/classic_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/classic_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::solr6::classic" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/hathitrust/solr6/lss_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6/lss_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::solr6::lss" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/hathitrust/solr6_spec.rb
+++ b/spec/classes/profile/hathitrust/solr6_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::hathitrust::solr6" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/profile/http_fileserver_spec.rb
+++ b/spec/classes/profile/http_fileserver_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::http_fileserver" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/deb_server_config.yaml" }

--- a/spec/classes/profile/https_to_port_spec.rb
+++ b/spec/classes/profile/https_to_port_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::https_to_port" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:server_name) { facts[:fqdn] }

--- a/spec/classes/profile/imagemagick_spec.rb
+++ b/spec/classes/profile/imagemagick_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::imagemagick" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/known_host_public_keys_spec.rb
+++ b/spec/classes/profile/known_host_public_keys_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::known_host_public_keys" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/krb5_spec.rb
+++ b/spec/classes/profile/krb5_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::krb5" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/kubelet_spec.rb
+++ b/spec/classes/profile/kubelet_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubelet" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) { {kubelet_version: "invalid-example-version"} }

--- a/spec/classes/profile/kubernetes/apt_spec.rb
+++ b/spec/classes/profile/kubernetes/apt_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::apt" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/kubernetes/bootstrap/destination_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/destination_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::bootstrap::destination" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/etcd_config_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::bootstrap::etcd_config" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/bootstrap/source_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/source_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::bootstrap::source" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/bootstrap/user_spec.rb
+++ b/spec/classes/profile/kubernetes/bootstrap/user_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::bootstrap::user" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -14,7 +14,7 @@ require "spec_helper"
   ["gelf_tcp", 32201, "check"]
 ].each do |service, port, options|
   describe "nebula::profile::kubernetes::destination_port::#{service}" do
-    on_supported_os.each do |os, os_facts|
+    on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
       context "on #{os}" do
         let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
         let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/dns_client_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_client_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::dns_client" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) do

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::dns_server" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       context "with cluster set to first_cluster" do
         let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }

--- a/spec/classes/profile/kubernetes/etcdctl_spec.rb
+++ b/spec/classes/profile/kubernetes/etcdctl_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::etcdctl" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/filesystems_spec.rb
+++ b/spec/classes/profile/kubernetes/filesystems_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::filesystems" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/default_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/haproxy_spec.rb
+++ b/spec/classes/profile/kubernetes/haproxy_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::haproxy" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/keepalived_spec.rb
+++ b/spec/classes/profile/kubernetes/keepalived_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::keepalived" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/kubeadm_config_spec.rb
+++ b/spec/classes/profile/kubernetes/kubeadm_config_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::kubeadm_config" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/kubernetes/kubeadm_spec.rb
+++ b/spec/classes/profile/kubernetes/kubeadm_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::kubeadm" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/kubernetes/kubectl_spec.rb
+++ b/spec/classes/profile/kubernetes/kubectl_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::kubectl" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/kubelet_spec.rb
+++ b/spec/classes/profile/kubernetes/kubelet_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::kubelet" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/prometheus_spec.rb
+++ b/spec/classes/profile/kubernetes/prometheus_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::prometheus" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/kubernetes/router_spec.rb
+++ b/spec/classes/profile/kubernetes/router_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::kubernetes::router" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/kubernetes/first_cluster_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/logrotate_spec.rb
+++ b/spec/classes/profile/logrotate_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::logrotate" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/loki_spec.rb
+++ b/spec/classes/profile/loki_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::loki" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/managed_known_hosts_spec.rb
+++ b/spec/classes/profile/managed_known_hosts_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::managed_known_hosts" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/monitor_pl_spec.rb
+++ b/spec/classes/profile/monitor_pl_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::monitor_pl" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) { {directory: "/somewhere"} }

--- a/spec/classes/profile/mysql_spec.rb
+++ b/spec/classes/profile/mysql_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::mysql" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:params) { {password: "some_password"} }

--- a/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
+++ b/spec/classes/profile/networking/firewall/http_datacenters_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::firewall::http_datacenters" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/firewall/private_ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/private_ssh_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::firewall::private_ssh" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/firewall/ssh_spec.rb
+++ b/spec/classes/profile/networking/firewall/ssh_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::firewall::ssh" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/firewall_spec.rb
+++ b/spec/classes/profile/networking/firewall_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require "faker"
 
 describe "nebula::profile::networking::firewall" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/firewall_config.yaml" }

--- a/spec/classes/profile/networking/keytab_spec.rb
+++ b/spec/classes/profile/networking/keytab_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::keytab" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/private_spec.rb
+++ b/spec/classes/profile/networking/private_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::private" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(networking: {ip: "1.2.3.123"})

--- a/spec/classes/profile/networking/sshd_group_mask_spec.rb
+++ b/spec/classes/profile/networking/sshd_group_mask_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::networking::sshd_group_umask" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/sshd_spec.rb
+++ b/spec/classes/profile/networking/sshd_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::networking::sshd" do
     contain_file("/etc/ssh/sshd_config.d/50-lit.conf")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking/sysctl_spec.rb
+++ b/spec/classes/profile/networking/sysctl_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::networking::sysctl" do
     contain_file("/etc/sysctl.conf")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/networking_spec.rb
+++ b/spec/classes/profile/networking_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::networking" do
     contain_class("nebula::profile::networking::#{name}")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/ntp_spec.rb
+++ b/spec/classes/profile/ntp_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::ntp" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:pools) { "/etc/chrony/sources.d/local-pools.sources" }

--- a/spec/classes/profile/postfix_spec.rb
+++ b/spec/classes/profile/postfix_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::postfix" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus::exporter::haproxy" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(datacenter: "mydatacenter") }
       let(:params) { {master: false} }

--- a/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus::exporter::ipmi" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {

--- a/spec/classes/profile/prometheus/exporter/mysql_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/mysql_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus::exporter::mysql" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(datacenter: "mydatacenter") }
 

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus::exporter::node" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/prometheus_spec.rb
+++ b/spec/classes/profile/prometheus_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/prometheus_with_docker_spec.rb
+++ b/spec/classes/profile/prometheus_with_docker_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::prometheus_with_docker" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/puppet/db_spec.rb
+++ b/spec/classes/profile/puppet/db_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::puppet::db" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/puppet/master_spec.rb
+++ b/spec/classes/profile/puppet/master_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::puppet::master" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/puppet/query_spec.rb
+++ b/spec/classes/profile/puppet/query_spec.rb
@@ -15,7 +15,7 @@ describe "nebula::profile::puppet::query" do
       .with_ensure("directory")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/quod/prod/haproxy_spec.rb
+++ b/spec/classes/profile/quod/prod/haproxy_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require "spec_helper"
 describe "nebula::profile::quod::prod::haproxy" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.deep_merge(

--- a/spec/classes/profile/root_spec.rb
+++ b/spec/classes/profile/root_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::profile::root" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/root_ssh_private_keys_spec.rb
+++ b/spec/classes/profile/root_ssh_private_keys_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::root_ssh_private_keys" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/ruby_spec.rb
+++ b/spec/classes/profile/ruby_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::ruby" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/search/catalog/solr_monitor_spec.rb
+++ b/spec/classes/profile/search/catalog/solr_monitor_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::search::catalog::solr_monitor" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {

--- a/spec/classes/profile/search/catalog/solr_spec.rb
+++ b/spec/classes/profile/search/catalog/solr_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::search::catalog::solr" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {

--- a/spec/classes/profile/solr_spec.rb
+++ b/spec/classes/profile/solr_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::solr" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/taghosts/index_spec.rb
+++ b/spec/classes/profile/taghosts/index_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::taghosts::index" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/taghosts/tags_spec.rb
+++ b/spec/classes/profile/taghosts/tags_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::taghosts::tags" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/tsm_spec.rb
+++ b/spec/classes/profile/tsm_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::tsm" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/unattended_upgrades_spec.rb
+++ b/spec/classes/profile/unattended_upgrades_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::unattended_upgrades" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/unison_spec.rb
+++ b/spec/classes/profile/unison_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::unison" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/unison_config.yaml" }

--- a/spec/classes/profile/users_spec.rb
+++ b/spec/classes/profile/users_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::users" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/ssh_keys_config.yaml" }

--- a/spec/classes/profile/vim_spec.rb
+++ b/spec/classes/profile/vim_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::profile::vim" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/vmhost/host_spec.rb
+++ b/spec/classes/profile/vmhost/host_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::vmhost::host" do
     contain_nebula__virtual_machine(name)
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/www_lib/cron_spec.rb
+++ b/spec/classes/profile/www_lib/cron_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require "spec_helper"
 describe "nebula::profile::www_lib::cron" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/www_lib_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/classes/profile/www_lib/php_spec.rb
+++ b/spec/classes/profile/www_lib/php_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require "spec_helper"
 describe "nebula::profile::www_lib::php" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
+++ b/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
@@ -5,7 +5,7 @@
 # BSD License. See LICENSE.txt for details.
 require "spec_helper"
 describe "nebula::profile::www_lib::register_for_load_balancing" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/resolv_conf_spec.rb
+++ b/spec/classes/resolv_conf_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::resolv_conf" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/aleph_marcedit_spec.rb
+++ b/spec/classes/role/aleph_marcedit_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require "faker"
 
 describe "nebula::role::aleph::marcedit" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/app_host_dev_spec.rb
+++ b/spec/classes/role/app_host_dev_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require "faker"
 
 describe "nebula::role::app_host::dev" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/chipmunk_spec.rb
+++ b/spec/classes/role/chipmunk_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::role::chipmunk" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/chipmunk_config.yaml" }

--- a/spec/classes/role/fulcrum_www_and_app_spec.rb
+++ b/spec/classes/role/fulcrum_www_and_app_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_mocked_nodes"
 
 describe "nebula::role::webhost::fulcrum_www_and_app" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(hostname: "thisnode", datacenter: "somedc") }
       let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }

--- a/spec/classes/role/hathitrust/solr/catalog_spec.rb
+++ b/spec/classes/role/hathitrust/solr/catalog_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::role::hathitrust::solr::catalog" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/role/hathitrust/solr/lss_spec.rb
+++ b/spec/classes/role/hathitrust/solr/lss_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::role::hathitrust::solr::lss" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/role/hathitrust_spec.rb
+++ b/spec/classes/role/hathitrust_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "nebula::role::hathitrust" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require "faker"
 
 describe "nebula::role::hathitrust::datasets" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/role/ht_ingest_spec.rb
+++ b/spec/classes/role/ht_ingest_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require "faker"
 
 describe "nebula::role::hathitrust::ingest_indexing" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/hathitrust_config.yaml" }

--- a/spec/classes/role/htvm_global_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_global_primary_webhost_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_htvm_setup"
 
 describe "nebula::role::webhost::htvm::global_primary" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/role/htvm_prod_webhost_spec.rb
+++ b/spec/classes/role/htvm_prod_webhost_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_htvm_setup"
 
 describe "nebula::role::webhost::htvm::prod" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/role/htvm_site_primary_webhost_spec.rb
+++ b/spec/classes/role/htvm_site_primary_webhost_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_htvm_setup"
 
 describe "nebula::role::webhost::htvm::site_primary" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/role/htvm_test_webhost_spec.rb
+++ b/spec/classes/role/htvm_test_webhost_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_htvm_setup"
 
 describe "nebula::role::webhost::htvm::test" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
       it { is_expected.to contain_package("nodejs") }

--- a/spec/classes/role/htvm_webhost_spec.rb
+++ b/spec/classes/role/htvm_webhost_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_htvm_setup"
 
 describe "nebula::role::webhost::htvm" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       include_context "with setup for htvm node", os_facts
 

--- a/spec/classes/role/kubernetes_spec.rb
+++ b/spec/classes/role/kubernetes_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 
 %w[primary backup].each do |tier|
   describe "nebula::role::kubernetes::#{tier}_gateway" do
-    on_supported_os.each do |os, os_facts|
+    on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
       next if os == "debian-8-x86_64"
 
       context "on #{os}" do
@@ -38,7 +38,7 @@ end
 
 %w[controller etcd worker].each do |role|
   describe "nebula::role::kubernetes::#{role}" do
-    on_supported_os.each do |os, os_facts|
+    on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
       next if os == "debian-8-x86_64"
 
       context "on #{os}" do

--- a/spec/classes/role/minimum_spec.rb
+++ b/spec/classes/role/minimum_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::role::minimum" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/umich_spec.rb
+++ b/spec/classes/role/umich_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::role::umich" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/vmhost_spec.rb
+++ b/spec/classes/role/vmhost_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::role::vmhost" do
     contain_class("nebula::profile::networking::sysctl")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/classes/role/www_lib_vm_spec.rb
+++ b/spec/classes/role/www_lib_vm_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 require_relative "../../support/contexts/with_mocked_nodes"
 
 describe "nebula::role::webhost::www_lib_vm" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(hostname: "thisnode", datacenter: "somedc") }
       let(:rolenode) { {"ip" => Faker::Internet.ip_v4_address, "hostname" => "rolenode"} }

--- a/spec/defines/authzd_user_spec.rb
+++ b/spec/defines/authzd_user_spec.rb
@@ -21,7 +21,7 @@ describe "nebula::authzd_user" do
     }
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/cert_spec.rb
+++ b/spec/defines/cert_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::cert" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/cifs_mount_spec.rb
+++ b/spec/defines/cifs_mount_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::cifs_mount" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/cifs_config.yaml" }

--- a/spec/defines/exposed_port_spec.rb
+++ b/spec/defines/exposed_port_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::exposed_port" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/exposed_port_config.yaml" }

--- a/spec/defines/file/ssh_keys_spec.rb
+++ b/spec/defines/file/ssh_keys_spec.rb
@@ -11,7 +11,7 @@ describe "nebula::file::ssh_keys" do
     {}
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/firewall_allow_spec.rb
+++ b/spec/defines/firewall_allow_spec.rb
@@ -9,7 +9,7 @@ describe "nebula::firewall_allow" do
   let(:title) { "my_firewall_allow" }
   let(:params) { {} }
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:hiera_config) { "spec/fixtures/hiera/firewall_allow_config.yaml" }

--- a/spec/defines/haproxy_binding_spec.rb
+++ b/spec/defines/haproxy_binding_spec.rb
@@ -16,7 +16,7 @@ describe "nebula::haproxy::binding" do
     }
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -9,7 +9,7 @@ describe "nebula::haproxy::service" do
   let(:title) { "svc1" }
   let(:params) { {} }
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:params) do
         super().merge(floating_ip: "1.2.3.4")

--- a/spec/defines/log_spec.rb
+++ b/spec/defines/log_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::log" do
     }
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/taghosts/tag_spec.rb
+++ b/spec/defines/taghosts/tag_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::taghosts::tag" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/defines/unison_client_spec.rb
+++ b/spec/defines/unison_client_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::unison::client" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:title) { "myinstance" }

--- a/spec/defines/unison_server_spec.rb
+++ b/spec/defines/unison_server_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "nebula::unison::server" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:title) { "myinstance" }

--- a/spec/defines/usergroup_spec.rb
+++ b/spec/defines/usergroup_spec.rb
@@ -11,7 +11,7 @@ describe "nebula::usergroup" do
     {}
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:hiera_config) { "spec/fixtures/hiera/usergroups_config.yaml" }
       let(:facts) { os_facts }

--- a/spec/defines/virtual_machine_spec.rb
+++ b/spec/defines/virtual_machine_spec.rb
@@ -21,7 +21,7 @@ describe "nebula::virtual_machine" do
     contain_file("/tmp/.virtual.#{title}/preseed.cfg")
   end
 
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/functions/public_ip_spec.rb
+++ b/spec/functions/public_ip_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe "public_ip" do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/spec/spec_helper/supported_os.rb
+++ b/spec/spec_helper/supported_os.rb
@@ -1,0 +1,30 @@
+require "json"
+
+module Nebula
+  # adapted from rspec-puppet-facts
+  def self.metadata
+    return @metadata if @metadata
+    unless File.file? metadata_file
+      fail StandardError, "Can't find metadata.json... dunno why"
+    end
+    content = File.read metadata_file
+    @metadata = JSON.parse content
+  end
+
+  def self.metadata_file
+    "metadata.json"
+  end
+
+  def self.supported_os
+    return @supported_os if @supported_os
+    if ENV.key?("SUPPORTED_OS") && !ENV["SUPPORTED_OS"].empty?
+      if /^(?<os>\w+) (?<rel>\d+(?:\.\d+)?)$/ =~ ENV["SUPPORTED_OS"]
+        [{"operatingsystem" => os, "operatingsystemrelease" => [rel]}]
+      else
+        raise "can't parse SUPPORTED_OS env var"
+      end
+    else
+      metadata["operatingsystem_support"]
+    end
+  end
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -3,3 +3,4 @@
 require "faker"
 require "spec_helper/deep_merge"
 require "spec_helper/stub_loader"
+require "spec_helper/supported_os"


### PR DESCRIPTION
Provide base support for per OS CI runs. This only affects local tests so far.

Examples:
```
% SUPPORTED_OS="Debian 12" bundle exec rake parallel_spec_standalone
% SUPPORTED_OS="Ubuntu 22.04" bundle exec rspec spec/classes/profile/vmhost/host_spec.rb
% SUPPORTED_OS="Ubuntu 24.04" bundle exec rspec spec/classes/profile/vmhost/host_spec.rb
% bundle exec rake supported_os
["Debian 11","Debian 12","Debian 13","Ubuntu 22.04"]
```