### PR TITLE
remove legacy networking facts from specs

### DIFF
--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -13,7 +13,7 @@ describe "nebula::profile::base" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:fqdn) { facts[:fqdn] }
+      let(:fqdn) { facts[:networking]["fqdn"] }
 
       it { is_expected.to contain_service("puppet").with_ensure("running") }
       it { is_expected.to contain_service("puppet").with_enable(true) }

--- a/spec/classes/profile/exim4_spec.rb
+++ b/spec/classes/profile/exim4_spec.rb
@@ -9,7 +9,7 @@ describe "nebula::profile::exim4" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:fqdn) { facts[:fqdn] }
+      let(:fqdn) { facts[:networking]["fqdn"] }
 
       it do
         expect(subject).to contain_service("exim4").with(

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -28,7 +28,7 @@ describe "nebula::profile::haproxy" do
       let(:keepalived_conf) { "/etc/keepalived/keepalived.conf" }
       let(:service) { "keepalived" }
 
-      let(:thisnode) { {"ip" => facts[:networking][:ip], "hostname" => facts[:hostname]} }
+      let(:thisnode) { {"ip" => facts[:networking][:ip], "hostname" => facts[:networking]["hostname"]} }
       let(:base_params) do
         {
           cert_source: "/some/where",

--- a/spec/classes/profile/https_to_port_spec.rb
+++ b/spec/classes/profile/https_to_port_spec.rb
@@ -9,7 +9,7 @@ describe "nebula::profile::https_to_port" do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:server_name) { facts[:fqdn] }
+      let(:server_name) { facts[:networking]["fqdn"] }
       let(:letsencrypt_directory) { "/etc/letsencrypt/live/#{server_name}" }
 
       context "when port is set to 1234" do

--- a/spec/classes/profile/kubernetes/destination_port_spec.rb
+++ b/spec/classes/profile/kubernetes/destination_port_spec.rb
@@ -25,16 +25,16 @@ require "spec_helper"
           subject { exported_resources }
 
           it do
-            expect(subject).to contain_concat_fragment("haproxy kubernetes #{service.tr("_", " ")} #{facts[:hostname]}")
+            expect(subject).to contain_concat_fragment("haproxy kubernetes #{service.tr("_", " ")} #{facts[:networking]["hostname"]}")
               .with_target("/etc/haproxy/services.d/#{service}.cfg")
               .with_order("02")
-              .with_content("  server #{facts[:hostname]} #{facts[:ipaddress]}:#{port} #{options}\n")
+              .with_content("  server #{facts[:networking]["hostname"]} #{facts[:networking]["ip"]}:#{port} #{options}\n")
               .with_tag("first_cluster_haproxy_kubernetes_#{service}")
           end
 
           if service == "etcd"
             it do
-              expect(subject).to contain_concat_fragment("prometheus #{service.tr("_", " ")} service #{facts[:hostname]}")
+              expect(subject).to contain_concat_fragment("prometheus #{service.tr("_", " ")} service #{facts[:networking]["hostname"]}")
                 .with_target("/etc/prometheus/#{service}.yml")
                 .with_tag("mydatacenter_prometheus_etcd_service_list")
             end

--- a/spec/classes/profile/kubernetes/dns_client_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_client_spec.rb
@@ -31,7 +31,7 @@ describe "nebula::profile::kubernetes::dns_client" do
         expect(exported_resources).to contain_concat_fragment("/etc/hosts ipv4 #{facts[:networking]["ip"]}")
           .with_target("/etc/hosts")
           .with_order("04")
-          .with_content("#{facts[:networking]["ip"]} #{facts[:fqdn]} #{facts[:hostname]}\n")
+          .with_content("#{facts[:networking]["ip"]} #{facts[:networking]["fqdn"]} #{facts[:networking]["hostname"]}\n")
       end
 
       it do

--- a/spec/classes/profile/kubernetes/keepalived_spec.rb
+++ b/spec/classes/profile/kubernetes/keepalived_spec.rb
@@ -39,10 +39,10 @@ describe "nebula::profile::kubernetes::keepalived" do
         end
 
         it "exports its ip address for first_cluster keepalived peers" do
-          expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:networking]["hostname"]}")
             .with_target(file)
             .with_order("02")
