### PR TITLE
update puppetlabs/apt and other modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,7 +12,7 @@ fixtures:
       ref: 5.0.0
     letsencrypt:
       repo: puppet/letsencrypt
-      ref: 13.1.0
+      ref: 13.2.0
     logrotate:
       repo: puppet/logrotate
       ref: 9.0.0
@@ -33,7 +33,7 @@ fixtures:
       ref: 13.1.0
     apt:
       repo: puppetlabs/apt
-      ref: 10.0.1
+      ref: 11.2.0
     augeas_core:
       repo: puppetlabs/augeas_core
       ref: 2.0.1
@@ -45,16 +45,16 @@ fixtures:
       ref: 2.0.2
     docker:
       repo: puppetlabs/docker
-      ref: 10.3.0
+      ref: 10.4.0
     firewall:
       repo: puppetlabs/firewall
-      ref: 8.2.0
+      ref: 8.3.0
     host_core:
       repo: puppetlabs/host_core
       ref: 2.0.1
     inifile:
       repo: puppetlabs/inifile
-      ref: 6.2.0
+      ref: 6.3.0
     lvm:
       repo: puppetlabs/lvm
       ref: 3.0.1

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ bundle exec rake lint # lint .pp files
 # check puppet module dependencies for available updates
 bundle exec rake forge:outdated
 # update dependencies
+vi rakelib/metadata.yaml
 bundle exec rake forge:update
 # test for dependency conflicts
 bundle exec rake librarian

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mlibrary-nebula",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "MLibrary",
   "summary": "Central MLibrary module",
   "license": "BSD-3-Clause",
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppet/letsencrypt",
-      "version_requirement": ">= 13.1.0 < 14.0.0"
+      "version_requirement": ">= 13.2.0 < 14.0.0"
     },
     {
       "name": "puppet/logrotate",
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 10.0.1 < 11.0.0"
+      "version_requirement": ">= 11.2.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",
@@ -64,11 +64,11 @@
     },
     {
       "name": "puppetlabs/docker",
-      "version_requirement": ">= 10.3.0 < 11.0.0"
+      "version_requirement": ">= 10.4.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 8.2.0 < 9.0.0"
+      "version_requirement": ">= 8.3.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/host_core",
@@ -76,7 +76,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
+      "version_requirement": ">= 6.3.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/lvm",

--- a/rakelib/metadata.yaml
+++ b/rakelib/metadata.yaml
@@ -1,6 +1,7 @@
 ---
+# used by forge.rake tasks to generate metadata.json and .fixtures.yml
 name: mlibrary-nebula
-version: 3.0.0
+version: 3.1.0
 author: MLibrary
 summary: Central MLibrary module
 license: BSD-3-Clause
@@ -32,13 +33,10 @@ dependencies:
 - name: puppet/unattended_upgrades
 - name: puppetlabs/apache
 - name: puppetlabs/apt
-  ref: 10.0.1
-  info: puppetlabs/apt 11.0.0 blocked by puppetlabs/docker 10.3.0
 - name: puppetlabs/augeas_core
 - name: puppetlabs/concat
 - name: puppetlabs/cron_core
 - name: puppetlabs/docker
-  info: puppetlabs/docker 10.3.0 blocks puppetlabs/apt 11.0.0
 - name: puppetlabs/firewall
 - name: puppetlabs/host_core
 - name: puppetlabs/inifile


### PR DESCRIPTION
- remove lock on apt module, because puppetlabs/docker update was finally released
- update all modules to current
- add documentation on using `rake forge:update` task
- bump nebula version to 3.1.0