### PR TITLE
use bundle cooldown

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_COOLDOWN: "7"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 .yardoc
 .yardwarns
 *.iml
-/.bundle/
+!/.bundle/
+/.bundle/*
+!/.bundle/config
 /.idea/
 /.vagrant/
 /coverage/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,8 +253,10 @@ GEM
     yard (0.9.45)
 
 PLATFORMS
-  arm64-darwin-24
+  arm64-darwin
+  arm64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   faker
@@ -270,6 +272,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   deep_merge (1.2.2) sha256=83ced3a3d7f95f67de958d2ce41b1874e83c8d94fe2ddbff50c8b4b82323563a
@@ -367,4 +370,4 @@ CHECKSUMS
   yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
 
 BUNDLED WITH
-  4.0.9
+  4.0.17

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ ruby 3.2.10
 
 # bundle
 bundle install
+# check/update Gemfile.lock
+bundle outdated
+bundle update --all
+# check/update standard.gemfile.lock
+BUNDLE_GEMFILE=standard.gemfile bundle outdated
+BUNDLE_GEMFILE=standard.gemfile bundle update --all
 
 # list all rake tasks
 bin/rake -T

--- a/standard.gemfile.lock
+++ b/standard.gemfile.lock
@@ -49,14 +49,17 @@ GEM
     unicode-emoji (4.2.0)
 
 PLATFORMS
-  arm64-darwin-24
+  arm64-darwin
+  arm64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   standard (~> 1.56.0)
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -77,4 +80,4 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-  4.0.9
+  4.0.17


### PR DESCRIPTION
tl;dr `bundle update` is documented in README.md, should no longer add useless diffs (i.e. reporting macos version in Gemfile.lock), and is configured to enforce a 7 day cooldown just like we have configured for dependabot.

---
original commit message:

- update to current bundler to support cooldown (introduced in 4.0.13)
  - bundle update --bundler
- since bundler won't stop adding platforms, at least make the list correct
  - bundle lock --add-platform arm64-linux
  - bundle lock --add-platform x86_64-linux
  - bundle lock --normalize-platforms
- configure cooldown to 7 days
  - bundle config set --local cooldown 7
  - update .gitignore to commit this
- add update instructions to README.md