### PR TITLE
ht rsync: explicitly allow out-of-module symlinks

### DIFF
--- a/spec/classes/role/ht_datasets_spec.rb
+++ b/spec/classes/role/ht_datasets_spec.rb
@@ -25,7 +25,7 @@ describe "nebula::role::hathitrust::datasets" do
         it { is_expected.to contain_firewall("200 rsync: dataset dataset2 - Test User 3, University of East Westtestland, testuser3@default.invalid").with_source("192.0.2.108") }
         it { is_expected.to contain_firewall("200 rsync: dataset dataset2 - Test User 4, University of West Easttestland, testuser4@default.invalid").with_source("198.51.100.15") }
 
-        it { is_expected.to contain_file("/etc/rsyncd.conf").with_content(%r{path\s*=\s*/datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
+        it { is_expected.to contain_file("/etc/rsyncd.conf").with_content(%r{path\s*=\s*/./datasets/dataset1.*log file\s*=\s*/var/log/rsync/dataset1.log.*hosts allow =.*192.0.2.102.*198.51.100.10}m) }
         it { is_expected.to contain_file("/etc/rsyncd.conf").with_content(%r{/datasets/dataset2.*hosts allow =.*192.0.2.108.*198.51.100.15}m) }
       end
 

--- a/templates/profile/hathitrust/rsync/rsyncd.conf.erb
+++ b/templates/profile/hathitrust/rsync/rsyncd.conf.erb
@@ -1,15 +1,15 @@
 # File managed by puppet; changes here will be lost.
 
-uid       = <%= @rsync_user %>
-list      = false
-read only = true
+uid        = <%= @rsync_user %>
+list       = false
+read only  = true
+use chroot = true
 
 <% @datasets.each do |name, dataset| %>
 [<%= name %>]
   comment     = <%= dataset['comment'] %>
-  path        = <%= dataset['path'] %>
+  path        = /.<%= dataset['path'] %>
   log file    = <%= "#{@log_path}/#{name}.log" %>
-  use chroot  = false
   <% if dataset.has_key?('users') -%>
     hosts allow = \
     <% dataset['users'].each do |user| -%>


### PR DESCRIPTION
Previously, we relied on the (apparently?) unintended behavior of `use chroot = false` to allow symlinks to reach out of the rsync module. This "feature" was recently "fixed". With chroot enabled, we can instead make it explicit that rsync should be able to see the entire filesystem by prepending `/./` to the module path. (see: [rsyncd.conf(5)](https://manpages.debian.org/bullseye/rsync/rsyncd.conf.5.en.html#use))