-            .with_content(%r{^\s*#{os_facts[:ipaddress]}\s*$}m)
+            .with_content(%r{^\s*#{os_facts[:networking]["ip"]}\s*$}m)
             .with_tag("first_cluster_keepalived")
         end
 
@@ -56,7 +56,7 @@ describe "nebula::profile::kubernetes::keepalived" do
           %r{root@default.invalid},
           %r{state BACKUP},
           %r{priority 100},
-          %r{unicast_src_ip #{os_facts[:ipaddress]}},
+          %r{unicast_src_ip #{os_facts[:networking]["ip"]}},
           %r{virtual_ipaddress \{[^\}]*10\.0\.0\.1[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.1 dev ens4[^\}]*\}}m,
           %r{virtual_ipaddress \{[^\}]*172\.16\.0\.6 dev ens4[^\}]*\}}m,
@@ -70,7 +70,7 @@ describe "nebula::profile::kubernetes::keepalived" do
           let(:hiera_config) { "spec/fixtures/hiera/kubernetes/second_cluster_config.yaml" }
 
           it "exports its ip address for second_cluster keepalived peers" do
-            expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("keepalived #{os_facts[:networking]["hostname"]}")
               .with_tag("second_cluster_keepalived")
           end
 

--- a/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/haproxy_spec.rb
@@ -33,7 +33,7 @@ describe "nebula::profile::prometheus::exporter::haproxy" do
       end
 
       it "exports target data" do
-        expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
+        expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:networking]["hostname"]}")
           .with_target("/etc/prometheus/haproxy.yml")
           .with_tag("mydatacenter_prometheus_haproxy_service_list")
       end
@@ -42,7 +42,7 @@ describe "nebula::profile::prometheus::exporter::haproxy" do
         let(:params) { {master: false} }
 
         it "exports target data with priority backup" do
-          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:networking]["hostname"]}")
             .with_content(%r{priority: 'backup'})
         end
       end
@@ -51,7 +51,7 @@ describe "nebula::profile::prometheus::exporter::haproxy" do
         let(:params) { {master: true} }
 
         it "exports target data with priority primary" do
-          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:networking]["hostname"]}")
             .with_content(%r{priority: 'primary'})
         end
       end
@@ -66,7 +66,7 @@ describe "nebula::profile::prometheus::exporter::haproxy" do
         let(:facts) { os_facts.merge(datacenter: "fakedatacenter") }
 
         it do
-          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus haproxy service #{facts[:networking]["hostname"]}")
             .with_tag("fakedatacenter_prometheus_haproxy_service_list")
         end
       end

--- a/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/ipmi_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {
-          "public" => [os_facts[:ipaddress]],
+          "public" => [os_facts[:networking]["ip"]],
           "private" => []
         })
       end
@@ -19,7 +19,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
       it { is_expected.not_to contain_service("kubelet") }
       it { is_expected.not_to contain_file("/etc/prometheus") }
       it { is_expected.not_to contain_file("/etc/prometheus/ipmi.yaml") }
-      it { expect(exported_resources).not_to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}") }
+      it { expect(exported_resources).not_to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}") }
 
       context "with an account set" do
         let(:params) do
@@ -49,14 +49,14 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
             .with_tag("mydatacenter_prometheus_ipmi_exporter")
             .with_target("/etc/prometheus/ipmi.yml")
             .with_order("02")
             .with_content(%r{^ +- +"remote-ipmi.example"$})
             .with_content(%r{^ +datacenter: "mydatacenter"$})
-            .with_content(%r{^ +via: "#{facts[:hostname]}"$})
-            .with_content(%r{^ +replacement: "#{facts[:ipaddress]}:9290"$})
+            .with_content(%r{^ +via: "#{facts[:networking]["hostname"]}"$})
+            .with_content(%r{^ +replacement: "#{facts[:networking]["ip"]}:9290"$})
         end
       end
 
@@ -85,7 +85,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
             .with_content(%r{^ +- +"ipmi-1.example"$})
             .with_content(%r{^ +- +"ipmi-2.example"$})
         end
@@ -108,7 +108,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
         end
 
         it do
-          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
             .with_content(%r{^ +- +"ipmi.example"$})
         end
       end
@@ -234,7 +234,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
           end
 
           it do
-            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
               .with_content(%r{^ +replacement: "100.100.100.100:9290"$})
           end
 
@@ -247,7 +247,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
             end
 
             it do
-              expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+              expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
                 .with_content(%r{^ +replacement: "10.23.45.67:9290"$})
             end
           end
@@ -262,7 +262,7 @@ describe "nebula::profile::prometheus::exporter::ipmi" do
           end
 
           it "chooses the first private IP address" do
-            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("prometheus ipmi scrape config #{facts[:networking]["hostname"]}")
               .with_content(%r{^ +replacement: "192.168.0.100:9290"$})
               .without_content(%r{100.100.100.100})
               .without_content(%r{100.200.200.200})

