### PR TITLE
Correct naming of fd binary

### DIFF
--- a/manifests/profile/interactive.pp
+++ b/manifests/profile/interactive.pp
@@ -14,4 +14,9 @@ class nebula::profile::interactive {
     'zsh',
     'git',
   ])
+  file { '/usr/local/bin/fd':
+    ensure  => link,
+    target  => '/usr/bin/fdfind',
+    require => Package['fd-find'],
+  }
 }


### PR DESCRIPTION
Debian renamed fd to "fdfind" so in doesn't conflict with https://packages.debian.org/trixie/fdclone. I think it's safe to assume we'll never install that package.

This will break if debian ever fixes the naming, but the fdfind name is still present in forky, so I doubt that is coming soon, if ever.
https://packages.debian.org/forky/fd-find