### PR TITLE
revert k8s settings allowing cgroup v1

### DIFF
--- a/templates/profile/kubelet/config.yaml.erb
+++ b/templates/profile/kubelet/config.yaml.erb
@@ -11,4 +11,3 @@ authentication:
     enabled: false
 authorization:
   mode: "AlwaysAllow"
-failCgroupV1: false

--- a/templates/profile/kubernetes/kubeadm_config.yaml.erb
+++ b/templates/profile/kubernetes/kubeadm_config.yaml.erb
@@ -31,4 +31,3 @@ clusterName: kubernetes
 apiVersion: 'kubelet.config.k8s.io/v1beta1'
 kind: 'KubeletConfiguration'
 cgroupDriver: 'systemd'
-FailCgroupV1: false


### PR DESCRIPTION
We're upgrading all kubernetes nodes to a modern kernel, so this will no longer be needed.