### PR TITLE
Configure dnsmasq to ignore the presence of /sbin/resolvconf

### DIFF
--- a/manifests/profile/kubernetes/dns_server.pp
+++ b/manifests/profile/kubernetes/dns_server.pp
@@ -63,6 +63,19 @@ class nebula::profile::kubernetes::dns_server {
   concat { '/etc/ssh/ssh_known_hosts': }
   Concat_fragment <<| tag == "${cluster_name}_known_host_public_keys" |>>
 
+  exec { 'divert /etc/default/dnsmasq':
+    creates => '/etc/default/dnsmasq.dist',
+    command => '/usr/bin/dpkg-divert --rename --divert /etc/default/dnsmasq.dist --add /etc/default/dnsmasq',
+    notify  => Service['dnsmasq'],
+    require => Package['dnsmasq'],
+  }
+
+  file { '/etc/default/dnsmasq':
+    content => "CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new\nIGNORE_RESOLVCONF=yes\n",
+    notify  => Service['dnsmasq'],
+    require => Exec['divert /etc/default/dnsmasq'],
+  }
+
   file { '/etc/dnsmasq.d/local_domain':
     content => "local=/${private_domain}/\n",
     notify  => Service['dnsmasq']

--- a/spec/classes/profile/kubernetes/dns_server_spec.rb
+++ b/spec/classes/profile/kubernetes/dns_server_spec.rb
@@ -87,6 +87,24 @@ describe "nebula::profile::kubernetes::dns_server" do
         end
 
         it do
+          expect(subject).to contain_file("/etc/default/dnsmasq")
+            .with_content("CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new\nIGNORE_RESOLVCONF=yes\n")
+        end
+
+        it do
+          expect(subject).to contain_exec("divert /etc/default/dnsmasq")
+            .with_creates("/etc/default/dnsmasq.dist")
+            .with_command("/usr/bin/dpkg-divert --rename --divert /etc/default/dnsmasq.dist --add /etc/default/dnsmasq")
+        end
+
+        it do
+          expect(subject).to contain_exec("divert /etc/default/dnsmasq")
+            .that_notifies("Service[dnsmasq]")
+            .that_requires("Package[dnsmasq]")
+            .that_comes_before("File[/etc/default/dnsmasq]")
+        end
+
+        it do
           expect(subject).to contain_concat_fragment("/etc/hosts ipv6 debian")
             .with_target("/etc/hosts")
             .with_content("ff02::1 ip6-allnodes\nff02::2 ip6-allrouters\n")


### PR DESCRIPTION
Installing netplan requires installing systemd-resolved which in turn installs /usr/bin/resolvectl which in turn adds a wrapper that is supposed to be compatible with /sbin/resolvconf, but which we've also never wanted, used, or relied on.

Dnsmasq looks for /sbin/resolvconf and tries to play nice with it, but in this case it's getting tricked into trying to play nice with resolvconf when it is in fact systemd's implementation of resolvconf, which dnsmasq can safely just ignore, and which does not behave the way dnsmasq expects.

So we take over management of /etc/default/dnsmasq in order to uncomment `IGNORE_RESOLVCONF=yes`, which will tell dnsmasq to ignore the presence of a systemd implementation of /sbin/resolvconf and not try to use it to actually do anything.

Dnsmasq will instead just assume /etc/resolv.conf is set up correctly.