### PR TITLE
role::minimum: add rsync package

### DIFF
--- a/manifests/role/minimum.pp
+++ b/manifests/role/minimum.pp
@@ -27,6 +27,7 @@ class nebula::role::minimum (
       package { 'iptables-persistent': ensure => purged }
     }
 
+    stdlib::ensure_packages(['rsync'])
     include nebula::profile::networking::firewall::private_ssh
     include nebula::profile::apt
     include nebula::profile::vim

--- a/spec/classes/role/minimum_spec.rb
+++ b/spec/classes/role/minimum_spec.rb
@@ -11,6 +11,7 @@ describe "nebula::role::minimum" do
       let(:facts) { os_facts }
 
       it { is_expected.to contain_class("nebula::profile::networking::firewall") }
+      it { is_expected.to contain_package("rsync") }
 
       context "manage_firewall false" do
         let(:params) do


### PR DESCRIPTION
After needing to manually install `rsync` on each of the last several servers I've imaged, I'm feeling this should be part of the standard base config.

If for some reason we really don't want it everywhere I will add it to the mariadb::server profile instead. 