### PR TITLE
set architecture for nodesource repo

### DIFF
--- a/manifests/profile/apt/nodejs.pp
+++ b/manifests/profile/apt/nodejs.pp
@@ -31,6 +31,7 @@ class nebula::profile::apt::nodejs (
       release       => 'nodistro',
       repos         => ['main'],
       keyring       => '/etc/apt/keyrings/nodesource.asc',
+      architecture  => $facts['os']['architecture'],
     }
 
     apt::keyring { 'nodesource.asc':


### PR DESCRIPTION
prevents errors on ancient VMs that still actually attempt to check for i386 packages