--- a/spec/classes/profile/prometheus/exporter/mysql_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/mysql_spec.rb
@@ -32,10 +32,10 @@ describe "nebula::profile::prometheus::exporter::mysql" do
       end
 
       it "exports itself to the default datacenter's service discovery" do
-        expect(exported_resources).to contain_concat_fragment("prometheus mysql service #{facts[:hostname]}")
+        expect(exported_resources).to contain_concat_fragment("prometheus mysql service #{facts[:networking]["hostname"]}")
           .with_tag("mydatacenter_prometheus_mysql_service_list")
           .with_target("/etc/prometheus/mysql.yml")
-          .with_content(%r{'#{facts[:ipaddress]}:9104'})
+          .with_content(%r{'#{facts[:networking]["ip"]}:9104'})
       end
     end
   end

--- a/spec/classes/profile/prometheus/exporter/node_spec.rb
+++ b/spec/classes/profile/prometheus/exporter/node_spec.rb
@@ -107,14 +107,14 @@ describe "nebula::profile::prometheus::exporter::node" do
       end
 
       it "exports itself to the default datacenter's service discovery" do
-        expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+        expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:networking]["hostname"]}")
           .with_tag("default_prometheus_node_service_list")
           .with_target("/etc/prometheus/nodes.yml")
           .with_content(%r{'123.123.123.123:9100'})
       end
 
       it "exports itself to the default datacenter's pushgateway" do
-        expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 123.123.123.123")
+        expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 123.123.123.123")
           .with_tag("default_pushgateway_node")
           .with_proto("tcp")
           .with_dport(9091)
@@ -132,20 +132,20 @@ describe "nebula::profile::prometheus::exporter::node" do
         end
 
         it "exports itself to the default datacenter's service discovery" do
-          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:networking]["hostname"]}")
             .with_tag("default_prometheus_node_service_list")
             .with_target("/etc/prometheus/nodes.yml")
             .with_content(%r{'100\.100\.100\.100:9100'})
         end
 
         it "exports itself[0] to the default datacenter's pushgateway" do
-          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 100.100.100.100")
             .with_tag("default_pushgateway_node")
             .with_source("100.100.100.100")
         end
 
         it "exports itself[1] to the default datacenter's pushgateway" do
-          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 200.200.200.200")
             .with_tag("default_pushgateway_node")
             .with_source("200.200.200.200")
         end
@@ -166,12 +166,12 @@ describe "nebula::profile::prometheus::exporter::node" do
         let(:params) { {covered_datacenters: %w[mydatacenter]} }
 
         it "exports itself to its datacenter's service discovery" do
-          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+          expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:networking]["hostname"]}")
             .with_tag("mydatacenter_prometheus_node_service_list")
         end
 
         it "exports itself to its datacenter's pushgateway" do
-          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.123.123.123")
+          expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 10.123.123.123")
             .with_tag("mydatacenter_pushgateway_node")
             .with_source("10.123.123.123")
         end
@@ -185,20 +185,20 @@ describe "nebula::profile::prometheus::exporter::node" do
           end
 
           it "exports itself to the default datacenter's service discovery" do
-            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:networking]["hostname"]}")
               .with_tag("mydatacenter_prometheus_node_service_list")
               .with_target("/etc/prometheus/nodes.yml")
               .with_content(%r{'10\.1\.2\.3:9100'})
           end
 
           it "exports itself[0] to its datacenter's pushgateway" do
-            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.1.2.3")
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 10.1.2.3")
               .with_tag("mydatacenter_pushgateway_node")
               .with_source("10.1.2.3")
           end
 
           it "exports itself[1] to its datacenter's pushgateway" do
-            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 10.4.5.6")
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 10.4.5.6")
               .with_tag("mydatacenter_pushgateway_node")
               .with_source("10.4.5.6")
           end
@@ -213,20 +213,20 @@ describe "nebula::profile::prometheus::exporter::node" do
           end
 
           it "exports itself to the default datacenter's service discovery" do
-            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:hostname]}")
+            expect(exported_resources).to contain_concat_fragment("prometheus node service #{facts[:networking]["hostname"]}")
               .with_tag("mydatacenter_prometheus_node_service_list")
               .with_target("/etc/prometheus/nodes.yml")
               .with_content(%r{'100\.100\.100\.100:9100'})
           end
 
           it "exports itself[0] to the default datacenter's pushgateway" do
-            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 100.100.100.100")
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 100.100.100.100")
               .with_tag("mydatacenter_pushgateway_node")
               .with_source("100.100.100.100")
           end
 
           it "exports itself[1] to the default datacenter's pushgateway" do
