### PR TITLE
Add rake task to update forge deps

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,41 +1,81 @@
-# This file can be used to install module depdencies for unit testing
-# See https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures for details
 ---
 fixtures:
-  # I'm leaving this here for next time, since it comes up so rarely
-  # that I always have to look it up. If we fork something and want to
-  # include our fork (the same applies to anything not in the forge), we
-  # add it to our fixtures under `repositories` instead of under
-  # `forge_modules`. Also, we add it to the Puppetfile in the control
-  # repo; not to metadata.json in nebula.
-  #
-  #repositories:
-  #  module_name:
-  #    repo: "https://github.com/mlibrary/repo_name"
   forge_modules:
-    rbenv:               {"repo": "jdowning/rbenv",             "ref": "3.1.0" }
-    archive:             {"repo": "puppet/archive",             "ref": "8.1.0" }
-    kmod:                {"repo": "puppet/kmod",                "ref": "5.0.0" }
-    letsencrypt:         {"repo": "puppet/letsencrypt",         "ref": "13.1.0"}
-    logrotate:           {"repo": "puppet/logrotate",           "ref": "9.0.0" }
-    nginx:               {"repo": "puppet/nginx",               "ref": "7.0.1" }
-    php:                 {"repo": "puppet/php",                 "ref": "12.0.0"}
-    systemd:             {"repo": "puppet/systemd",             "ref": "9.4.0" }
-    unattended_upgrades: {"repo": "puppet/unattended_upgrades", "ref": "9.1.0" }
-    apache:              {"repo": "puppetlabs/apache",          "ref": "13.1.0"}
-    apt:                 {"repo": "puppetlabs/apt",             "ref": "10.0.1"}
-    augeas_core:         {"repo": "puppetlabs/augeas_core",     "ref": "2.0.1" }
-    concat:              {"repo": "puppetlabs/concat",          "ref": "9.1.0" }
-    cron_core:           {"repo": "puppetlabs/cron_core",       "ref": "2.0.2" }
-    docker:              {"repo": "puppetlabs/docker",          "ref": "10.3.0"}
-    firewall:            {"repo": "puppetlabs/firewall",        "ref": "8.2.0" }
-    host_core:           {"repo": "puppetlabs/host_core",       "ref": "2.0.1" }
-    inifile:             {"repo": "puppetlabs/inifile",         "ref": "6.2.0" }
-    lvm:                 {"repo": "puppetlabs/lvm",             "ref": "3.0.1" }
-    mount_core:          {"repo": "puppetlabs/mount_core",      "ref": "2.0.1" }
-    mysql:               {"repo": "puppetlabs/mysql",           "ref": "16.3.0"}
-    reboot:              {"repo": "puppetlabs/reboot",          "ref": "5.1.0" }
-    sshkeys_core:        {"repo": "puppetlabs/sshkeys_core",    "ref": "3.0.1" }
-    stdlib:              {"repo": "puppetlabs/stdlib",          "ref": "9.7.0" }
-    vcsrepo:             {"repo": "puppetlabs/vcsrepo",         "ref": "7.0.0" }
-    debconf:             {"repo": "stm/debconf",                "ref": "7.0.1" }
+    rbenv:
+      repo: jdowning/rbenv
+      ref: 3.1.0
+    archive:
+      repo: puppet/archive
+      ref: 8.1.0
+    kmod:
+      repo: puppet/kmod
+      ref: 5.0.0
+    letsencrypt:
+      repo: puppet/letsencrypt
+      ref: 13.1.0
+    logrotate:
+      repo: puppet/logrotate
+      ref: 9.0.0
+    nginx:
+      repo: puppet/nginx
+      ref: 7.0.1
+    php:
+      repo: puppet/php
+      ref: 12.0.0
+    systemd:
+      repo: puppet/systemd
+      ref: 9.4.0
+    unattended_upgrades:
+      repo: puppet/unattended_upgrades
+      ref: 9.1.0
+    apache:
+      repo: puppetlabs/apache
+      ref: 13.1.0
+    apt:
+      repo: puppetlabs/apt
+      ref: 10.0.1
+    augeas_core:
+      repo: puppetlabs/augeas_core
+      ref: 2.0.1
+    concat:
+      repo: puppetlabs/concat
+      ref: 9.1.0
+    cron_core:
+      repo: puppetlabs/cron_core
+      ref: 2.0.2
+    docker:
+      repo: puppetlabs/docker
+      ref: 10.3.0
+    firewall:
+      repo: puppetlabs/firewall
+      ref: 8.2.0
+    host_core:
+      repo: puppetlabs/host_core
+      ref: 2.0.1
+    inifile:
+      repo: puppetlabs/inifile
+      ref: 6.2.0
+    lvm:
+      repo: puppetlabs/lvm
+      ref: 3.0.1
+    mount_core:
+      repo: puppetlabs/mount_core
+      ref: 2.0.1
+    mysql:
+      repo: puppetlabs/mysql
+      ref: 16.3.0
+    reboot:
+      repo: puppetlabs/reboot
+      ref: 5.1.0
+    sshkeys_core:
+      repo: puppetlabs/sshkeys_core
+      ref: 3.0.1
+    stdlib:
+      repo: puppetlabs/stdlib
+      ref: 9.7.0
+    vcsrepo:
+      repo: puppetlabs/vcsrepo
+      ref: 7.0.0
+    debconf:
+      repo: stm/debconf
+      ref: 7.0.1

