### PR TITLE
ht solr: check for stop flag in snapshot

### DIFF
--- a/templates/profile/hathitrust/solr6/index-release.sh.erb
+++ b/templates/profile/hathitrust/solr6/index-release.sh.erb
@@ -24,12 +24,12 @@ else
   [[ "$snapname" = "htsolr-<%= @solr_name %>_$(date +%Y-%m-%d)"* ]] || onoe "latest snap was not made today, refusing to run automatic release"
 fi
 
-# check if the administrative release stop flag is set
-[[ -f "${base}/flags/<%= @solr_stop_flag %>" ]] && onoe "<%= @solr_stop_flag %> flag present...skip release today"
-
 # check that today's snap exists
 [[ ! -d ${snap}/cores/ ]] && onoe "can't read snapshot dir...aborting release"
 [[ ! -d ${snap}/flags/ ]] && onoe "can't read snapshot dir...aborting release"
+
+# check if the administrative release stop flag is set
+[[ -f "${snap}/flags/<%= @solr_stop_flag %>" ]] && onoe "<%= @solr_stop_flag %> flag present...skip release today"
 
 # check today's snap for 'busy' flag
 [[ -f "${snap}/flags/busy" ]] && onoe "indexing or optimization occurring...skip release today"


### PR DESCRIPTION
We were checking for the stop flag in the live index, which produces inconsistent results between replication src and target datacenters.