### PR TITLE
HathiTrust ETT-1166: Add php-smarty3

### DIFF
--- a/manifests/profile/hathitrust/php.pp
+++ b/manifests/profile/hathitrust/php.pp
@@ -22,6 +22,7 @@ class nebula::profile::hathitrust::php () {
       'php-mdb2',
       'php-mdb2-driver-mysql',
       'php-smarty',
+      'smarty3',
       'php-xml',
       'php-mbstring',
       'php-yaml',


### PR DESCRIPTION
We are working towards PHP 8 / Debian 12/13 compatibility; smarty3 is provided by Debian including in Debian 12 and 13. It is also available in Debian 11 and works with PHP 7.4; the current version of the catalog also works with this package installed on dev-N.catalog.hathitrust.org -- that is, Smarty 2 via php-smarty (our package) does not conflict with Debian-packaged php-smarty3.