### PR TITLE
set architecture for openvox repo

### DIFF
--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -90,6 +90,7 @@ class nebula::profile::apt (
       release       => "${facts['os']['name'].downcase()}${facts['os']['release']['major']}",
       repos         => [$puppet_repo],
       keyring       => '/etc/apt/keyrings/openvox.asc',
+      architecture  => $facts['os']['architecture'],
     }
 
     apt::keyring { 'openvox.asc':


### PR DESCRIPTION
prevents errors on ancient VMs that still actually attempt to check for i386 packages