### PR TITLE
correct path for openafs.ko on trixie

### DIFF
--- a/manifests/profile/afs.pp
+++ b/manifests/profile/afs.pp
@@ -44,9 +44,18 @@ class nebula::profile::afs (
   package { 'openafs-krb5': }
   package { 'openafs-modules-dkms': }
 
+  $kmod = $facts['os']['distro']['codename'] ? {
+    'jammy'    => 'openafs.ko',
+    'bullseye' => 'openafs.ko',
+    'bookworm' => 'openafs.ko',
+    'noble'    => 'openafs.ko',
+    'trixie'   => 'openafs.ko.xz',
+    default    => 'openafs.ko.xz'
+  }
+
   exec { 'reinstall kernel to enable afs':
     command => '/usr/bin/apt-get -y install --reinstall linux-headers-amd64',
-    creates => "/lib/modules/${facts['kernelrelease']}/updates/dkms/openafs.ko",
+    creates => "/lib/modules/${facts['kernelrelease']}/updates/dkms/${$kmod}",
     timeout => 600,
     require => Package['openafs-modules-dkms'],
   }

--- a/spec/classes/profile/afs_spec.rb
+++ b/spec/classes/profile/afs_spec.rb
@@ -21,13 +21,27 @@ describe "nebula::profile::afs" do
 
       it { is_expected.to contain_class("nebula::profile::krb5") }
 
-      it do
-        expect(subject).to contain_exec("reinstall kernel to enable afs").with(
-          command: "/usr/bin/apt-get -y install --reinstall linux-headers-amd64",
-          creates: "/lib/modules/#{kernelrelease}/updates/dkms/openafs.ko",
-          timeout: 600,
-          require: "Package[openafs-modules-dkms]"
-        )
+      case os
+      when "debian-11-x86_64", "ubuntu-22.04-x86_64", "debian-12-x86_64", "ubuntu-24.04-x86_64"
+        it do
+          expect(subject).to contain_exec("reinstall kernel to enable afs").with(
+            command: "/usr/bin/apt-get -y install --reinstall linux-headers-amd64",
+            creates: "/lib/modules/#{kernelrelease}/updates/dkms/openafs.ko",
+            timeout: 600,
+            require: "Package[openafs-modules-dkms]"
+          )
+        end
+      when "debian-13-x86_64"
+        it do
+          expect(subject).to contain_exec("reinstall kernel to enable afs").with(
+            command: "/usr/bin/apt-get -y install --reinstall linux-headers-amd64",
+            creates: "/lib/modules/#{kernelrelease}/updates/dkms/openafs.ko.xz",
+            timeout: 600,
+            require: "Package[openafs-modules-dkms]"
+          )
+        end
+      else
+        raise "expected afs dkms behavior not defined in spec for current os version"
       end
 
       it { is_expected.not_to contain_reboot("afs") }


### PR DESCRIPTION
Set openafs.ko extension based on os version.

On trixie dkms modules have .xz extension. This name change caused
the module to be rebuilt on every puppet run.