### PR TITLE
Kubeadm config

### DIFF
--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -35,12 +35,6 @@ class nebula::profile::kubelet (
     require => Package['kubelet'],
   }
 
-  exec { 'kubelet reload daemon':
-    command     => '/bin/systemctl daemon-reload',
-    refreshonly => true,
-    notify      => Service['kubelet'],
-  }
-
   if($facts['os']['distro']['codename'] in ['bookworm', 'bullseye']) {
     file { '/etc/systemd/system/kubelet.service.d':
       ensure  => 'directory',
@@ -51,6 +45,12 @@ class nebula::profile::kubelet (
       content => template('nebula/profile/kubernetes/30-kubelet.conf.erb'),
       require => Package['kubelet'],
       notify  => Exec['kubelet reload daemon'],
+    }
+
+    exec { 'kubelet reload daemon':
+      command     => '/bin/systemctl daemon-reload',
+      refreshonly => true,
+      notify      => Service['kubelet'],
     }
   }
 
@@ -77,6 +77,12 @@ class nebula::profile::kubelet (
       content => template('nebula/profile/kubelet/config.yaml.erb'),
       require => Package['kubelet'],
       notify  => Service['kubelet'],
+    }
+
+    exec { 'kubelet reload daemon':
+      command     => '/bin/systemctl daemon-reload',
+      refreshonly => true,
+      notify      => Service['kubelet'],
     }
   }
 }

--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -35,6 +35,25 @@ class nebula::profile::kubelet (
     require => Package['kubelet'],
   }
 
+  exec { 'kubelet reload daemon':
+    command     => '/bin/systemctl daemon-reload',
+    refreshonly => true,
+    notify      => Service['kubelet'],
+  }
+
+  if($facts['os']['distro']['codename'] == 'bookworm') {
+    file { '/etc/systemd/system/kubelet.service.d':
+      ensure  => 'directory',
+      require => Package['kubelet'],
+    }
+
+    file { '/etc/systemd/system/kubelet.service.d/30-kubelet.conf':
+      content => template('nebula/profile/kubernetes/30-kubelet.conf.erb'),
+      require => Package['kubelet'],
+      notify  => Exec['kubelet reload daemon'],
+    }
+  }
+
   if $manage_pods_with_puppet {
     file { $pod_manifest_path:
       ensure  => 'directory',
@@ -58,12 +77,6 @@ class nebula::profile::kubelet (
       content => template('nebula/profile/kubelet/config.yaml.erb'),
       require => Package['kubelet'],
       notify  => Service['kubelet'],
-    }
-
-    exec { 'kubelet reload daemon':
-      command     => '/bin/systemctl daemon-reload',
-      refreshonly => true,
-      notify      => Service['kubelet'],
     }
   }
 }

--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -41,7 +41,7 @@ class nebula::profile::kubelet (
     notify      => Service['kubelet'],
   }
 
-  if($facts['os']['distro']['codename'] == 'bookworm') {
+  if($facts['os']['distro']['codename'] in ['bookworm', 'bullseye]) {
     file { '/etc/systemd/system/kubelet.service.d':
       ensure  => 'directory',
       require => Package['kubelet'],

--- a/manifests/profile/kubelet.pp
+++ b/manifests/profile/kubelet.pp
@@ -41,7 +41,7 @@ class nebula::profile::kubelet (
     notify      => Service['kubelet'],
   }
 
-  if($facts['os']['distro']['codename'] in ['bookworm', 'bullseye]) {
+  if($facts['os']['distro']['codename'] in ['bookworm', 'bullseye']) {
     file { '/etc/systemd/system/kubelet.service.d':
       ensure  => 'directory',
       require => Package['kubelet'],

--- a/manifests/profile/kubernetes/bootstrap/etcd_config.pp
+++ b/manifests/profile/kubernetes/bootstrap/etcd_config.pp
@@ -25,8 +25,12 @@ class nebula::profile::kubernetes::bootstrap::etcd_config {
     notify  => Service['kubelet'],
   }
 
-  file { '/etc/systemd/system/kubelet.service.d':
-    ensure => 'directory',
+  # we are selectively declaring this directory in profiles/kubelet.pp
+  # and declaring it twice creates an error
+  unless($facts['os']['distro']['codename'] in ['bookworm', 'bullseye']) {
+    file { '/etc/systemd/system/kubelet.service.d':
+      ensure  => 'directory',
+    }
   }
 
   if $initial_cluster != 'none' and $etcd_image != 'none' {

--- a/manifests/profile/kubernetes/bootstrap/etcd_config.pp
+++ b/manifests/profile/kubernetes/bootstrap/etcd_config.pp
@@ -25,11 +25,17 @@ class nebula::profile::kubernetes::bootstrap::etcd_config {
     notify  => Service['kubelet'],
   }
 
-  # we are selectively declaring this directory in profiles/kubelet.pp
-  # and declaring it twice creates an error
+  # we are selectively declaring this directory and exec in profiles/kubelet.pp
+  # and declaring them twice creates an error
   unless($facts['os']['distro']['codename'] in ['bookworm', 'bullseye']) {
     file { '/etc/systemd/system/kubelet.service.d':
       ensure  => 'directory',
+    }
+
+    exec { 'kubelet reload daemon':
+      command     => '/bin/systemctl daemon-reload',
+      refreshonly => true,
+      notify      => Service['kubelet'],
     }
   }
 
@@ -38,11 +44,5 @@ class nebula::profile::kubernetes::bootstrap::etcd_config {
       ensure  => 'file',
       content => template('nebula/profile/kubernetes/etcd/etcd.yaml.erb'),
     }
-  }
-
-  exec { 'kubelet reload daemon':
-    command     => '/bin/systemctl daemon-reload',
-    refreshonly => true,
-    notify      => Service['kubelet'],
   }
 }

--- a/templates/profile/kubernetes/30-kubelet.conf.erb
+++ b/templates/profile/kubernetes/30-kubelet.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml --fail-cgroupv1=false"


### PR DESCRIPTION
create a drop-in sysctl config file for kubelet setting the cgroups fail = false as a command line argument. this will create the file on etcd nodes even though it seems to be unnecessary there. since this change only needs to exist until all our nodes are on trixie, it seems ok?