### PR TITLE
remove smartconnect dns server entry

### DIFF
--- a/manifests/profile/dns/smartconnect.pp
+++ b/manifests/profile/dns/smartconnect.pp
@@ -4,20 +4,11 @@
 
 # nebula::profile::dns::smartconnect
 #
-# Set up bind9 for smartconnect. You must also define these two array
-# parameters in hiera:
+# Deprecated. Accepts all parameters that it previously did, but ignores them.
+# This profile only exists to:
+#    - ensure catalogs that use it compile until they are rewritten
+#    - delete `nameserver 127.0.0.1` from resolv.conf
 #
-# - nebula::resolv_conf::searchpath
-# - nebula::resolv_conf::nameservers
-#
-# @param domain Domain to forward to the nameserver
-# @param nameserver Nameserver IP address
-# @param master_zones Ordered list of master zone names and files
-# @param other_ns_ips Override nebula::resolv_conf::nameservers by
-#   setting this to a nonempty array of IP addresses
-#
-# @example
-#   include nebula::profile::dns::smartconnect
 class nebula::profile::dns::smartconnect (
   String $domain,
   String $nameserver,
@@ -26,52 +17,5 @@ class nebula::profile::dns::smartconnect (
 ) {
   include stdlib
 
-  package { 'nebula::profile::dns::smartconnect::bind9':
-    ensure => 'present',
-    name   => 'bind9',
-  }
-
-  service { 'bind9':
-    ensure     => 'running',
-    enable     => true,
-    hasrestart => true,
-    tag        => 'private_network'
-  }
-
-  if empty($other_ns_ips) {
-    $nameservers = lookup('nebula::resolv_conf::nameservers')
-  } else {
-    $nameservers = $other_ns_ips
-  }
-
-  class { 'nebula::resolv_conf':
-    nameservers => concat(['127.0.0.1'], $nameservers),
-    searchpath  => lookup('nebula::resolv_conf::searchpath'),
-    require     => Service['bind9']
-  }
-
-  Service['bind9'] -> File['/etc/resolv.conf']
-  File['/etc/resolv.conf'] -> Nebula::Nfs_mount <| tag == 'smartconnect' |>
-
-  file { '/etc/bind':
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'bind',
-    require => Package['nebula::profile::dns::smartconnect::bind9']
-  }
-
-  file { '/etc/bind/named.conf':
-    notify  => Service['bind9'],
-    content => template('nebula/profile/dns/smartconnect/named.conf.erb'),
-  }
-
-  file { '/etc/bind/named.conf.local':
-    notify  => Service['bind9'],
-    content => template('nebula/profile/dns/smartconnect/named.conf.local.erb'),
-  }
-
-  file { '/etc/bind/named.conf.options':
-    notify  => Service['bind9'],
-    content => template('nebula/profile/dns/smartconnect/named.conf.options.erb'),
-  }
+  class { 'nebula::resolv_conf': }
 }

--- a/spec/classes/profile/dns/smartconnect_spec.rb
+++ b/spec/classes/profile/dns/smartconnect_spec.rb
@@ -10,24 +10,20 @@ describe "nebula::profile::dns::smartconnect" do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it do
-        expect(subject).to contain_package(
-          "nebula::profile::dns::smartconnect::bind9"
-        ).with_name("bind9").with_ensure("present")
-      end
-
-      it do
-        expect(subject).to contain_service("bind9").with_ensure("running")
+      it "has no bind package" do
+        is_expected.not_to contain_package("nebula::profile::dns::smartconnect::bind9")
+        is_expected.not_to contain_package("bind9")
+        is_expected.not_to contain_service("bind9")
       end
 
       it do
         expect(subject).to contain_class("nebula::resolv_conf").with_nameservers(
           [
-            "127.0.0.1",  # localhost
             "5.5.5.5",    # nebula::resolv_conf::nameservers[0]
             "4.4.4.4"    # nebula::resolv_conf::nameservers[1]
           ]
         ).with_searchpath(["searchpath.default.invalid"])
+        is_expected.not_to contain_class("nebula::resolv_conf")
           .with_require("Service[bind9]")
       end
 
@@ -39,9 +35,10 @@ describe "nebula::profile::dns::smartconnect" do
         expect(subject).to contain_file("/etc/resolv.conf")
           .with_content(%r{^#.*puppet})
           .with_content(%r{^search searchpath\.default\.invalid$})
-          .with_content(%r{^nameserver 127.0.0.1$})
           .with_content(%r{^nameserver 5.5.5.5$})
           .with_content(%r{^nameserver 4.4.4.4$})
+        is_expected.not_to contain_file("/etc/resolv.conf")
+          .with_content(%r{^nameserver 127.0.0.1$})
       end
 
       [
@@ -49,52 +46,7 @@ describe "nebula::profile::dns::smartconnect" do
         "/etc/bind/named.conf.local",
         "/etc/bind/named.conf.options"
       ].each do |name|
-        it { is_expected.to contain_file(name).with_notify("Service[bind9]") }
-      end
-
-      it do
-        expect(subject).to contain_file("/etc/bind/named.conf").with_content(
-          %r{/etc/bind/named.conf.options}
-        ).with_content(
-          %r{/etc/bind/named.conf.local}
-        )
-      end
-
-      [
-        %r{^zone "localhost" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.local";$}m,
-        %r{^zone "127\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.127";$}m,
-        %r{^zone "0\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.0";$}m,
-        %r{^zone "255\.in-addr\.arpa" \{[^\}]*type master;[^\}]*file "/etc/bind/db\.255";$}m,
-        %r{^zone "smartconnect\.default\.invalid" \{[^\}]*type forward;[^\}]*forward only;[^\}]*1\.2\.3\.4;$}m
-      ].each do |content|
-        it { is_expected.to contain_file("/etc/bind/named.conf.local").with_content(content) }
-      end
-
-      it do
-        expect(subject).to contain_file("/etc/bind/named.conf.options").with_content(
-          %r{^\s*5\.5\.5\.5; 4\.4\.4\.4;$}
-        )
-      end
-
-      context "when given other_ns_ips" do
-        let(:params) { {other_ns_ips: ["3.3.3.3", "2.2.2.2", "1.1.1.1"]} }
-
-        it do
-          expect(subject).to contain_class("nebula::resolv_conf").with_nameservers(
-            [
-              "127.0.0.1",
-              "3.3.3.3",
-              "2.2.2.2",
-              "1.1.1.1"
-            ]
-          ).with_searchpath(["searchpath.default.invalid"])
-        end
-
-        it do
-          expect(subject).to contain_file("/etc/bind/named.conf.options").with_content(
-            %r{^\s*3\.3\.3\.3; 2\.2\.2\.2; 1\.1\.1\.1;$}
-          )
-        end
+        it { is_expected.not_to contain_file(name) }
       end
     end
   end


### PR DESCRIPTION
- do nothing to configure smartconnect
- delete `nameserver 127.0.0.1` from resolv.conf
- does NOT remove bind9, we'll purge it manually
- after this has run everywhere the smartconnect class can be removed completely