### PR TITLE
Add basic metrics for quod requests

### DIFF
--- a/files/mtail/quod_apache.mtail
+++ b/files/mtail/quod_apache.mtail
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# This file is an adaptation of the apache_combined.mtail example from the mtail project,
+# formerly hosted at https://github.com/google/mtail, now: https://github.com/jaqx0r/mtail
+#
+# It carried the following copyright and license notice:
+#
+#   Copyright 2015 Ben Kochie <superq@gmail.com>. All Rights Reserved.
+#   This file is available under the Apache license.
+#
+# The "Apache license" mentioned is the Apache License, Version 2.0 -- SPDX Apache-2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#   https://opensource.org/license/apache-2-0
+#
+########
+
+# Parser for the common apache "NCSA extended/combined" log format
+# LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"
+
+counter quod_http_requests_total by request_method, request_status, prefix, collection
+counter quod_http_bytes_total by request_method, request_status, prefix, collection
+histogram quod_http_request_time_seconds buckets 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50 by request_method, request_status, prefix, collection
+
+hidden text prefix
+hidden text collid
+
+#### Component constants - These are inlined into the constants below, and the compiler complains if we defined but don't use them
+# const PATH_COLLECTION  /\/(?P<collection>[0-9A-Za-z_]+)/
+# const QUERY_COLLECTION /(\?(\S+=\S+(&|;|%3B))*(cc=(?P<collection>[0-9A-Za-z_]+)))?/
+
+# const IIIF_BASE     /(?P<base>\/cgi\/(i\/image|t\/text)\/api\/)/
+# const IMAGE_BASE    /(?P<base>\/cgi\/i\/image\/)/ 
+# const TEXT_BASE     /(?P<base>\/cgi\/t\/text\/)/
+# const BIB_BASE      /(?P<base>\/cgi\/b\/bib\/)/
+# const PAGEFIND_BASE /(?P<base>\/a-z\/pagefind\/)/
+
+# const IIIF_RESOURCE /(?P<iiif_resource>image|tile|thumb)/
+# const IMAGE_SCRIPT  /(?P<script>download-pdf-ix|getimage-idx|idx|image-idx|pdf-idx|pdf-idx-reduced)/
+# const TEXT_SCRIPT   /(?P<script>download-pfx-idx|idx|obj-idx|pageviewer-idx|pdf-idx|text-idx)/
+# const BIB_SCRIPT    /(?P<script>bib-idx)/
+
+
+# These are workarounds... For some reason, we can't use explicit comparison with concatenated constants... ???
+
+const IIIF_REQUEST     /(?P<base>\/cgi\/(i\/image|t\/text)\/api\/)(?P<iiif_resource>image|tile|thumb)\/(?P<collection>[0-9A-Za-z_]+)/
+const IMAGE_REQUEST    /(?P<base>\/cgi\/i\/image\/)(?P<script>download-pdf-ix|getimage-idx|idx|image-idx|pdf-idx|pdf-idx-reduced)(\?(\S+=\S+(&|;|%3B))*(cc=(?P<collection>[0-9A-Za-z_]+)))?/
+const TEXT_REQUEST     /(?P<base>\/cgi\/t\/text\/)(?P<script>download-pfx-idx|idx|obj-idx|pageviewer-idx|pdf-idx|text-idx)(\?(\S+=\S+(&|;|%3B))*(cc=(?P<collection>[0-9A-Za-z_]+)))?/
+const BIB_REQUEST      /(?P<base>\/cgi\/b\/bib\/)(?P<script>bib-idx)(\?(\S+=\S+(&|;|%3B))*(cc=(?P<collection>[0-9A-Za-z_]+)))?/
+const PAGEFIND_REQUEST /(?P<base>\/a-z\/pagefind)\//
+
+/^/ +
+/(?P<hostname>[0-9A-Za-z\.:-]+) / + # %h
+/(?P<remote_logname>[0-9A-Za-z-]+) / + # %l
+/(?P<remote_username>([0-9A-Za-z-]+|"")) / + # %u
+/\[(?P<timestamp>\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} (\+|-)\d{4})\] / + # %t
+/"(?P<request_method>[A-Z]+) (?P<URI>\S+) (?P<http_version>HTTP\/[0-9\.]+)" / + # \"%r\"
+/(?P<request_status>\d{3}) / + # %>s
+/((?P<response_size>\d+)|-) / + # %b
+/"(?P<referer>\S+)" / + # \"%{Referer}i\"
+/"(?P<user_agent>[[:print:]]+)" / + # \"%{User-agent}i\"
+/(?P<server_name>\S+) / +
+/(?P<micro_time>\d+)/ +
+/$/ {
+  strptime($timestamp, "02/Jan/2006:15:04:05 -0700") # for tests
+
+  # handles thumb/coll/item as well as image/coll:item
+  #$URI =~ IIIF_BASE + IIIF_RESOURCE + PATH_COLLECTION {
+  $URI =~ IIIF_REQUEST {
+    prefix = $base + $iiif_resource
+    collid = $collection
+  }
+
+  #$URI =~ IMAGE_BASE + IMAGE_SCRIPT + QUERY_COLLECTION {
+  $URI =~ IMAGE_REQUEST {
+    prefix = $base + $script
+    collid = $collection
+  }
+
+  #$URI =~ TEXT_BASE + TEXT_SCRIPT + QUERY_COLLECTION {
+  $URI =~ TEXT_REQUEST {
+    prefix = $base + $script
+    collid = $collection
+  }
+
+  #$URI =~ BIB_BASE + BIB_SCRIPT + QUERY_COLLECTION {
+  $URI =~ BIB_REQUEST {
+    prefix = $base + $script
+    collid = $collection
+  }
+
+  $URI =~ PAGEFIND_REQUEST {
+    prefix = $base
+    collid = ""
+  }
+
+  otherwise {
+    prefix = "/"
+    collid = ""
+  }
+
+  quod_http_request_time_seconds[$request_method][$request_status][prefix][collid] = $micro_time / 1000000.0
+
+  quod_http_requests_total[$request_method][$request_status][prefix][collid]++
+  $response_size > 0 {
+      quod_http_bytes_total[$request_method][$request_status][prefix][collid] += $response_size
+  }
+}