--- a/metadata.json
+++ b/metadata.json
@@ -1,47 +1,131 @@
 {
   "name": "mlibrary-nebula",
-  "version": "2.0.2",
-  "author": "Matthew Alexander LaChance",
+  "version": "3.0.0",
+  "author": "MLibrary",
   "summary": "Central MLibrary module",
   "license": "BSD-3-Clause",
   "source": "https://github.com/mlibrary/nebula",
-  "issues_url": "https://github.com/mlibrary/nebula/issues",
   "dependencies": [
-    {"name": "jdowning/rbenv",             "version_requirement": ">= 3.1.0  < 4.0.0" },
-    {"name": "puppet/archive",             "version_requirement": ">= 8.1.0  < 9.0.0" },
-    {"name": "puppet/kmod",                "version_requirement": ">= 5.0.0  < 6.0.0" },
-    {"name": "puppet/letsencrypt",         "version_requirement": ">= 13.1.0 < 14.0.0"},
-    {"name": "puppet/logrotate",           "version_requirement": ">= 9.0.0  < 10.0.0"},
-    {"name": "puppet/nginx",               "version_requirement": ">= 7.0.1  < 8.0.0" },
-    {"name": "puppet/php",                 "version_requirement": ">= 12.0.0 < 13.0.0"},
-    {"name": "puppet/systemd",             "version_requirement": ">= 9.4.0  < 10.0.0"},
-    {"name": "puppet/unattended_upgrades", "version_requirement": ">= 9.1.0  < 10.0.0"},
-    {"name": "puppetlabs/apache",          "version_requirement": ">= 13.1.0 < 14.0.0"},
-    {"name": "puppetlabs/apt",             "version_requirement": ">= 10.0.1 < 11.0.0"},
-    {"name": "puppetlabs/augeas_core",     "version_requirement": ">= 2.0.1  < 3.0.0" },
-    {"name": "puppetlabs/concat",          "version_requirement": ">= 9.1.0  < 10.0.0"},
-    {"name": "puppetlabs/cron_core",       "version_requirement": ">= 2.0.2  < 3.0.0" },
-    {"name": "puppetlabs/docker",          "version_requirement": ">= 10.3.0 < 11.0.0"},
-    {"name": "puppetlabs/firewall",        "version_requirement": ">= 8.2.0  < 9.0.0" },
-    {"name": "puppetlabs/host_core",       "version_requirement": ">= 2.0.1  < 3.0.0" },
-    {"name": "puppetlabs/inifile",         "version_requirement": ">= 6.2.0  < 7.0.0" },
-    {"name": "puppetlabs/lvm",             "version_requirement": ">= 3.0.1  < 4.0.0" },
-    {"name": "puppetlabs/mount_core",      "version_requirement": ">= 2.0.1  < 3.0.0" },
-    {"name": "puppetlabs/mysql",           "version_requirement": ">= 16.3.0 < 17.0.0"},
-    {"name": "puppetlabs/reboot",          "version_requirement": ">= 5.1.0  < 6.0.0" },
-    {"name": "puppetlabs/sshkeys_core",    "version_requirement": ">= 3.0.1  < 4.0.0" },
-    {"name": "puppetlabs/stdlib",          "version_requirement": ">= 9.7.0  < 10.0.0"},
-    {"name": "puppetlabs/vcsrepo",         "version_requirement": ">= 7.0.0  < 8.0.0" },
-    {"name": "stm/debconf",                "version_requirement": ">= 7.0.1  < 8.0.0" }
+    {
+      "name": "jdowning/rbenv",
+      "version_requirement": ">= 3.1.0 < 4.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 8.1.0 < 9.0.0"
+    },
+    {
+      "name": "puppet/kmod",
+      "version_requirement": ">= 5.0.0 < 6.0.0"
+    },
+    {
+      "name": "puppet/letsencrypt",
+      "version_requirement": ">= 13.1.0 < 14.0.0"
+    },
+    {
+      "name": "puppet/logrotate",
+      "version_requirement": ">= 9.0.0 < 10.0.0"
+    },
+    {
+      "name": "puppet/nginx",
+      "version_requirement": ">= 7.0.1 < 8.0.0"
+    },
+    {
+      "name": "puppet/php",
+      "version_requirement": ">= 12.0.0 < 13.0.0"
+    },
+    {
+      "name": "puppet/systemd",
+      "version_requirement": ">= 9.4.0 < 10.0.0"
+    },
+    {
+      "name": "puppet/unattended_upgrades",
+      "version_requirement": ">= 9.1.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/apache",
+      "version_requirement": ">= 13.1.0 < 14.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 10.0.1 < 11.0.0"
+    },
+    {
+      "name": "puppetlabs/augeas_core",
+      "version_requirement": ">= 2.0.1 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 9.1.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/cron_core",
+      "version_requirement": ">= 2.0.2 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/docker",
+      "version_requirement": ">= 10.3.0 < 11.0.0"
+    },
+    {
+      "name": "puppetlabs/firewall",
+      "version_requirement": ">= 8.2.0 < 9.0.0"
+    },
+    {
+      "name": "puppetlabs/host_core",
+      "version_requirement": ">= 2.0.1 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/inifile",
+      "version_requirement": ">= 6.2.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/lvm",
+      "version_requirement": ">= 3.0.1 < 4.0.0"
+    },
+    {
+      "name": "puppetlabs/mount_core",
+      "version_requirement": ">= 2.0.1 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/mysql",
+      "version_requirement": ">= 16.3.0 < 17.0.0"
+    },
+    {
+      "name": "puppetlabs/reboot",
+      "version_requirement": ">= 5.1.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/sshkeys_core",
+      "version_requirement": ">= 3.0.1 < 4.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 9.7.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/vcsrepo",
+      "version_requirement": ">= 7.0.0 < 8.0.0"
+    },
+    {
+      "name": "stm/debconf",
+      "version_requirement": ">= 7.0.1 < 8.0.0"
+    }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["11","12","13"]
+      "operatingsystemrelease": [
+        "11",
+        "12",
+        "13"
+      ]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": ["22.04"]
+      "operatingsystemrelease": [
+        "22.04",
+        "24.04"
+      ]
     }
   ],
   "requirements": [
@@ -49,8 +133,5 @@
       "name": "puppet",
       "version_requirement": ">= 8.0.0 < 9.0.0"
     }
