### PR TITLE
mariadb::server: install rsync

### DIFF
--- a/manifests/profile/mariadb/server.pp
+++ b/manifests/profile/mariadb/server.pp
@@ -15,6 +15,9 @@ class nebula::profile::mariadb::server (
     'mariadb-backup': ;
   }
 
+  # almost always needed for mariadb setup, not a hard dependency
+  stdlib::ensure_packages('rsync')
+
   # /usr/bin/mariabackup is a useless symlink, breaks tab completion
   file { '/usr/bin/mariabackup':
     ensure => absent,

--- a/spec/classes/profile/mariadb/server_spec.rb
+++ b/spec/classes/profile/mariadb/server_spec.rb
@@ -16,6 +16,10 @@ describe "nebula::profile::mariadb::server" do
         is_expected.to contain_package("mariadb-backup").that_requires("Package[mariadb-client]")
       end
 
+      it "installs rsync" do
+        is_expected.to contain_package("rsync")
+      end
+
       it "removes /usr/bin/mariabackup symlink" do
         is_expected.to contain_file("/usr/bin/mariabackup").with_ensure("absent")
       end


### PR DESCRIPTION
not strictly required, but we've manually installed rsync on every mariadb server, so this just clarifies the situation