### PR TITLE
ETT-1533 plack-lib uses ancient Net::CIDR::Lite with multiple CVEs

### DIFF
--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -100,6 +100,7 @@ class nebula::profile::hathitrust::perl () {
     'libpackage-stash-perl',
     'libparse-recdescent-perl',
     'libplack-perl',
+    'libplack-builder-conditionals-perl',
     'libpod-simple-perl',
     'libproc-processtable-perl',
     'libprometheus-tiny-shared-perl',
@@ -145,6 +146,7 @@ class nebula::profile::hathitrust::perl () {
     'Algorithm::LUHN',
     'EBook::EPUB',
     'MARC::File::MiJ',
+    'Net::CIDR::Lite',
     'Noid'
     ]:
   }

--- a/manifests/profile/hathitrust/perl.pp
+++ b/manifests/profile/hathitrust/perl.pp
@@ -91,6 +91,7 @@ class nebula::profile::hathitrust::perl () {
     'libmoose-perl',
     'libmouse-perl',
     'libmro-compat-perl',
+    'libnet-cidr-lite-perl',
     'libnet-dns-perl',
     'libnet-http-perl',
     'libnet-libidn-perl',
@@ -146,7 +147,6 @@ class nebula::profile::hathitrust::perl () {
     'Algorithm::LUHN',
     'EBook::EPUB',
     'MARC::File::MiJ',
-    'Net::CIDR::Lite',
     'Noid'
     ]:
   }


### PR DESCRIPTION
- The HathiTrust `babel` repo contains two out of date vendored Perl modules. Neither appear to be available in the default config so we're requesting additional Perl support.
  - `Net::CIDR::Lite` has a number of CVEs that have been fixed recently
    - The Debian trixie version is 0.22 lagging the latest 0.24 which addresses additional vulnerabilities. Better install from CPAN.
  - `Plack::Builder::Conditionals` is simply out of date. No CVEs.
    - Debian provides `libplack-builder-conditionals-perl`

Note to reviewer: I'm in somewhat unfamiliar territory here. This is meant to apply to all of the hosts supporting HathiTrust's discovery apps (in particular imgsrv).