-  ],
-  "pdk-version": "3.3.0",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#3.0.1",
-  "template-ref": "tags/3.0.1-0-gd13288a"
+  ]
 }

--- a/rakelib/forge.rake
+++ b/rakelib/forge.rake
@@ -1,30 +1,127 @@
-desc "list outdated modules in .fixtures.yml"
-task :outdated do |t|
-  require "yaml"
-  require "net/http"
-  require "uri"
-  require "json"
+require "yaml"
+require "net/http"
+require "uri"
+require "json"
 
-  fixtures = YAML.load_file(".fixtures.yml")
-  fixtures["fixtures"]["forge_modules"].values.each do |mod|
-    repo = mod["repo"]
-    slug = repo.tr("/", "-")
-    vers = mod["ref"]
-    uri = URI.parse "https://forgeapi.puppet.com/v3/modules/#{slug}"
+def metadata_file
+  "metadata.json"
+end
 
-    response = Net::HTTP.get_response(uri)
-    raise "failed to fetch #{mod["repo"]}" unless response.code == "200"
+def fixtures_file
+  ".fixtures.yml"
+end
 
-    releases = JSON.parse(response.body)["releases"].map { |x| x["version"] }
-    installed_index = releases.find_index(vers)
-    installed = releases[installed_index]
+def metadata_src_file
+  "rakelib/metadata.yaml"
+end
 