--- a/manifests/profile/prometheus_with_docker.pp
+++ b/manifests/profile/prometheus_with_docker.pp
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The Regents of the University of Michigan.
+# Copyright (c) 2019-2026 The Regents of the University of Michigan.
 # All Rights Reserved. Licensed according to the terms of the Revised
 # BSD License. See LICENSE.txt for details.
 
@@ -40,6 +40,7 @@ class nebula::profile::prometheus_with_docker (
       '/etc/prometheus/ipmi.yml:/etc/prometheus/ipmi.yml',
       '/etc/prometheus/etcd.yml:/etc/prometheus/etcd.yml',
       '/etc/prometheus/catalog_search.yml:/etc/prometheus/catalog_search.yml',
+      '/etc/prometheus/quod.yml:/etc/prometheus/quod.yml',
       '/etc/prometheus/tls:/tls',
       '/opt/prometheus:/prometheus',
     ],
@@ -120,6 +121,13 @@ class nebula::profile::prometheus_with_docker (
   }
 
   Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_catalog_search_service_list" |>>
+
+  concat_file { '/etc/prometheus/quod.yml':
+    notify  => Docker::Run['prometheus'],
+    require => File['/etc/prometheus'],
+  }
+
+  Concat_fragment <<| tag == "${facts['datacenter']}_prometheus_quod_service_list" |>>
 
   file { '/etc/prometheus':
     ensure => 'directory',
@@ -286,6 +294,10 @@ class nebula::profile::prometheus_with_docker (
 
       "010 prometheus private search catalog reindex exporter ${::networking['hostname']} ${address}":
         tag => "${facts['datacenter']}_prometheus_private_search_catalog_reindex_exporter",
+      ;
+
+      "010 prometheus quod exporter ${::networking['hostname']} ${address}":
+        tag => "${facts['datacenter']}_prometheus_private_quod_exporter"
       ;
     }
   }

