### PR TITLE
mariadb-backup: delete useless symlink

### DIFF
--- a/manifests/profile/mariadb/server.pp
+++ b/manifests/profile/mariadb/server.pp
@@ -15,6 +15,12 @@ class nebula::profile::mariadb::server (
     'mariadb-backup': ;
   }
 
+  # /usr/bin/mariabackup is a useless symlink, breaks tab completion
+  file { '/usr/bin/mariabackup':
+    ensure => absent,
+    require => Package['mariadb-backup'];
+  }
+
   service { 'mariadb':
     ensure  => 'running',
     enable  => true,

--- a/spec/classes/profile/mariadb/server_spec.rb
+++ b/spec/classes/profile/mariadb/server_spec.rb
@@ -16,6 +16,10 @@ describe "nebula::profile::mariadb::server" do
         is_expected.to contain_package("mariadb-backup").that_requires("Package[mariadb-client]")
       end
 
+      it "removes /usr/bin/mariabackup symlink" do
+        is_expected.to contain_file("/usr/bin/mariabackup").with_ensure("absent")
+      end
+
       it "configures mariadb-server" do
         is_expected.to contain_file("/etc/mysql/mariadb.conf.d/90-mlibrary.cnf")
           .with_content(/^\[mysqld\]$/)


### PR DESCRIPTION
Delete useless /usr/bin/mariadbackup alias so maria<tab> works properly.