-    if installed_index != 0
-      newer = releases.slice(0, installed_index).join(", ")
-      puts "#{repo} (#{installed}) < #{newer}"
-      puts "https://forge.puppet.com/modules/#{repo}"
+def api_server
+  "forgeapi.puppet.com"
+end
 
-      puts
+def forge_meta(forge_module)
+  slug = forge_module.tr("/", "-")
+  uri = URI.parse "https://#{api_server}/v3/modules/#{slug}"
+  resp = Net::HTTP.get_response(uri)
+  resp.code == "200" or
+    raise "failed to fetch metadata from #{api_server} for module #{forge_module}"
+
+  JSON.parse(resp.body)
+end
+
+namespace "forge" do
+  desc "list outdated modules in .fixtures.yml"
+  task :outdated do |t|
+    fixtures = YAML.load_file(fixtures_file)
+    fixtures["fixtures"]["forge_modules"].values.each do |mod|
+      repo = mod["repo"]
+      vers = mod["ref"]
+
+      releases = forge_meta(mod["repo"])["releases"].map { |x| x["version"] }
+      installed_index = releases.find_index(vers)
+      installed = releases[installed_index]
+
+      if installed_index != 0
+        newer = releases.slice(0, installed_index).join(", ")
+        puts "#{repo} (#{installed}) < #{newer}"
+        puts "https://forge.puppet.com/modules/#{repo}"
+
+        puts
+      end
     end
+  end
+
+  def next_maj(version)
+    /^(?<maj>\d+)\.(?<_>\d+)\.(?<_>\d+)$/ =~ version or
+      raise "can't parse version: #{version}"
+    "#{maj.to_i + 1}.0.0"
+  end
+
+  desc "regenerate metadata.json and .fixtures.yml with updated modules"
+  task :update do |t|
+    meta = YAML.load_file(metadata_src_file)
+    deps = meta["dependencies"]
+    meta["dependencies"] = []
+
+    # validate
+    module_names = deps.map { |x| x["name"].split("/")[-1] }
+    module_names.length == module_names.uniq.length or
+      raise "#{metadata_src_file} contains duplicate dependency"
+
+    fixtures = {}
+
+    deps.each do |mod|
+      full_name = mod["name"]
+      /^(?<_>(?<org_name>\w+)\/)?(?<mod_name>\w+)$/ =~ full_name or
+        raise "#{full_name} is not a valid module name"
+
+      mod["info"] and
+        puts "INFO: #{mod["info"]}"
+
+      if org_name
+        # module from forge
+        mod["repo"] and
+          raise "field 'repo' makes no sense for modules installed from forge"
+
+        current_version = forge_meta(full_name)["current_release"]["version"]
+        version = mod["ref"] || current_version
+        version_requirement = ">= #{version} < #{next_maj(version)}"
+
+        if mod["ref"]
+          mod["info"] or
+            raise "#{full_name} has version pinned with 'ref', but no 'info'. Add a comment in 'info' explaining why a pinned version is needed."
+
+          puts
+          puts "WARNING: Using fixed version for module '#{full_name}'. If you need a more specific"
+          puts "         version_requirement set than is listed below, you MUST manually edit"
+          puts "         metadata.json before committing. Additionally, please be certain that"
+          puts "         this pinned version is still actually required, and consider removing"
+          puts "         the 'ref' field for #{full_name} from '#{metadata_src_file}'."
+          puts
+          puts "                                       module: #{full_name}"
+          puts "                              current version: #{current_version}"
+          puts "                                fixed version: #{version}"
+          puts "           generated version_requirement spec: '#{version_requirement}'"
+          puts
+        end
+
+        meta["dependencies"].push({"name" => full_name, "version_requirement" => version_requirement})
+        fixtures["forge_modules"] ||= {}
+        fixtures["forge_modules"][mod_name] = {"repo" => full_name, "ref" => version}
+        puts "#{full_name} #{version}"
+      else
+        # module from git
+        mod["repo"] or
+          raise "field 'repo' required for modules installed from git"
+
+        fixtures["repositories"] ||= []
+        fixtures["repositories"][full_name] = {"repo" => mod["repo"]}
+        mod["ref"] and
+          fixtures["repositories"][full_name]["ref"] = mod["ref"]
+      end
+    end
+
+    File.write(fixtures_file, {"fixtures" => fixtures}.to_yaml)
+    File.write(metadata_file, JSON.pretty_generate(meta) + "\n")
   end
 end

