### PR TITLE
revert puppetlabs/apt to 10.0.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -33,7 +33,7 @@ fixtures:
       ref: 13.1.0
     apt:
       repo: puppetlabs/apt
-      ref: 11.2.0
+      ref: 10.0.1
     augeas_core:
       repo: puppetlabs/augeas_core
       ref: 2.0.1

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mlibrary-nebula",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "MLibrary",
   "summary": "Central MLibrary module",
   "license": "BSD-3-Clause",
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 11.2.0 < 12.0.0"
+      "version_requirement": ">= 10.0.1 < 11.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",

--- a/rakelib/metadata.yaml
+++ b/rakelib/metadata.yaml
@@ -1,7 +1,7 @@
 ---
 # used by forge.rake tasks to generate metadata.json and .fixtures.yml
 name: mlibrary-nebula
-version: 3.1.0
+version: 3.1.1
 author: MLibrary
 summary: Central MLibrary module
 license: BSD-3-Clause
@@ -33,6 +33,8 @@ dependencies:
 - name: puppet/unattended_upgrades
 - name: puppetlabs/apache
 - name: puppetlabs/apt
+  ref: 10.0.1
+  info: regression in puppetlabs/apt 11 breaks hpe repo
 - name: puppetlabs/augeas_core
 - name: puppetlabs/concat
 - name: puppetlabs/cron_core


### PR DESCRIPTION
Semantics of adding repos changed here:
https://github.com/puppetlabs/puppetlabs-apt/commit/62c07676868d75f7d9c4e645cbea19a7b5249732

Not clear if this is a bug on their end, ours, or the HPE apt repo, but it's breaking the HP repo.