### PR TITLE
add unattended_upgrades to minimum role

### DIFF
--- a/manifests/profile/unattended_upgrades.pp
+++ b/manifests/profile/unattended_upgrades.pp
@@ -1,9 +1,26 @@
 class nebula::profile::unattended_upgrades {
   class { 'unattended_upgrades':
     extra_origins                      => [
-      'origin=Vox Pupuli',
+      'origin=mlibrary',
+      'origin=Docker',            # containerd
+      'site=pkg.duosecurity.com', # duo
+      'origin=HPE',               # hpe
+      'origin=elastic',           # filebeat, metricbeat
+      'site=apt.grafana.com',     # grafana alloy
+      'origin=XamarinBuster',     # mono
+      'origin=nginx',             # nginx
+      'site=deb.nodesource.com',  # nodejs
+      'origin=Artifactory',       # openjdk
+      'origin=Vox Pupuli',        # openvox
+      'origin=deb.sury.org',      # php
+      'origin=yarn',              # yarn
     ],
     only_on_ac_power                   => false,
     skip_updates_on_metered_connection => false,
+    blacklist                          => [
+      'falcon-sensor',
+      'apache2','apache2-bin','apache2-data','apache2-utils',
+      'mariadb-server','mariadb-server-.*',
+    ],
   }
 }

--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -34,5 +34,6 @@ class nebula::role::minimum (
     include nebula::profile::ntp
   }
 
+  include nebula::profile::unattended_upgrades
   include nebula::profile::taghosts::tags
 }


### PR DESCRIPTION
- add all origins
- blacklist apache and mariadb

considerations:
- we could add an option to turn this on/off in hiera if we want to roll it out gradually, but I don't want that to become at option to except a host forever; unattended_upgrades should not be optional
- @daaang, could you specifically weigh in on automatically updating containerd (which should be the only thing we're using from the Docker origin)?