--- a/rakelib/metadata.yaml
+++ b/rakelib/metadata.yaml
@@ -1,0 +1,65 @@
+---
+name: mlibrary-nebula
+version: 3.0.0
+author: MLibrary
+summary: Central MLibrary module
+license: BSD-3-Clause
+source: https://github.com/mlibrary/nebula
+dependencies:
+# examples:
+# # add a module from a puppet forge, use latest version
+# - name: example/foobar
+# # add a module from a puppet forge, pinned to a specific version
+# - name: example/foobar
+#   # set version to ">= 10.1.0 < 11.0.0"; if you want something more specific,
+#   # you'll have to hand-edit config after it's generated
+#   version: 10.1.0 # optional, only affects .fixtures.yml
+# # add a module from a git repo (note: must also add module control repo!)
+# - name: private_module
+#   repo: https://github.com/mlibrary/repo_name
+#   ref: some_git_ref # optional
+# # print additional info while checking this module
+# - name: example/foobar
+#   info: example/foobar 1.2.3 blocks example/baz 4.0.0
+- name: jdowning/rbenv
+- name: puppet/archive
+- name: puppet/kmod
+- name: puppet/letsencrypt
+- name: puppet/logrotate
+- name: puppet/nginx
+- name: puppet/php
+- name: puppet/systemd
+- name: puppet/unattended_upgrades
+- name: puppetlabs/apache
+- name: puppetlabs/apt
+  ref: 10.0.1
+  info: puppetlabs/apt 11.0.0 blocked by puppetlabs/docker 10.3.0
+- name: puppetlabs/augeas_core
+- name: puppetlabs/concat
+- name: puppetlabs/cron_core
+- name: puppetlabs/docker
+  info: puppetlabs/docker 10.3.0 blocks puppetlabs/apt 11.0.0
+- name: puppetlabs/firewall
+- name: puppetlabs/host_core
+- name: puppetlabs/inifile
+- name: puppetlabs/lvm
+- name: puppetlabs/mount_core
+- name: puppetlabs/mysql
+- name: puppetlabs/reboot
+- name: puppetlabs/sshkeys_core
+- name: puppetlabs/stdlib
+- name: puppetlabs/vcsrepo
+- name: stm/debconf
+operatingsystem_support:
+- operatingsystem: Debian
+  operatingsystemrelease:
+  - "11"
+  - "12"
+  - "13"
+- operatingsystem: Ubuntu
+  operatingsystemrelease:
+  - "22.04"
+  - "24.04"
+requirements:
+- name: puppet
+  version_requirement: ">= 8.0.0 < 9.0.0"


### PR DESCRIPTION
- add forge:update rake task
  - reads specs from rakelib/metadata.yaml
  - fetches current version numbers from forge
  - writes both metadata.json and .fixtures.yml
- rename outdated to forge:outdated for consistency