-            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:hostname]} 200.200.200.200")
+            expect(exported_resources).to contain_firewall("300 pushgateway #{facts[:networking]["hostname"]} 200.200.200.200")
               .with_tag("mydatacenter_pushgateway_node")
               .with_source("200.200.200.200")
           end

--- a/spec/classes/profile/prometheus_with_docker_spec.rb
+++ b/spec/classes/profile/prometheus_with_docker_spec.rb
@@ -135,7 +135,7 @@ describe "nebula::profile::prometheus_with_docker" do
 
       it do
         expect(subject).to contain_file("/etc/prometheus/tls/client.crt")
-          .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.crt")
+          .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:networking]["fqdn"]}.crt")
           .with_mode("0644")
           .with_owner("nobody")
           .with_group("nogroup")
@@ -145,7 +145,7 @@ describe "nebula::profile::prometheus_with_docker" do
 
       it do
         expect(subject).to contain_file("/etc/prometheus/tls/client.key")
-          .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:fqdn]}.key")
+          .with_source("puppet:///ssl-certs/prometheus-pki/#{facts[:networking]["fqdn"]}.key")
           .with_mode("0600")
           .with_owner("nobody")
           .with_group("nogroup")
@@ -196,18 +196,18 @@ describe "nebula::profile::prometheus_with_docker" do
       [["haproxy", 9101],
         ["mysql", 9104]].each do |exporter, port|
         it "exports a firewall so that #{exporter} exporters can open #{port}" do
-          expect(exported_resources).to contain_firewall("010 prometheus #{exporter} exporter #{facts[:hostname]}")
+          expect(exported_resources).to contain_firewall("010 prometheus #{exporter} exporter #{facts[:networking]["hostname"]}")
             .with_tag("mydatacenter_prometheus_#{exporter}_exporter")
             .with_proto("tcp")
             .with_dport(port)
-            .with_source(facts[:ipaddress])
+            .with_source(facts[:networking]["ip"])
             .with_state("NEW")
             .with_jump("accept")
         end
       end
 
       it "does not export legacy port 9100 firewall resource" do
-        expect(exported_resources).not_to contain_firewall("010 prometheus legacy node exporter #{facts[:hostname]}")
+        expect(exported_resources).not_to contain_firewall("010 prometheus legacy node exporter #{facts[:networking]["hostname"]}")
       end
 
       context "with no mlibrary_ip_addresses fact" do
@@ -220,13 +220,13 @@ describe "nebula::profile::prometheus_with_docker" do
         it do
           expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced url mydatacenter")
             .with_target("/usr/local/bin/pushgateway_advanced")
-            .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
+            .with_content("PUSHGATEWAY='http://#{facts[:networking]["ip"]}:9091'\n")
         end
 
         it do
           expect(exported_resources).to contain_concat_fragment("02 pushgateway advanced public url mydatacenter")
             .with_target("/usr/local/bin/pushgateway_advanced")
-            .with_content("PUSHGATEWAY='http://#{facts[:ipaddress]}:9091'\n")
+            .with_content("PUSHGATEWAY='http://#{facts[:networking]["ip"]}:9091'\n")
         end
 
         it do
@@ -243,7 +243,7 @@ describe "nebula::profile::prometheus_with_docker" do
         end
 
         it do
-          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:networking]["hostname"]} 100.100.100.100")
             .with_source("100.100.100.100")
             .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
@@ -274,13 +274,13 @@ describe "nebula::profile::prometheus_with_docker" do
         end
 
         it do
-          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 100.100.100.100")
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:networking]["hostname"]} 100.100.100.100")
             .with_source("100.100.100.100")
             .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
 
         it do
-          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:hostname]} 200.200.200.200")
+          expect(exported_resources).to contain_firewall("010 prometheus public node exporter #{facts[:networking]["hostname"]} 200.200.200.200")
             .with_source("200.200.200.200")
             .with_tag("mydatacenter_prometheus_public_node_exporter")
         end
@@ -311,7 +311,7 @@ describe "nebula::profile::prometheus_with_docker" do
         end
 
         it do
-          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:hostname]} 10.1.2.3")
+          expect(exported_resources).to contain_firewall("010 prometheus private node exporter #{facts[:networking]["hostname"]} 10.1.2.3")
             .with_source("10.1.2.3")
             .with_tag("mydatacenter_prometheus_private_node_exporter")
         end
@@ -347,7 +347,7 @@ describe "nebula::profile::prometheus_with_docker" do
           [["node", 9100],
             ["ipmi", 9290]].each do |exporter, port|
             it "exports a firewall so that #{exporter} exporters can open #{network} #{port} to #{ip_address}" do
