### PR TITLE
fix librarian-puppet

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -54,7 +54,7 @@ fixtures:
       ref: 2.0.1
     inifile:
       repo: puppetlabs/inifile
-      ref: 6.3.1
+      ref: 6.4.0
     lvm:
       repo: puppetlabs/lvm
       ref: 4.0.1

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 6.3.1 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/lvm",

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 11.2.0 < 12.0.0"
+      "version_requirement": "= 11.2.0"
     },
     {
       "name": "puppetlabs/augeas_core",

--- a/rakelib/metadata.yaml
+++ b/rakelib/metadata.yaml
@@ -35,6 +35,8 @@ dependencies:
 - name: puppet/unattended_upgrades
 - name: puppetlabs/apache
 - name: puppetlabs/apt
+  ref: 11.2.0
+  info: librarian-puppet is confused, and puppetlabs/docker has unreasonable dependencies
 - name: puppetlabs/augeas_core
 - name: puppetlabs/concat
 - name: puppetlabs/cron_core


### PR DESCRIPTION
librarian-puppet has been failing to resolve dependencies since the latest puppet/apt was released. Pin to the old verision of puppet/apt (which we were using anyway) so it's not confused.

puppet/docker is at the root of this for having unreasonable dependency specs. It needs to be fired.

Minor bump to puppetlabs/inifile while we're here.