### PR TITLE
add bin/bundle-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 ruby 3.2.10
 
 # bundle
-bundle install
-bundle install --gemfile=standard.gemfile
+bin/bundle-install
 
 # list all rake tasks
 bin/rake -T

--- a/bin/bundle-install
+++ b/bin/bundle-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+bundle install
+bundle install --gemfile="${0%/*}/../standard.gemfile"


### PR DESCRIPTION
So we don't have to run `bundle install --gemfile=standard.gemfile`, add `bin/bundle-install` script to do it.

Mutually exclusive with PR #1013