-              expect(exported_resources).to contain_firewall("010 prometheus #{network} #{exporter} exporter #{facts[:hostname]} #{ip_address}")
+              expect(exported_resources).to contain_firewall("010 prometheus #{network} #{exporter} exporter #{facts[:networking]["hostname"]} #{ip_address}")
                 .with_tag("mydatacenter_prometheus_#{network}_#{exporter}_exporter")
                 .with_proto("tcp")
                 .with_dport(port)

--- a/spec/classes/profile/search/catalog/solr_monitor_spec.rb
+++ b/spec/classes/profile/search/catalog/solr_monitor_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::search::catalog::solr_monitor" do
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {
-          "public" => [os_facts[:ipaddress]],
+          "public" => [os_facts[:networking]["ip"]],
           "private" => []
         })
       end

--- a/spec/classes/profile/search/catalog/solr_spec.rb
+++ b/spec/classes/profile/search/catalog/solr_spec.rb
@@ -10,7 +10,7 @@ describe "nebula::profile::search::catalog::solr" do
     context "on #{os}" do
       let(:facts) do
         os_facts.merge(mlibrary_ip_addresses: {
-          "public" => [os_facts[:ipaddress]],
+          "public" => [os_facts[:networking]["ip"]],
           "private" => []
         })
       end

--- a/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
+++ b/spec/classes/profile/www_lib/register_for_load_balancing_spec.rb
@@ -18,26 +18,26 @@ describe "nebula::profile::www_lib::register_for_load_balancing" do
           let(:params) { {services: ["www-lib"]} }
 
           it do
-            expect(subject).to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib")
+            expect(subject).to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} www-lib")
               .with_service("www-lib")
           end
 
-          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:hostname]} deepblue") }
+          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} deepblue") }
         end
 
         context "with services set to www-lib and deepblue" do
           let(:params) { {services: %w[www-lib deepblue]} }
 
-          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib") }
-          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} deepblue") }
+          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} www-lib") }
+          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} deepblue") }
         end
 
         context "with services set to www-lib-testing" do
           let(:params) { {services: ["www-lib-testing"]} }
 
-          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib-testing") }
-          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:hostname]} www-lib") }
-          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:hostname]} deepblue") }
+          it { is_expected.to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} www-lib-testing") }
+          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} www-lib") }
+          it { is_expected.not_to contain_nebula__haproxy__binding("#{facts[:networking]["hostname"]} deepblue") }
         end
       end
     end

--- a/spec/defines/taghosts/tag_spec.rb
+++ b/spec/defines/taghosts/tag_spec.rb
@@ -16,7 +16,7 @@ describe "nebula::taghosts::tag" do
         it { is_expected.to compile }
 
         it do
-          expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 100 apache")
+          expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:networking]["fqdn"]} 100 apache")
             .with_tag("taghosts")
             .with_target("/var/lib/ae/active-servers")
             .with_content(" apache")
@@ -27,13 +27,13 @@ describe "nebula::taghosts::tag" do
         let(:title) { "python" }
 
         it { is_expected.to compile }
-        it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 100 python") }
+        it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:networking]["fqdn"]} 100 python") }
 
         context "with order set to 500" do
           let(:params) { {order: "500"} }
 
           it { is_expected.to compile }
-          it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:fqdn]} 500 python") }
+          it { expect(exported_resources).to contain_concat__fragment("taghosts #{facts[:networking]["fqdn"]} 500 python") }
         end
       end
     end

--- a/spec/defines/unison_client_spec.rb
+++ b/spec/defines/unison_client_spec.rb
@@ -57,10 +57,10 @@ describe "nebula::unison::client" do
       end
 
       it "exports firewall resource" do
-        expect(exported_resources).to contain_firewall("200 Unison: myinstance #{facts[:hostname]}").with(
+        expect(exported_resources).to contain_firewall("200 Unison: myinstance #{facts[:networking]["hostname"]}").with(
           proto: "tcp",
           dport: [12_345],
-          source: facts[:ipaddress],
+          source: facts[:networking]["ip"],
           tag: "unison-client-myinstance"
         )
       end

--- a/spec/defines/unison_server_spec.rb
+++ b/spec/defines/unison_server_spec.rb
@@ -41,7 +41,7 @@ describe "nebula::unison::server" do
 
       it "exports client" do
         expect(exported_resources).to contain_nebula__unison__client("myinstance").with(
-          server: facts[:fqdn],
+          server: facts[:networking]["fqdn"],
           # from hiera
           port: 12_345,
           root: "/myroot",


### PR DESCRIPTION
Remove legacy networking facts in specs that break on rspec-puppet v5.0.0. This unblocks several gem dependencies, including rspec-puppet-facts, facterdb, and puppetlabs_spec_helper.