### PR TITLE
ht solr release script: umount stale snapshots

### DIFF
--- a/manifests/profile/hathitrust/solr6/catalog.pp
+++ b/manifests/profile/hathitrust/solr6/catalog.pp
@@ -40,6 +40,7 @@ class nebula::profile::hathitrust::solr6::catalog (
   $core_link_prefix = ''
   $is_catalog = true
   $is_primary_node = true # catalog solr is only one node per site
+  ensure_packages(['jq'])
   file { '/usr/local/bin/index-release':
     owner   => 'root',
     mode    => '0755',

--- a/manifests/profile/hathitrust/solr6/lss.pp
+++ b/manifests/profile/hathitrust/solr6/lss.pp
@@ -48,6 +48,7 @@ class nebula::profile::hathitrust::solr6::lss (
   $solr_stop_flag = 'STOPLSSRELEASE'
   $core_link_prefix = 'lss-'
   $is_lss = true
+  ensure_packages(['jq'])
   file { '/usr/local/bin/index-release':
     owner   => 'root',
     mode    => '0755',

--- a/templates/profile/hathitrust/solr6/index-release.sh.erb
+++ b/templates/profile/hathitrust/solr6/index-release.sh.erb
@@ -13,16 +13,16 @@ if [[ -n "${manual_snap}" ]]; then
   if ! [[ -d "${snap}" ]]; then
     echo "can't find snapshot: '${manual_snap}'"
     echo "valid snapshots are: "
-    \ls ${base}/.zfs/snapshot/
+    /bin/ls ${base}/.zfs/snapshot/
     exit 1
   fi
+  snapname="$(basename "${snap}")"
 else
   snaps=( "${base}/.zfs/snapshot/htsolr-<%= @solr_name %>_"* )
   snap="${snaps[-1]}"
-  pat="htsolr-<%= @solr_name %>_$(date +%Y-%m-%d)"
-  [[ "$snap" =~ "$pat" ]] || onoe "latest snap was not made today, refusing to run automatic release"
+  snapname="$(basename "${snap}")"
+  [[ "$snapname" = "htsolr-<%= @solr_name %>_$(date +%Y-%m-%d)"* ]] || onoe "latest snap was not made today, refusing to run automatic release"
 fi
-snapname="$(basename "${snap}")"
 
 # check if the administrative release stop flag is set
 [[ -f "${base}/flags/<%= @solr_stop_flag %>" ]] && onoe "<%= @solr_stop_flag %> flag present...skip release today"

--- a/templates/profile/hathitrust/solr6/index-release.sh.erb
+++ b/templates/profile/hathitrust/solr6/index-release.sh.erb
@@ -65,6 +65,11 @@ rm -f ${serve}/<%= @core_link_prefix %><%= core %> && ln -s "${snap}/cores/<%= c
   onoe "error removing or creating symlink for core <%= core %>...solr WILL NOT be started on $(hostname -s)"
 <% end -%>
 
+# umount stale snaps
+for x in $(findmnt --mountpoint $base -RJ | jq -r '.filesystems[] | select(.children) | .children[].target | select(. != "'"${snap}"'")'); do
+  umount "$x"
+done
+
 # if all went well, start solr
 systemctl start solr || onoe "error starting solr on $(hostname -s)"
 


### PR DESCRIPTION
umount stale snapshots, misc lint fixes

Currently, when we delete old snaps they may still be mounted solr servers. This `umount`s all snaps except the one we're releasing so these excess mountpoints don't stick around.