### PR TITLE
HathiTrust ETT-634: PHP composer

### DIFF
--- a/manifests/role/webhost/htvm/test.pp
+++ b/manifests/role/webhost/htvm/test.pp
@@ -18,6 +18,7 @@ class nebula::role::webhost::htvm::test {
   }
 
   ensure_packages([
+    'composer',
     'libxml2-utils',
     'perl-doc',
     'ripgrep',


### PR DESCRIPTION
Add composer in development environments for vendoring PHP libraries

Not needed in production - we'll essentially do composer install (or whatever) in dev, then scp those files to production.