### PR TITLE
Fix secure rsync inability to find data sets

### DIFF
--- a/templates/profile/hathitrust/secure_rsync/secure-rsync.service.erb
+++ b/templates/profile/hathitrust/secure_rsync/secure-rsync.service.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=<%= @rsync_home %>
+WorkingDirectory=/
 ExecStart=/usr/bin/stunnel <%= @rsync_home %>/stunnel.conf
 RemainAfterExit=no
 Restart=always


### PR DESCRIPTION
Secure rsync has been failing since the rsync update, and it turns out the mitigation we applied didn't work (we didn't notice because there wasn't a lot of updates anyway because of a separate issues.) I found that the secure rsync was using @rsync_home as its chroot; I believe it's just using the working directory at startup as the chroot.  I saw that the researcher rsync was using / as the working directory, which has not had this problem.