### PR TITLE
keepalived conf updates

### DIFF
--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -93,7 +93,7 @@ class nebula::profile::haproxy (
 
   concat_fragment { 'keepalived preamble':
     target  => '/etc/keepalived/keepalived.conf',
-    content => template('nebula/profile/haproxy/keepalived/keepalived_pre.erb'),
+    content => template('nebula/profile/haproxy/keepalived/keepalived.conf.erb'),
     order   => '01'
   }
 
@@ -109,7 +109,7 @@ class nebula::profile::haproxy (
 
   concat_fragment { 'keepalived postamble':
     target  => '/etc/keepalived/keepalived.conf',
-    content => template('nebula/profile/haproxy/keepalived/keepalived_post.erb'),
+    content => "  }\n}\n",
     order   => '03'
   }
 

--- a/manifests/profile/haproxy.pp
+++ b/manifests/profile/haproxy.pp
@@ -84,8 +84,6 @@ class nebula::profile::haproxy (
     require    => Package['keepalived'],
   }
 
-  $email = lookup('nebula::root_email')
-
   concat { '/etc/keepalived/keepalived.conf':
     ensure  => 'present',
     require => Package['keepalived'],

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -228,8 +228,10 @@ describe "nebula::profile::haproxy" do
 
         it { is_expected.to contain_concat_fragment("keepalived preamble").with_target(keepalived_conf) }
 
-        it "has a vrrp_scripts check_haproxy section" do
-          expect(subject).to contain_concat_fragment("keepalived preamble").with_content(%r{^vrrp_script check_haproxy})
+        it "keepalived conf uses vrrp_track_process to track haproxy" do
+          is_expected.to contain_concat_fragment("keepalived preamble")
+            .with_content(/^vrrp_track_process track_haproxy {\n  process haproxy$/)
+            .with_content(/^vrrp_instance haproxy {\n.*state (BACKUP|MASTER)\n\s+priority \d+\n\n\s+track_process { track_haproxy }$/)
         end
 
         it "has the haproxy floating ip addresses" do

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -274,8 +274,6 @@ describe "nebula::profile::haproxy" do
         it {
           is_expected.to contain_concat_fragment("keepalived preamble")
             .with_content(%r{interface #{facts[:networking][:primary]}})
-            .with_content(%r{notification_email {\n\s.*root@default.invalid\n\s.*}}m)
-            .with_content(%r{notification_email_from root@default.invalid})
         }
 
         context "when on a master node" do

--- a/spec/classes/profile/haproxy_spec.rb
+++ b/spec/classes/profile/haproxy_spec.rb
@@ -234,6 +234,12 @@ describe "nebula::profile::haproxy" do
             .with_content(/^vrrp_instance haproxy {\n.*state (BACKUP|MASTER)\n\s+priority \d+\n\n\s+track_process { track_haproxy }$/)
         end
 
+        it "keepalived conf uses track_file to allow manual override" do
+          is_expected.to contain_concat_fragment("keepalived preamble")
+            .with_content(%r|^track_file etc_keepalived_weight { file /etc/keepalived/weight }$|)
+            .with_content(/^\s+track_file { etc_keepalived_weight }$/)
+        end
+
         it "has the haproxy floating ip addresses" do
           expect(subject).to contain_concat_fragment("keepalived preamble").with_content(%r{virtual_ipaddress {\n\s*12\.23\.32\.22\n\s*12\.23\.32\.23\n\s*}}m)
         end

--- a/templates/profile/haproxy/keepalived/keepalived.conf.erb
+++ b/templates/profile/haproxy/keepalived/keepalived.conf.erb
@@ -1,22 +1,19 @@
-global_defs {
-  enable_script_security
-}
-
-vrrp_script check_haproxy {
-  script "/usr/bin/haproxyctl show health"
-  timeout 1
-  interval 2
-  weight 2
+vrrp_track_process track_haproxy {
+  process haproxy
+  weight 10
 }
 
 vrrp_instance haproxy {
-  <% if @master %>
+<% if @master -%>
   state MASTER
   priority 101
-  <% else %>
+<% else -%>
   state BACKUP
   priority 100
-  <% end %>
+<% end -%>
+
+  track_process { track_haproxy }
+  track_file { etc_keepalived_weight }
 
   interface <%= @networking['primary'] %>
   virtual_router_id 51
@@ -31,3 +28,4 @@ vrrp_instance haproxy {
 
   unicast_src_ip <%= @networking["ip"] %>
   unicast_peer {
+<%# closing curly brackets intentionally omitted -%>

--- a/templates/profile/haproxy/keepalived/keepalived.conf.erb
+++ b/templates/profile/haproxy/keepalived/keepalived.conf.erb
@@ -1,3 +1,16 @@
+# `track_file` lets us manually setting an arbitrary offset to priority.
+# Below are some examples, but any offset may be set, just be sure to clear the
+# manual offset once maintenance is completed.
+#
+# Force backup to act as primary:
+#   echo 5 > /etc/keepalived/weight
+# Disable this server
+#   echo -10 > /etc/keepalived/weight
+# Reset manual weight (either of these commands will have the same effect):
+#   rm /etc/keepalived/weight
+#   echo 0 > /etc/keepalived/weight
+track_file etc_keepalived_weight { file /etc/keepalived/weight }
+
 vrrp_track_process track_haproxy {
   process haproxy
   weight 10

--- a/templates/profile/haproxy/keepalived/keepalived_post.erb
+++ b/templates/profile/haproxy/keepalived/keepalived_post.erb
@@ -1,6 +1,0 @@
-  }
-
-  track_script {
-    check_haproxy
-  }
-}

--- a/templates/profile/haproxy/keepalived/keepalived_pre.erb
+++ b/templates/profile/haproxy/keepalived/keepalived_pre.erb
@@ -1,10 +1,4 @@
 global_defs {
-  notification_email {
-    <%= @email %>
-  }
-  notification_email_from <%= @email %>
-  smtp_server localhost
-  smtp_connect_timeout 60
   enable_script_security
 }
 


### PR DESCRIPTION
- rm unused smtp config
- replace track_script with track_process: more efficient and reliable
- rm enable_script_security directive: noop since I removed the vrrp_script block
- reduce config to a single .erb template
- add manual weight offset file (at `/etc/keepalived/weight`) to allow overrides for maintenance