--- a/manifests/profile/quod/prod/metrics.pp
+++ b/manifests/profile/quod/prod/metrics.pp
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+
+# nebula::profile::quod::prod::metrics
+#
+# Collect and export quod metrics based on Apache logs and running processes
+#
+# @example
+#   include nebula::profile::quod::prod::metrics
+class nebula::profile::quod::prod::metrics (
+  $mtail_port = 3903,
+) {
+  ensure_packages([
+    'mtail'
+  ])
+
+  $role = lookup_role()
+  $hostname = $::networking['hostname']
+  $datacenter = $facts['datacenter']
+
+  $all_private_addresses = $facts["mlibrary_ip_addresses"]["private"]
+  if $all_private_addresses == [] {
+    fail('Host cannot be scraped without a private IP address')
+  } else {
+    $ipaddress = $all_private_addresses[0]
+
+    Firewall <<| tag == "${facts['datacenter']}_prometheus_private_quod_exporter" |>> {
+      dport => $mtail_port,
+    }
+  }
+
+  @@concat_fragment { "prometheus quod scrape config ${hostname}":
+    tag     => "${datacenter}_prometheus_quod_service_list",
+    target  => '/etc/prometheus/quod.yml',
+    order   => '02',
+    content => template('nebula/profile/prometheus/exporter/quod/target.yaml.erb')
+  }
+
+  # The package installs a systemd service and defaults file
+  service { 'mtail':
+    ensure  => 'running',
+    enable  => true,
+    require => Package['mtail'],
+  }
+
+  file { '/etc/mtail/quod_apache.mtail':
+    content => 'nebula/mtail/quod_apache.mtail',
+    notify  => Service['mtail'],
+  }
+
+  file { '/etc/default/mtail':
+    ensure  => 'file',
+    notify  => Service['mtail'],
+    content => @("MTAILCONF")
+      PORT=${mtail_port}
+      LOGS=/var/apache2/access.log
+      | MTAILCONF
+  }
+}

--- a/manifests/role/app_host/quod_prod.pp
+++ b/manifests/role/app_host/quod_prod.pp
@@ -16,6 +16,7 @@ class nebula::role::app_host::quod_prod {
   include nebula::profile::tsm
   include nebula::profile::quod::prod::perl
   include nebula::profile::quod::prod::haproxy
+  include nebula::profile::quod::prod::metrics
   include nebula::profile::networking::firewall::http
 
   # We put the machine certificate in a statically named file because the rdist

--- a/spec/classes/profile/prometheus_with_docker_spec.rb
+++ b/spec/classes/profile/prometheus_with_docker_spec.rb
@@ -25,6 +25,7 @@ describe "nebula::profile::prometheus_with_docker" do
             "/etc/prometheus/ipmi.yml:/etc/prometheus/ipmi.yml",
             "/etc/prometheus/etcd.yml:/etc/prometheus/etcd.yml",
             "/etc/prometheus/catalog_search.yml:/etc/prometheus/catalog_search.yml",
+            "/etc/prometheus/quod.yml:/etc/prometheus/quod.yml",
             "/etc/prometheus/tls:/tls",
             "/opt/prometheus:/prometheus"])
           .that_requires("File[/opt/prometheus]")

--- a/spec/classes/profile/quod/prod/metrics_spec.rb
+++ b/spec/classes/profile/quod/prod/metrics_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 The Regents of the University of Michigan.
+# All Rights Reserved. Licensed according to the terms of the Revised
+# BSD License. See LICENSE.txt for details.
+require "spec_helper"
+
+describe "nebula::profile::quod::prod::metrics" do
+  on_supported_os(supported_os: Nebula.supported_os).each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it do
+        expect(subject).to contain_service("mtail")
+          .with_ensure("running")
+          .with_enable(true)
+      end
+
+      it "exports the target to the datacenter's service discovery" do
+        expect(exported_resources).to contain_concat_fragment("prometheus quod scrape config #{facts[:networking]["hostname"]}")
+          .with_tag("mydatacenter_prometheus_quod_service_list")
+          .with_target("/etc/prometheus/quod.yml")
+      end
+    end
+  end
+end

--- a/templates/profile/prometheus/exporter/quod/target.yaml.erb
+++ b/templates/profile/prometheus/exporter/quod/target.yaml.erb
@@ -1,0 +1,6 @@
+- targets: [ '<%= @ipaddress %>:<%= @mtail_port %>' ]
+  labels:
+    datacenter: '<%= @datacenter %>'
+    hostname: '<%= @hostname %>'
+    role: '<%= @role %>'
+


### PR DESCRIPTION
- Install mtail package
- Ensure the service is enabled/running
- Add the mtail program to process quod Apache logs
- Configure mtail under /etc/default
- Publish the exporter to Prometheus
- Allow Prometheus to connect
- Integrate the new target into Prometheus config
- Add the new profile to production quod only for now