### PR TITLE
update forge modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -33,7 +33,7 @@ fixtures:
       ref: 13.1.0
     apt:
       repo: puppetlabs/apt
-      ref: 11.2.0
+      ref: 11.3.0
     augeas_core:
       repo: puppetlabs/augeas_core
       ref: 2.0.1
@@ -78,4 +78,4 @@ fixtures:
       ref: 7.0.0
     debconf:
       repo: stm/debconf
-      ref: 7.0.1
+      ref: 8.0.0

--- a/manifests/profile/apt.pp
+++ b/manifests/profile/apt.pp
@@ -79,18 +79,19 @@ class nebula::profile::apt (
       # - https://downloads.linux.hpe.com/SDR/keys.html
       # - https://wiki.debian.org/HP/ProLiant#HP_Repository
 
+      apt::source { 'hpe':
+        source_format => 'sources',
+        location      => ['https://downloads.linux.hpe.com/SDR/repo/mcp'],
+        release       => "${facts['os']['distro']['codename']}/current",
+        repos         => ['non-free'],
+        keyring       => '/etc/apt/keyrings/hpe1_hpe2.gpg',
+      }
+
       # dist integral keys in case they are needed for debugging
       ['hpe1.gpg', 'hpe2.gpg', 'hpe1_hpe2.gpg'].each |$key| {
         apt::keyring { $key:
           source => "puppet:///modules/nebula/apt/keyrings/${key}",
         }
-      }
-
-      apt::source { 'hpe':
-        location => 'https://downloads.linux.hpe.com/SDR/repo/mcp',
-        release  => "${facts['os']['distro']['codename']}/current",
-        repos    => 'non-free',
-        keyring  => '/etc/apt/keyrings/hpe1_hpe2.gpg',
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 11.2.0 < 12.0.0"
+      "version_requirement": ">= 11.3.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",
@@ -108,7 +108,7 @@
     },
     {
       "name": "stm/debconf",
-      "version_requirement": ">= 7.0.1 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/profile/apt_spec.rb
+++ b/spec/classes/profile/apt_spec.rb
@@ -173,7 +173,7 @@ describe "nebula::profile::apt" do
 
         it do
           expect(subject).to contain_apt__source("hpe").with(
-            # source_format: "sources",
+            source_format: "sources",
             location: ["https://downloads.linux.hpe.com/SDR/repo/mcp"],
             release: "#{facts[:os]["distro"]["codename"]}/current",
             repos: ["non-free"],


### PR DESCRIPTION
- stm/debconf 8.0.0
- puppetlabs/apt 11.3.0
  - this unlocks switching hpe back to 'sources' format (there was a bugfix we were waiting for in this release)