### PR TITLE
update Standard Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ ruby 3.2.10
 
 # bundle
 bundle install
-bundle install --gemfile=standard.gemfile
 
 # list all rake tasks
 bin/rake -T
@@ -31,7 +30,7 @@ bin/rake clean
 # lint
 bin/rake validate # includes syntax task, other misc. checks
 bin/rake lint
-bin/standardrb # Standard Ruby
+bin/standardrb # [Standard Ruby](https://github.com/standardrb/standard)
 
 # check puppet module dependencies for available updates
 bin/rake forge:outdated

--- a/bin/standardrb
+++ b/bin/standardrb
@@ -11,6 +11,10 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../standard.gemfile", __dir__)
 
 require "rubygems"
+unless system("bundle", "check", out: File::NULL, err: File::NULL)
+  warn "Bundle not installed. Running bundle install..."
+  system("bundle", "install") or abort("bundle install failed")
+end
 require "bundler/setup"
 
 load Gem.bin_path("standard", "standardrb")

--- a/spec/defines/haproxy_service_spec.rb
+++ b/spec/defines/haproxy_service_spec.rb
@@ -203,14 +203,15 @@ describe "nebula::haproxy::service" do
                                          "path_end" => [".abc", ".def"]})
             end
 
-            ["acl whitelist_path_beg path_beg -n -f /etc/haproxy/svc1_whitelist_path_beg.txt",
+            [
+              "acl whitelist_path_beg path_beg -n -f /etc/haproxy/svc1_whitelist_path_beg.txt",
               "acl whitelist_path_end path_end -n -f /etc/haproxy/svc1_whitelist_path_end.txt",
-              "use_backend svc1-dc1-https-back-exempt if whitelist_path_beg OR whitelist_path_end"]
-              .each do |fragment|
-                it do
-                  expect(subject).to contain_concat_fragment("svc1-dc1-https frontend")
-                    .with_content(%r{#{fragment}})
-                end
+              "use_backend svc1-dc1-https-back-exempt if whitelist_path_beg OR whitelist_path_end"
+            ].each do |fragment|
+              it do
+                expect(subject).to contain_concat_fragment("svc1-dc1-https frontend")
+                  .with_content(/#{Regexp.escape(fragment)}/)
+              end
             end
 
             it do

--- a/standard.gemfile
+++ b/standard.gemfile
@@ -1,7 +1,4 @@
 # Dedicated Gemfile for running standardrb
 source ENV["GEM_SOURCE"] || "https://rubygems.org"
 
-gem "standard", require: false
-# Keep the same maximum (but not minimum) version of rubocop as voxpupuli-test
-#   see: https://github.com/voxpupuli/voxpupuli-test/blob/master/voxpupuli-test.gemspec
-gem "rubocop", "< 1.86.0", require: false
+gem "standard", "~> 1.56.0", require: false

--- a/standard.gemfile.lock
+++ b/standard.gemfile.lock
@@ -2,29 +2,29 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    json (2.19.8)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     parallel (1.28.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
     racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.12.0)
-    rubocop (1.84.2)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -32,10 +32,10 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
-    standard (1.54.0)
+    standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.84.0)
+      rubocop (~> 1.88.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -53,25 +53,24 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rubocop (< 1.86.0)
-  standard
+  standard (~> 1.56.0)
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
-  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
-  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rubocop (1.84.2) sha256=5692cea54168f3dc8cb79a6fe95c5424b7ea893c707ad7a4307b0585e88dbf5f
-  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  standard (1.54.0) sha256=7a4b08f83d9893083c8f03bc486f0feeb6a84d48233b40829c03ef4767ea0100
+  standard (1.56.0) sha256=ae2af4d9669589162ac69ed5ef59dcf9f346d4afc81f7e62b84339310dfcb787
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42


### PR DESCRIPTION
- upgrade standard gem to 1.56.0 (was 1.54.0)
- upgrade all standard dependencies
- bin/standardrb automatically runs `bundle install` as needed
- one lint fix (spec/defines/haproxy_service_spec.rb)
  - appears to be a parser bug/regression; reworked the syntax so now it passes both old and new versions of standard