### PR TITLE
profile::base: rm dbus

### DIFF
--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -30,7 +30,6 @@ class nebula::profile::base (
   }
 
   ensure_packages([
-    'dbus', # ??
     'zstd', # prevent warnings about fallback on `apt dist-upgrade`
   ])
 

--- a/spec/classes/profile/base_spec.rb
+++ b/spec/classes/profile/base_spec.rb
@@ -21,7 +21,6 @@ describe "nebula::profile::base" do
       case os
       when %r{^debian}, %r{^ubuntu}
         it { is_expected.to contain_package("zstd") }
-        it { is_expected.to contain_package("dbus") }
 
         it do
           expect(subject).to contain_file("/etc/localtime")


### PR DESCRIPTION
Not sure why we ever cared whether `dbus` was installed, but it's part of the default Debian install, so whatever the original reason, this line effectively a no-op.

Note: `dbus` package was added in aaaacd29, part of https://github.com/mlibrary/nebula/pull/1.